### PR TITLE
Upload coverage from one job instead of two

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -32,7 +32,15 @@ jobs:
       - name: Running test
         run: make test
 
+      # Only one job in the matrix uploads. Coveralls closes a build when it receives a
+      # job for it, so the second upload of the same commit is rejected with 422 "Build is
+      # closed" — whichever Go version happened to finish last failed the pipeline for a
+      # reason that had nothing to do with the code.
+      #
+      # The coverage is identical either way: it is the same source, and the number is not
+      # a property of the toolchain.
       - name: Send coverage
+        if: matrix.go == '1.24'
         uses: shogo82148/actions-goveralls@v1
         with:
           path-to-profile: coverage.out


### PR DESCRIPTION
The pipeline failed on the first pull request it ever ran on — Go 1.23 red, Go 1.24 green, identical tests. Not the code:

```
bad response status from coveralls: 422
{"message":"Can't add a job to a build that is already closed. Build 31928103943 is closed."}
```

Both versions in the matrix send coverage for the same commit, and Coveralls closes a build the moment it receives a job for it. The second upload is rejected, so **whichever version happened to finish last failed the pipeline**.

It was invisible while the pipeline only ran on `main`, because a red run after the merge is a thing nobody is waiting on. It stops being invisible the moment a pull request is gated on it, which is this week.

## The fix

The newest Go in the matrix uploads; the other does not. The number is the same either way — it is the same source, and coverage is not a property of the toolchain.

The alternative is Coveralls' parallel mode (`parallel: true` on each job plus a finishing job), which is more moving parts for a number that would not change.

## Value

A red pipeline means something again. A flake that fails half the time teaches people to merge over red, which is worse than having no pipeline at all.