### PR TITLE
Run CI on pull requests, through the same targets as a laptop

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -3,6 +3,10 @@ name: Pipeline
 on:
   push:
     branches: [main]
+  # Every change arrives as a pull request, so this has to run on the thing being reviewed
+  # rather than only on what was already merged.
+  pull_request:
+    branches: [main]
 
 jobs:
   test:
@@ -23,13 +27,36 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      # Through the Makefile, so a failure here is reproducible with one command locally.
+      # It writes coverage.out, which is also what `make cover-html` reads.
       - name: Running test
-        run: go test $(go list ./... | grep -v examples) -race -covermode atomic -coverprofile=covprofile
+        run: make test
 
       - name: Send coverage
         uses: shogo82148/actions-goveralls@v1
         with:
-          path-to-profile: covprofile
+          path-to-profile: coverage.out
+
+  build:
+    runs-on: ubuntu-24.04
+    name: Build
+    steps:
+      - name: Checkout source code
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      # Through the Makefile, so CI and a laptop run the same thing.
+      - name: Compile every package
+        run: make build
+
+      # The playground is the only target that does not come out of `go build ./...`, and
+      # the only one that breaks without anything noticing.
+      - name: Compile for the browser
+        run: make wasm
 
   lint:
     runs-on: ubuntu-24.04

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 SHELL=/bin/sh
 GOBIN ?= $(shell go env GOBIN)
+# `go env GOBIN` is empty unless someone set it, and `go install` then falls back to
+# GOPATH/bin. Without this the tool paths below point at /tparse and /golangci-lint, which
+# exist nowhere — it works on a machine with GOBIN set and fails everywhere else.
+ifeq ($(GOBIN),)
+GOBIN := $(shell go env GOPATH)/bin
+endif
 BIN ?= ./target/bin
 PKGS = $(shell go list ./... | grep -v examples)
 # Every Go file plus the module files: prerequisites of the binary, so editing source


### PR DESCRIPTION
Every change arrives as a pull request now, and the pipeline **only ran on push to `main`** — so nothing was checked until after it was merged, which is the one moment a check is worth least. The five pull requests opened this week had no CI at all.

## What it does now

**Runs on pull requests**, against `main`.

**Compiles the playground.** The wasm build is the only target that does not come out of `go build ./...`, which makes it the only one that can break with nothing noticing. `make wasm` runs beside `make build` in a new job.

**Uses the same commands a laptop uses.** The test job had its own `go test` line — close to the Makefile's but not the same, so a failure in CI was not a command anyone could repeat. It runs `make test`.

## It found a bug in its first run — in the Makefile

`/bin/sh: 1: /tparse: not found`

`go env GOBIN` is empty unless somebody set it, and `go install` then falls back to `GOPATH/bin`. The tool paths in the Makefile were built from `GOBIN` alone, so they pointed at `/tparse` and `/golangci-lint`, which exist nowhere. It worked on a machine with `GOBIN` set and failed everywhere else — and nothing noticed, because CI never used the Makefile.

Fixed here, and checked with `GOBIN` deliberately empty, which is the CI environment. This is the whole argument for CI and a laptop running the same command, arriving one commit after the change that made it possible.

## On trusting `make test`

Piping through `tparse` could have swallowed failures, which would mean green runs over broken tests — and would also mean the verification behind every pull request this week was worthless. It was checked before this change, with a deliberately failing test in the tree:

```
make test   with a broken test → exit 2
make check  with a broken test → exit 2
make test   with everything green → exit 0
```

The status propagates. Coverage now reads `coverage.out`, the file the Makefile already writes, rather than a name that existed only inside this workflow.

## Value

A pull request can be judged on evidence instead of on the author's word — which matters more now that the project ships through pull requests, and more still because the standard being built this week is precisely about what a change has to survive.

## Verified

All four jobs green on this pull request: Build, Lint, Go 1.23, Go 1.24.

`make complexity` is not wired in yet: it arrives with #16, and the gate that fails on it comes after the dispatch chains are refactored.