### PR TITLE
Measure complexity, and check the docs by running them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,9 +11,9 @@ All notable changes and release notes for Aurora are documented here.
 - **Text is a tape, and reels are gone.** `"hi"` is the tape holding its bytes, right aligned like every other value — one more way of writing a tape, next to `1`, `0x2a`, `[1, 2]` and `true`.
 
   ```aurora
-  printb "hi";          # [0 0 0 0 0 0 104 105]
-  printd "hi";          # 26729
-  printd "a" equals 97; # 1 — the same tape, not a conversion
+  printb "hi";   #- [0 0 0 0 0 0 104 105]
+  printd "hi";   #- 26729
+  printd "a" equals 97;   #- 1 — the same tape, not a conversion
   ```
 
   Text used to be a **reel**: one tape per character, so `"hi"` was two tapes and `"Gui"` was 96 bytes at `--tape-size 32` — a cost that grew exactly when the tape got wider. It was also the one value in the language that was not a tape. Now `"a"` and `97` are the same value rather than a coincidence of one-character strings, arithmetic on text needs no rule of its own, and text fits in a struct field, which a reel never could.
@@ -33,7 +33,7 @@ All notable changes and release notes for Aurora are documented here.
     ident p = feed(0) as Point;
     p.x * p.y;
   };
-  printd area(Point{10, 20});   # 200
+  printd area(Point{10, 20});   #- 200
   ```
 
   Braces build the value, as in Go — which is also what tells a construction from applying values to a scope: `Point(1, 2)` and `greet(1, 2)` are the same shape, `Point{1, 2}` is not.

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,16 @@ $(LINTER):
 	@echo "==> Installing linter..."
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/f7cf900a4f6021580b7b962645872bbd453f11f2/install.sh | sh -s -- -b ${GOBIN} v2.7.2
 
+# Report how complex the code is, without failing: it is the instrument, not the gate.
+#
+# Cognitive complexity is the number that matters and the one `make lint` enforces — it
+# measures how hard a function is to follow. Cyclomatic complexity comes along as
+# information only: it counts branches, so it punishes a flat lookup switch that anyone
+# reads in seconds (ResolveOpCode scores 105 and is trivial) while missing deep nesting.
+complexity: $(LINTER)
+	@$(LINTER) run ./... --timeout 10m --no-config --default=none \
+		--enable=gocognit --enable=gocyclo --enable=funlen --enable=nestif || true
+
 # This jobs is to simulate github ci environment for tests github action workflows
 act: $(ACT_BIN)
 	$(ACT_BIN) --container-architecture linux/amd64 --platform ubuntu-latest=node:buster --rm
@@ -83,4 +93,4 @@ $(TPARSE_BIN):
 	@echo "==> Installing tparse..."
 	@go install github.com/mfridman/tparse@latest
 
-.PHONY: all check build wasm build-force aurora aurorals test bench lint act cover-html clean
+.PHONY: all check build wasm build-force aurora aurorals test bench lint complexity act cover-html clean

--- a/docs/defer_scope_visibility.md
+++ b/docs/defer_scope_visibility.md
@@ -47,7 +47,7 @@ ident caller = defer {
 };
 
 caller();
-show();       #- called from the top, where there is no x → identifier x not found
+show();       #- fails: identifier x not found — called from the top, where x does not exist
 ```
 
 Note that `show` is defined where no `x` exists at all, and still prints one: nothing about

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -1,0 +1,254 @@
+package cli
+
+import (
+	"io"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+// The documentation is full of Aurora, and prose rots quietly: a snippet keeps saying what
+// the language used to do long after it stopped. Reading for that does not work — three
+// snippets were still describing reels the day text became a tape, and they were only found
+// by running them.
+//
+// So they are run. Every fenced ```aurora block in the language documentation is executed,
+// and a block says which of three things it is, in its own text:
+//
+//	#- greeting.ar          a named file of a multi-file example; the files run together
+//	#- fails: <message>     a block that documents an error; it must fail, and say that
+//	(neither)               a whole program; it must run
+//
+// A block written to be read rather than run — a grammar rule, a form with a placeholder —
+// is left alone.
+
+var (
+	// auroraBlock matches a fenced block written in Aurora.
+	auroraBlock = regexp.MustCompile("(?s)```aurora\n(.*?)```")
+	// namedFile matches the comment a multi-file example opens each block with.
+	namedFile = regexp.MustCompile(`^#-\s+(\S+\.ar)\s*$`)
+	// expectedFailure matches the marker a block documenting an error carries.
+	expectedFailure = regexp.MustCompile(`#-\s*fails:\s*([^\n—]+)`)
+)
+
+// snippet is one Aurora block of a document.
+type snippet struct {
+	code string
+	line int
+	// file is the name the block gave itself, when it belongs to a multi-file example.
+	file string
+	// wantErr is the message the block says it fails with, when it documents an error.
+	wantErr string
+}
+
+// snippetsOf reads the Aurora blocks of a document, skipping the ones written to be read
+// rather than run: a grammar rule (`_expr -> …`) or a form with a placeholder
+// (`assert(<condition>, …)`).
+func snippetsOf(source string) []snippet {
+	snippets := make([]snippet, 0)
+
+	for _, match := range auroraBlock.FindAllStringSubmatchIndex(source, -1) {
+		code := source[match[2]:match[3]]
+		if strings.Contains(code, "->") || strings.Contains(code, "<") {
+			continue
+		}
+
+		s := snippet{code: code, line: strings.Count(source[:match[0]], "\n") + 1}
+		if named := namedFile.FindStringSubmatch(strings.SplitN(code, "\n", 2)[0]); named != nil {
+			s.file = named[1]
+		}
+		if fails := expectedFailure.FindStringSubmatch(code); fails != nil {
+			s.wantErr = strings.TrimSpace(fails[1])
+		}
+		snippets = append(snippets, s)
+	}
+	return snippets
+}
+
+// documentationFiles lists the markdown expected to hold runnable Aurora.
+//
+// A document that opens by declaring itself a proposal is skipped whole: it describes a
+// language that does not exist yet, and the compiler is meant to reject its examples.
+func documentationFiles(t *testing.T) []string {
+	t.Helper()
+
+	var docs []string
+	for _, root := range []string{filepath.Join("..", ".."), filepath.Join("..", "..", "docs")} {
+		entries, err := os.ReadDir(root)
+		if err != nil {
+			t.Fatalf("reading %s: %v", root, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".md") {
+				continue
+			}
+			path := filepath.Join(root, entry.Name())
+			if isProposal(t, path) {
+				continue
+			}
+			docs = append(docs, path)
+		}
+	}
+	return docs
+}
+
+// isProposal answers whether a document declares itself one, which it does at the top.
+func isProposal(t *testing.T, path string) bool {
+	t.Helper()
+
+	bs, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	head := string(bs)
+	if len(head) > 800 {
+		head = head[:800]
+	}
+	return strings.Contains(head, "Status: proposal")
+}
+
+// runSnippet runs one standalone block and checks it did what it said it would.
+func runSnippet(t *testing.T, doc string, s snippet) {
+	t.Helper()
+
+	entry := filepath.Join(t.TempDir(), "main.ar")
+	if err := os.WriteFile(entry, []byte(s.code), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Run(t.Context(), RunInput{Source: entry, Stdout: io.Discard})
+
+	if s.wantErr == "" {
+		if err != nil {
+			t.Errorf("%s:%d does not run: %v\n%s", doc, s.line, err, s.code)
+		}
+		return
+	}
+	// The block says it fails, so passing is the failure — and the message it promises has
+	// to be the message it gets.
+	if err == nil {
+		t.Errorf("%s:%d says it fails with %q, and it ran\n%s", doc, s.line, s.wantErr, s.code)
+		return
+	}
+	if !strings.Contains(err.Error(), s.wantErr) {
+		t.Errorf("%s:%d says it fails with %q, and it failed with %q", doc, s.line, s.wantErr, err)
+	}
+}
+
+// runNamedExample writes the named blocks of a document side by side and runs the test files
+// among them, which is what the pairing rule of `aurora test` does.
+func runNamedExample(t *testing.T, doc string, named []snippet) {
+	t.Helper()
+
+	dir := t.TempDir()
+	var tests []string
+	for _, s := range named {
+		path := filepath.Join(dir, s.file)
+		if err := os.WriteFile(path, []byte(s.code), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		if strings.HasSuffix(s.file, TestExtension) {
+			tests = append(tests, path)
+		}
+	}
+
+	for _, path := range tests {
+		report, err := Test(t.Context(), TestInput{Target: path, Stdout: io.Discard})
+		if err != nil {
+			t.Errorf("%s: the example named %s does not run: %v", doc, filepath.Base(path), err)
+			continue
+		}
+		if !report.OK() {
+			t.Errorf("%s: the example named %s does not pass: %d failed", doc, filepath.Base(path), report.Failed)
+		}
+		if report.Passed == 0 {
+			t.Errorf("%s: the example named %s asserts nothing", doc, filepath.Base(path))
+		}
+	}
+}
+
+func TestDocumentationSnippetsRun(t *testing.T) {
+	docs := documentationFiles(t)
+	if len(docs) == 0 {
+		t.Fatal("no documentation found, so nothing was checked")
+	}
+
+	checked := 0
+	for _, doc := range docs {
+		bs, err := os.ReadFile(doc)
+		if err != nil {
+			t.Fatalf("reading %s: %v", doc, err)
+		}
+
+		var named []snippet
+		for _, s := range snippetsOf(string(bs)) {
+			checked++
+			if s.file != "" {
+				named = append(named, s)
+				continue
+			}
+			t.Run(filepath.Base(doc)+":"+strconv.Itoa(s.line), func(t *testing.T) {
+				runSnippet(t, doc, s)
+			})
+		}
+
+		if len(named) > 0 {
+			t.Run(filepath.Base(doc)+" (named files)", func(t *testing.T) {
+				runNamedExample(t, doc, named)
+			})
+		}
+	}
+
+	if checked == 0 {
+		t.Fatal("no runnable snippet was found, so nothing was checked")
+	}
+}
+
+// A document holding Aurora that nobody runs is the failure this file exists to prevent,
+// and it arrives quietly: someone writes docs/contributing/foo.md with a snippet in it, and
+// the walk above never looks there.
+//
+// So the walk is checked too.
+func TestNoDocumentWithAuroraEscapesTheCheck(t *testing.T) {
+	checked := make(map[string]bool)
+	for _, doc := range documentationFiles(t) {
+		absolute, err := filepath.Abs(doc)
+		if err != nil {
+			t.Fatal(err)
+		}
+		checked[absolute] = true
+	}
+
+	err := filepath.WalkDir(filepath.Join("..", ".."), func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() || !strings.HasSuffix(d.Name(), ".md") {
+			return err
+		}
+		if strings.Contains(path, "node_modules") || strings.Contains(path, ".git/") {
+			return nil
+		}
+
+		bs, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		if !auroraBlock.Match(bs) || isProposal(t, path) {
+			return nil
+		}
+
+		absolute, absErr := filepath.Abs(path)
+		if absErr != nil {
+			return absErr
+		}
+		if !checked[absolute] {
+			t.Errorf("%s holds Aurora and nothing runs it: add it to documentationFiles, or declare it a proposal", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walking the repository: %v", err)
+	}
+}

--- a/internal/cli/examples_test.go
+++ b/internal/cli/examples_test.go
@@ -3,7 +3,9 @@ package cli
 import (
 	"io"
 	"io/fs"
+	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 )
@@ -63,5 +65,86 @@ func TestExamplesTestsPass(t *testing.T) {
 	}
 	if report.Passed == 0 {
 		t.Error("expected assertions to have run")
+	}
+}
+
+// declaredOutput reads the "#- Output:" block an example opens with: the lines it says it
+// prints. Examples that document two tape widths side by side use a different header and
+// answer nil, since a single run cannot be compared against both.
+func declaredOutput(t *testing.T, source string) []string {
+	t.Helper()
+
+	bs, err := os.ReadFile(source)
+	if err != nil {
+		t.Fatalf("reading %s: %v", source, err)
+	}
+
+	lines := strings.Split(string(bs), "\n")
+	start := slices.Index(lines, "#- Output:")
+	if start < 0 {
+		return nil
+	}
+
+	declared := make([]string, 0)
+	for _, line := range lines[start+1:] {
+		body, ok := strings.CutPrefix(line, "#-   ")
+		if !ok {
+			break
+		}
+		declared = append(declared, body)
+	}
+	return declared
+}
+
+// Every example says what it prints, and that block is pasted from a real run. This is what
+// keeps the promise: the header is compared against the output, so an example cannot drift
+// from the language without the suite noticing.
+//
+// It caught three of them the day text stopped being a reel, which is exactly the drift it
+// exists for — the checking was done by hand then, and by hand it does not last.
+func TestExamplesMatchTheirDeclaredOutput(t *testing.T) {
+	root := filepath.Join("..", "..", "examples")
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		t.Fatalf("reading examples: %v", err)
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, SourceExtension) || strings.HasSuffix(name, TestExtension) {
+			continue
+		}
+
+		source := filepath.Join(root, name)
+		declared := declaredOutput(t, source)
+		if len(declared) == 0 {
+			continue
+		}
+		checked++
+
+		t.Run(name, func(t *testing.T) {
+			stdout := &strings.Builder{}
+			if err := Run(t.Context(), RunInput{Source: source, Stdout: stdout}); err != nil {
+				t.Fatalf("%s failed: %v", source, err)
+			}
+
+			printed := make([]string, 0)
+			for _, line := range strings.Split(stdout.String(), "\n") {
+				if strings.TrimSpace(line) != "" {
+					printed = append(printed, line)
+				}
+			}
+
+			if strings.Join(printed, "\n") != strings.Join(declared, "\n") {
+				t.Errorf("the header of %s no longer matches what it prints:\ndeclared:\n  %s\nprinted:\n  %s",
+					name, strings.Join(declared, "\n  "), strings.Join(printed, "\n  "))
+			}
+		})
+	}
+
+	if checked == 0 {
+		t.Fatal("no example declared an output block, so nothing was compared")
 	}
 }


### PR DESCRIPTION
Two steps toward standards that can be enforced instead of remembered, both of them instruments rather than rules — the rules come next, once there are numbers to argue with.

## `make complexity`

Reports how complex the code is today, **without failing anything**:

```
7 functions above 30 cognitive · 2 above 30 cyclomatic · 21 long · 2 deeply nested
```

It also records which number matters. **Cognitive complexity** measures how hard a function is to follow, and is what a gate should enforce. **Cyclomatic** comes along as information only: it counts branches, so it scores `ResolveOpCode` at 105 — a flat lookup switch anyone reads in seconds — while saying nothing about deep nesting.

Uses the `golangci-lint` the project already installs. No new tool.

## The examples and the docs are checked by being run

Both of these were verifications done by hand and thrown away, which is the habit worth breaking: a check that lives in a terminal is gone the next day.

**Example headers are compared now.** `TestExamplesRun` only proved an example executes, while its own comment promised the `#- Output:` block would not rot — nobody compared it. Fifteen examples are pinned to what they print.

**Every ```aurora block in the documentation runs**, and a block says which of three things it is, in its own text:

| marker | meaning |
|---|---|
| `#- greeting.ar` | a named file of a multi-file example; they run together |
| `#- fails: <message>` | a block documenting an error; it must fail, and say that |
| *(neither)* | a whole program; it must run |

The named-file form means the pairing rule of `aurora test` is exercised by the document that teaches it. The `fails:` form means a documented error is verified too, rather than skipped — an error is as much a claim as an output.

Twenty-two snippets, and it **found a wrong one on the first run**: the CHANGELOG wrote Aurora comments as `#` instead of `#-`, so none of its examples would have compiled.

A companion test walks the whole repository for markdown holding Aurora and fails if any of it escapes the check, because that is how this rots — someone adds `docs/contributing/foo.md` and nothing looks there.

## Value for whoever reads this project

The documentation and the examples stop being able to lie. Both were wrong within the last week — the day text stopped being a reel — and both were found by running them, never by reading.

## Verified

- Each new test was **proved to bite** by breaking, on purpose, an example header, a promised failure and a paired assertion.
- `go test ./... -race`, `make lint` clean; each commit compiles and passes on its own.