### PR TITLE
Add CLAUDE.md, and make the Makefile the only way in

### DIFF
--- a/.claude/agents/aurora-standards.md
+++ b/.claude/agents/aurora-standards.md
@@ -63,6 +63,21 @@ The code says *what*; the comment says *why it is not otherwise*. The most valua
 
 Write that, not "emits the unary expression".
 
+## Every action goes through the Makefile
+
+Build, test, lint, measure — through a `make` target, **without exception**. When the target
+you need does not exist, add it in a pull request rather than working around it with a raw
+command: the next person needs the same thing, and a command that only lives in someone's
+shell history is not part of the project.
+
+**Never run the binary by hand against a scrap of source to see what happens.** If a
+behaviour needs checking, the test that checks it is the answer, and `make test` runs it.
+That way the check survives; a run in a terminal proves something once and leaves nothing
+behind — which is how this repository ended up with documentation and examples that had
+been verified and then drifted.
+
+`make check` — build, wasm, test, lint — is what a change survives before being committed.
+
 ## Delivery
 
 - **A commit is one concern, and it compiles and passes on its own.** Verify a series with `git worktree` before pushing.
@@ -90,15 +105,17 @@ written — with the tests, the linter and `make complexity` in hand.
 
 ## What you run
 
-Start from the change itself, never from memory of it:
+Start from the change itself, never from memory of it, and through the Makefile as
+everything here does:
 
 ```sh
 git status --short
-git diff                      # or: git diff origin/main...HEAD for a branch
-go test ./... -race
-make lint
-make complexity               # compare against what the change touched
+git diff                 # or: git diff origin/main...HEAD for a branch
+make check               # build, wasm, test, lint
+make complexity          # compare against what the change touched
 ```
+
+A change verified by hand is a finding: say so, and name the test it should have been.
 
 A finding you cannot point at with a file and a line is not a finding yet.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,8 +37,12 @@ without it.
   when it cannot be cut that small, discuss the scope first.
 - **Every new feature goes through a pull request** saying what it gives the user. A fix
   straight to `main` is called by the maintainer, not assumed.
-- `make test`, `make lint`, `make complexity`. Cognitive complexity is the gate; cyclomatic
-  is information.
+- **Every action goes through the Makefile, without exception**: `make check` before
+  committing (build, wasm, test, lint), `make complexity` to measure. When a target does not
+  exist, add it in a pull request instead of working around it.
+- **Never run the binary by hand against a scrap of source.** If a behaviour needs checking,
+  write the test and run `make test` — that way the check survives. Cognitive complexity is
+  the gate; cyclomatic is information.
 
 ## Where things are written
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,53 @@
+# Aurora
+
+An untyped, expression-only language written in Go. Every value is a **tape**: a fixed run
+of bytes, `tape_size` wide. It runs on its own evaluator and assembles to EVM bytecode.
+
+## What matters now
+
+The language proves itself in the **evaluator** and in the **REPL**. The EVM backend is
+**parked on purpose** until the behaviour there settles — only then does it get decided
+*how* to compile to the EVM.
+
+A feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped
+without it.
+
+## The four premises
+
+1. **Every function says what it does and why it exists.** Briefly. A loose fragment gets a
+   comment only when the algorithm is hard to follow.
+2. **A vital or auxiliary package knows nothing about the rest of the project** — enough
+   that someone could take a part of it and build a different compiler.
+3. **Errors are resolved in the host.** A phase returns an error; it does not write.
+4. **A vital package is pure**: values in, values out.
+
+| kind | who | may depend on |
+|---|---|---|
+| phase | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | earlier phases, auxiliaries |
+| auxiliary | `byteutil`, `fileutil`, `logger`, `manifest` | nothing of the project |
+| host | `cmd/*`, `repl`, `internal/cli`, `lsp` | anything; nothing depends on it |
+
+## Working here
+
+- **A success case and an error case** for every implementation; an integration test for
+  anything the user perceives. Never verify by running and throw it away — if you had to
+  execute it to believe it, it becomes a test.
+- **One concern per commit**, and it compiles and passes on its own. A pull request carries
+  several of them and is sized so a human reviews the whole of it in **under forty minutes**;
+  when it cannot be cut that small, discuss the scope first.
+- **Every new feature goes through a pull request** saying what it gives the user. A fix
+  straight to `main` is called by the maintainer, not assumed.
+- `make test`, `make lint`, `make complexity`. Cognitive complexity is the gate; cyclomatic
+  is information.
+
+## Where things are written
+
+- **`.claude/agents/aurora-standards.md`** — the standards in full, and how to review against
+  them. Read it before writing code here.
+- **`.claude/agents/aurora-internals.md`** — how the compiler actually works, verified
+  against the code rather than the docs.
+- **`docs/`** for the end user, **`docs/contributing/`** for contributors (English),
+  **`rfcs/`** for proposals and debt (Portuguese).
+- **`docs/roadmap.md`** is the direction: anything the user can perceive gets an entry there.
+
+Conversation is usually pt-BR; code, comments and `docs/` stay in English.

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,21 @@ TPARSE_BIN = $(GOBIN)/tparse
 # Execute all meaningful jobs from Makefile to release the project's binary
 all: test lint build-force
 
+# Everything a change has to survive before it is committed: it compiles for both targets,
+# the tests pass and the linter is quiet.
+#
+# The wasm build is in here because the playground is the one target that does not come out
+# of `go build ./...`, and it is the one that breaks silently — nothing else compiles for it.
+check: build wasm test lint
+
+# Compile every package, without producing binaries.
+build:
+	@go build ./...
+
+# Compile for the browser, which is what the playground runs on.
+wasm:
+	@GOOS=js GOARCH=wasm go build ./...
+
 build-force: clean aurora aurorals
 
 aurora: $(BIN)/aurora
@@ -62,4 +77,4 @@ $(TPARSE_BIN):
 	@echo "==> Installing tparse..."
 	@go install github.com/mfridman/tparse@latest
 
-.PHONY: all build build-force aurora aurorals test bench lint act cover-html clean
+.PHONY: all check build wasm build-force aurora aurorals test bench lint act cover-html clean


### PR DESCRIPTION
An agent has to be called. `CLAUDE.md` does not — it is in context on every session, which makes it the one place a rule holds without anyone remembering to ask for it.

*(Reopened from #20, which GitHub closed when its base branch was deleted on merge of #17.)*

## `CLAUDE.md`

Deliberately short, because it is loaded every time and a long one gets skimmed:

- **what the project is aiming at now** — the language proves itself in the evaluator and the REPL; the EVM backend is parked on purpose, so a feature does not need bytecode to be finished;
- **the four premises** — a function says why it exists; a vital or auxiliary package knows nothing of the project; errors are resolved in the host; a vital package is pure;
- **the three kinds of package**, and which may depend on which;
- **how a change ships** — a success case and an error case, one concern per commit, a pull request a human can review in under forty minutes.

Everything else it points at rather than restates: the standards agent for the full text, the internals agent for how the compiler actually works, `docs/` for the user, `rfcs/` for what is still argued about, `docs/roadmap.md` for the direction.

The premises are repeated here rather than only linked because those four decide whether a change belongs at all, and a rule nobody reads before writing code gets broken in the first commit.

## Every action goes through the Makefile

Now a general rule rather than a review step, with the two targets the work needed and did not have:

```
make check    build + wasm + test + lint — what a change survives before being committed
make wasm     compile for the browser
```

**The wasm build earns its own target** because the playground is the one thing that does not come out of `go build ./...`, and the one that breaks silently — nothing else compiles for it, so nothing else notices.

And the part with a reason behind it: **never run the binary by hand against a scrap of source to see what happens.** If a behaviour needs checking, the test that checks it is the answer. A run in a terminal proves something once and leaves nothing behind — which is exactly how this repository ended up with documentation and examples that had been verified and then drifted, and why two pull requests this week were about checking them by running them.

## Value

The standard stops depending on someone remembering to invoke an agent, and "is this change sound?" becomes one command instead of four remembered ones — the same one for everybody, including CI.