### PR TITLE
Add CLAUDE.md, the part that applies on its own

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Aurora
+
+An untyped, expression-only language written in Go. Every value is a **tape**: a fixed run
+of bytes, `tape_size` wide. It runs on its own evaluator and assembles to EVM bytecode.
+
+## What matters now
+
+The language proves itself in the **evaluator** and in the **REPL**. The EVM backend is
+**parked on purpose** until the behaviour there settles — only then does it get decided
+*how* to compile to the EVM.
+
+A feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped
+without it.
+
+## The four premises
+
+1. **Every function says what it does and why it exists.** Briefly. A loose fragment gets a
+   comment only when the algorithm is hard to follow.
+2. **A vital or auxiliary package knows nothing about the rest of the project** — enough
+   that someone could take a part of it and build a different compiler.
+3. **Errors are resolved in the host.** A phase returns an error; it does not write.
+4. **A vital package is pure**: values in, values out.
+
+| kind | who | may depend on |
+|---|---|---|
+| phase | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | earlier phases, auxiliaries |
+| auxiliary | `byteutil`, `fileutil`, `logger`, `manifest` | nothing of the project |
+| host | `cmd/*`, `repl`, `internal/cli`, `lsp` | anything; nothing depends on it |
+
+## Working here
+
+- **A success case and an error case** for every implementation; an integration test for
+  anything the user perceives. Never verify by running and throw it away — if you had to
+  execute it to believe it, it becomes a test.
+- **One concern per commit**, and it compiles and passes on its own. A pull request carries
+  several of them and is sized so a human reviews the whole of it in **under forty minutes**;
+  when it cannot be cut that small, discuss the scope first.
+- **Every new feature goes through a pull request** saying what it gives the user. A fix
+  straight to `main` is called by the maintainer, not assumed.
+- `make test`, `make lint`, `make complexity`. Cognitive complexity is the gate; cyclomatic
+  is information.
+
+## Where things are written
+
+- **`.claude/agents/aurora-standards.md`** — the standards in full, and how to review against
+  them. Read it before writing code here.
+- **`.claude/agents/aurora-internals.md`** — how the compiler actually works, verified
+  against the code rather than the docs.
+- **`docs/`** for the end user, **`docs/contributing/`** for contributors (English),
+  **`rfcs/`** for proposals and debt (Portuguese).
+- **`docs/roadmap.md`** is the direction: anything the user can perceive gets an entry there.
+
+Conversation is usually pt-BR; code, comments and `docs/` stay in English.


### PR DESCRIPTION
An agent has to be called. This does not — it is in context on every session, which makes it the one place a rule holds without anyone remembering to ask for it.

## What is in it

Deliberately short, because it is loaded every time and a long one gets skimmed:

- **what the project is aiming at now** — the language proves itself in the evaluator and the REPL; the EVM backend is parked on purpose, so a feature does not need bytecode to be finished;
- **the four premises** — a function says why it exists; a vital or auxiliary package knows nothing of the project; errors are resolved in the host; a vital package is pure;
- **the three kinds of package** and which may depend on which;
- **how a change ships** — a success case and an error case, one concern per commit, a pull request a human can review in under forty minutes, and never a verification done by hand and thrown away.

Everything else it points at rather than restates: the standards agent for the full text, the internals agent for how the compiler actually works, `docs/` for the user, `rfcs/` for what is still being argued about, and `docs/roadmap.md` for the direction.

## Why the premises are repeated here rather than only linked

Those four decide whether a change belongs at all. A rule nobody reads before writing code is a rule that gets broken in the first commit — and this is the file that is always already open.

## Value

The standard stops depending on someone remembering to invoke an agent. It is the difference between a convention that exists and one that applies.

## Note

Based on #17, which is where the standards agent lives. It retargets to `main` once that merges.