### PR TITLE
One comparison per kind of node

### DIFF
--- a/parser/testutil.go
+++ b/parser/testutil.go
@@ -34,6 +34,21 @@ func ASTEqual(got, want AST) bool {
 	return true
 }
 
+// sameKind answers whether b is the kind of node a is, and whether the two then compare
+// alike.
+//
+// Every case used to spell out the same three lines — assert the kind, give up if it is
+// another one, compare — so the comparison, which is the only part that differed, was buried
+// in the middle of twenty-one repetitions of the same shape. That is what carried nodeEqual
+// to 107 of cognitive complexity, the highest in the project.
+func sameKind[T Node](b Node, a T, alike func(a, b T) bool) bool {
+	vb, ok := b.(T)
+	return ok && alike(a, vb)
+}
+
+// nodeEqual answers whether two trees are the same tree. The kind of node picks how it is
+// compared; a kind with no case falls back to a deep comparison, which is what keeps a node
+// added tomorrow comparable before anyone writes one for it.
 func nodeEqual(a, b Node) bool {
 	if a == nil && b == nil {
 		return true
@@ -43,171 +58,96 @@ func nodeEqual(a, b Node) bool {
 	}
 	switch va := a.(type) {
 	case NumberLiteral:
-		vb, ok := b.(NumberLiteral)
-		if !ok {
-			return false
-		}
-		return va.Value == vb.Value && TokenEqual(va.Token, vb.Token)
+		return sameKind(b, va, numberEqual)
 	case BooleanLiteral:
-		vb, ok := b.(BooleanLiteral)
-		if !ok {
-			return false
-		}
-		return bytes.Equal(va.Value, vb.Value) && TokenEqual(va.Token, vb.Token)
+		return sameKind(b, va, booleanEqual)
 	case BinaryExpression:
-		vb, ok := b.(BinaryExpression)
-		if !ok {
-			return false
-		}
-		return nodeEqual(va.Left, vb.Left) && nodeEqual(va.Right, vb.Right) && opEqual(va.Operation, vb.Operation)
+		return sameKind(b, va, binaryEqual)
 	case IfExpression:
-		vb, ok := b.(IfExpression)
-		if !ok {
-			return false
-		}
-		if !nodeEqual(va.Test, vb.Test) || !nodesEqual(va.Body, vb.Body) {
-			return false
-		}
-		if (va.Else == nil) != (vb.Else == nil) {
-			return false
-		}
-		if va.Else != nil && !elseEqual(*va.Else, *vb.Else) {
-			return false
-		}
-		return true
+		return sameKind(b, va, ifEqual)
 	case BlockExpression:
-		vb, ok := b.(BlockExpression)
-		if !ok {
-			return false
-		}
-		return nodesEqual(va.Body, vb.Body)
+		return sameKind(b, va, blockEqual)
 	case IdentLiteral:
-		vb, ok := b.(IdentLiteral)
-		if !ok {
-			return false
-		}
-		return va.Id == vb.Id && TokenEqual(va.Token, vb.Token) && nodeEqual(va.Value, vb.Value)
+		return sameKind(b, va, identEqual)
 	case PrintStatement:
-		vb, ok := b.(PrintStatement)
-		if !ok {
-			return false
-		}
-		return va.Format == vb.Format && nodeEqual(va.Param, vb.Param)
+		return sameKind(b, va, printEqual)
 	case AssertStatement:
-		vb, ok := b.(AssertStatement)
-		if !ok {
-			return false
-		}
-		return TokenEqual(va.Token, vb.Token) && nodeEqual(va.Condition, vb.Condition) && va.Message == vb.Message
+		return sameKind(b, va, assertEqual)
 	case UnaryExpression:
-		vb, ok := b.(UnaryExpression)
-		if !ok {
-			return false
-		}
-		return nodeEqual(va.Expression, vb.Expression) && opEqual(va.Operation, vb.Operation)
+		return sameKind(b, va, unaryEqual)
 	case StructDeclaration:
-		vb, ok := b.(StructDeclaration)
-		if !ok {
-			return false
-		}
-		return va.Name == vb.Name && slices.Equal(va.Fields, vb.Fields)
+		return sameKind(b, va, structDeclarationEqual)
 	case StructLiteral:
-		vb, ok := b.(StructLiteral)
-		if !ok || va.Name != vb.Name || len(va.Values) != len(vb.Values) {
-			return false
-		}
-		for i := range va.Values {
-			if !nodeEqual(va.Values[i], vb.Values[i]) {
-				return false
-			}
-		}
-		return true
+		return sameKind(b, va, structLiteralEqual)
 	case FieldExpression:
-		vb, ok := b.(FieldExpression)
-		if !ok {
-			return false
-		}
-		return va.Index == vb.Index && nodeEqual(va.Expression, vb.Expression)
+		return sameKind(b, va, fieldEqual)
 	case ShapedExpression:
-		vb, ok := b.(ShapedExpression)
-		if !ok {
-			return false
-		}
-		return va.Struct == vb.Struct && nodeEqual(va.Expression, vb.Expression)
+		return sameKind(b, va, shapedEqual)
 	case DeferExpression:
-		vb, ok := b.(DeferExpression)
-		if !ok {
-			return false
-		}
-		return blockEqual(va.Block, vb.Block)
+		return sameKind(b, va, deferEqual)
 	case CalleeLiteral:
-		vb, ok := b.(CalleeLiteral)
-		if !ok {
-			return false
-		}
-		if !identifierEqual(va.Id, vb.Id) {
-			return false
-		}
-		if len(va.Params) != len(vb.Params) {
-			return false
-		}
-		for i := range va.Params {
-			if !nodeEqual(va.Params[i].Expression, vb.Params[i].Expression) {
-				return false
-			}
-		}
-		return true
+		return sameKind(b, va, calleeEqual)
 	case IdentifierLiteral:
-		vb, ok := b.(IdentifierLiteral)
-		if !ok {
-			return false
-		}
-		return va.Value == vb.Value && TokenEqual(va.Token, vb.Token)
+		return sameKind(b, va, identifierEqual)
 	case OperationLiteral:
-		vb, ok := b.(OperationLiteral)
-		if !ok {
-			return false
-		}
-		return opEqual(va, vb)
+		return sameKind(b, va, opEqual)
 	case TapeBracketExpression:
-		vb, ok := b.(TapeBracketExpression)
-		if !ok {
-			return false
-		}
-		if len(va.Items) != len(vb.Items) {
-			return false
-		}
-		for i := range va.Items {
-			if !nodeEqual(va.Items[i], vb.Items[i]) {
-				return false
-			}
-		}
-		return true
+		return sameKind(b, va, tapeEqual)
 	case FeedExpression:
-		vb, ok := b.(FeedExpression)
-		if !ok {
-			return false
-		}
-		return va.Nth.Value == vb.Nth.Value && TokenEqual(va.Nth.Token, vb.Nth.Token)
+		return sameKind(b, va, feedEqual)
 	case RelativeExpression:
-		vb, ok := b.(RelativeExpression)
-		if !ok {
-			return false
-		}
-		return nodeEqual(va.Left, vb.Left) && nodeEqual(va.Right, vb.Right) && opEqual(va.Operation, vb.Operation)
+		return sameKind(b, va, relativeEqual)
 	case BooleanExpression:
-		vb, ok := b.(BooleanExpression)
-		if !ok {
-			return false
-		}
-		return nodeEqual(va.Left, vb.Left) && nodeEqual(va.Right, vb.Right) && opEqual(va.Operation, vb.Operation)
+		return sameKind(b, va, booleanExpressionEqual)
 	default:
 		return reflect.DeepEqual(a, b)
 	}
 }
 
+func numberEqual(a, b NumberLiteral) bool {
+	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+}
+
+func booleanEqual(a, b BooleanLiteral) bool {
+	return bytes.Equal(a.Value, b.Value) && TokenEqual(a.Token, b.Token)
+}
+
 func opEqual(a, b OperationLiteral) bool {
 	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+}
+
+func identifierEqual(a, b IdentifierLiteral) bool {
+	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+}
+
+// The three expressions with two operands differ only in what they mean, and the operator is
+// compared in all of them: it is the half of the tree that says which one it is.
+func binaryEqual(a, b BinaryExpression) bool {
+	return nodeEqual(a.Left, b.Left) && nodeEqual(a.Right, b.Right) && opEqual(a.Operation, b.Operation)
+}
+
+func relativeEqual(a, b RelativeExpression) bool {
+	return nodeEqual(a.Left, b.Left) && nodeEqual(a.Right, b.Right) && opEqual(a.Operation, b.Operation)
+}
+
+func booleanExpressionEqual(a, b BooleanExpression) bool {
+	return nodeEqual(a.Left, b.Left) && nodeEqual(a.Right, b.Right) && opEqual(a.Operation, b.Operation)
+}
+
+func unaryEqual(a, b UnaryExpression) bool {
+	return nodeEqual(a.Expression, b.Expression) && opEqual(a.Operation, b.Operation)
+}
+
+// An if is equal to another when both take the same branch on the same test — so an else
+// that only one of them has is already a difference, before its body is read.
+func ifEqual(a, b IfExpression) bool {
+	if !nodeEqual(a.Test, b.Test) || !nodesEqual(a.Body, b.Body) {
+		return false
+	}
+	if (a.Else == nil) != (b.Else == nil) {
+		return false
+	}
+	return a.Else == nil || elseEqual(*a.Else, *b.Else)
 }
 
 func blockEqual(a, b BlockExpression) bool {
@@ -218,8 +158,58 @@ func elseEqual(a, b ElseExpression) bool {
 	return nodesEqual(a.Body, b.Body)
 }
 
-func identifierEqual(a, b IdentifierLiteral) bool {
-	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+func deferEqual(a, b DeferExpression) bool {
+	return blockEqual(a.Block, b.Block)
+}
+
+func identEqual(a, b IdentLiteral) bool {
+	return a.Id == b.Id && TokenEqual(a.Token, b.Token) && nodeEqual(a.Value, b.Value)
+}
+
+func printEqual(a, b PrintStatement) bool {
+	return a.Format == b.Format && nodeEqual(a.Param, b.Param)
+}
+
+func assertEqual(a, b AssertStatement) bool {
+	return TokenEqual(a.Token, b.Token) && nodeEqual(a.Condition, b.Condition) && a.Message == b.Message
+}
+
+// A struct's fields are positional, so their order is part of the shape and not a detail of
+// how the declaration was written.
+func structDeclarationEqual(a, b StructDeclaration) bool {
+	return a.Name == b.Name && slices.Equal(a.Fields, b.Fields)
+}
+
+func structLiteralEqual(a, b StructLiteral) bool {
+	return a.Name == b.Name && nodesEqual(a.Values, b.Values)
+}
+
+func fieldEqual(a, b FieldExpression) bool {
+	return a.Index == b.Index && nodeEqual(a.Expression, b.Expression)
+}
+
+func shapedEqual(a, b ShapedExpression) bool {
+	return a.Struct == b.Struct && nodeEqual(a.Expression, b.Expression)
+}
+
+func calleeEqual(a, b CalleeLiteral) bool {
+	if !identifierEqual(a.Id, b.Id) || len(a.Params) != len(b.Params) {
+		return false
+	}
+	for i := range a.Params {
+		if !nodeEqual(a.Params[i].Expression, b.Params[i].Expression) {
+			return false
+		}
+	}
+	return true
+}
+
+func tapeEqual(a, b TapeBracketExpression) bool {
+	return nodesEqual(a.Items, b.Items)
+}
+
+func feedEqual(a, b FeedExpression) bool {
+	return numberEqual(a.Nth, b.Nth)
 }
 
 func nodesEqual(a, b []Node) bool {

--- a/parser/testutil_test.go
+++ b/parser/testutil_test.go
@@ -1,0 +1,499 @@
+package parser
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+)
+
+// nodeEqual is what every parser test believes: ASTEqual asks it whether the tree that came
+// out of the parser is the tree that was expected. Nothing ever asked nodeEqual anything, so
+// a comparison answering "equal" too easily would have made all of those tests agree with
+// almost any tree — and said nothing while doing it.
+//
+// Every case below is a pair that must not be confused: the same kind of node, one field
+// apart. A comparison that forgets a field passes the alike case and fails here.
+
+// number, ident and word build the small nodes the bigger cases are made of.
+func number(v uint64) NumberLiteral       { return NumberLiteral{Value: v} }
+func word(v string) IdentifierLiteral     { return IdentifierLiteral{Value: v} }
+func operation(v string) OperationLiteral { return OperationLiteral{Value: v} }
+
+var (
+	one = tok{[]byte("1"), lexer.TagNumber}
+	two = tok{[]byte("2"), lexer.TagNumber}
+	// Same text, different tag: TokenEqual reads both, and a token is not only its match.
+	oneAsIdent = tok{[]byte("1"), lexer.TagIdent}
+)
+
+var comparisonCases = []struct {
+	name string
+	a, b Node
+	want bool
+}{
+	{name: "nothing against nothing", a: nil, b: nil, want: true},
+	{name: "nothing against a node", a: nil, b: number(1), want: false},
+	{name: "a node against nothing", a: number(1), b: nil, want: false},
+	{name: "two kinds of node", a: number(1), b: BooleanLiteral{Value: []byte{1}}, want: false},
+
+	{name: "number, alike", a: number(1), b: number(1), want: true},
+	{name: "number, another value", a: number(1), b: number(2), want: false},
+	{
+		name: "number, another token",
+		a:    NumberLiteral{Value: 1, Token: one},
+		b:    NumberLiteral{Value: 1, Token: two},
+		want: false,
+	},
+
+	{
+		name: "boolean, alike",
+		a:    BooleanLiteral{Value: []byte{1}, Token: one},
+		b:    BooleanLiteral{Value: []byte{1}, Token: one},
+		want: true,
+	},
+	{
+		name: "boolean, another value",
+		a:    BooleanLiteral{Value: []byte{1}},
+		b:    BooleanLiteral{Value: []byte{0}},
+		want: false,
+	},
+	{
+		name: "boolean, another token",
+		a:    BooleanLiteral{Value: []byte{1}, Token: one},
+		b:    BooleanLiteral{Value: []byte{1}, Token: oneAsIdent},
+		want: false,
+	},
+
+	{
+		name: "binary, alike",
+		a:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("+")},
+		b:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("+")},
+		want: true,
+	},
+	{
+		name: "binary, another left",
+		a:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("+")},
+		b:    BinaryExpression{Left: number(3), Right: number(2), Operation: operation("+")},
+		want: false,
+	},
+	{
+		name: "binary, another right",
+		a:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("+")},
+		b:    BinaryExpression{Left: number(1), Right: number(3), Operation: operation("+")},
+		want: false,
+	},
+	{
+		// The operands are the same and the tree is not: this is the pair that catches a
+		// comparison ignoring the operator.
+		name: "binary, another operation",
+		a:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("+")},
+		b:    BinaryExpression{Left: number(1), Right: number(2), Operation: operation("-")},
+		want: false,
+	},
+
+	{
+		name: "relative, another operation",
+		a:    RelativeExpression{Left: number(1), Right: number(2), Operation: operation("bigger")},
+		b:    RelativeExpression{Left: number(1), Right: number(2), Operation: operation("smaller")},
+		want: false,
+	},
+	{
+		name: "relative, alike",
+		a:    RelativeExpression{Left: number(1), Right: number(2), Operation: operation("bigger")},
+		b:    RelativeExpression{Left: number(1), Right: number(2), Operation: operation("bigger")},
+		want: true,
+	},
+
+	{
+		name: "boolean expression, another operation",
+		a:    BooleanExpression{Left: number(1), Right: number(2), Operation: operation("and")},
+		b:    BooleanExpression{Left: number(1), Right: number(2), Operation: operation("or")},
+		want: false,
+	},
+	{
+		name: "boolean expression, alike",
+		a:    BooleanExpression{Left: number(1), Right: number(2), Operation: operation("and")},
+		b:    BooleanExpression{Left: number(1), Right: number(2), Operation: operation("and")},
+		want: true,
+	},
+
+	{
+		name: "unary, alike",
+		a:    UnaryExpression{Expression: number(1), Operation: operation("-")},
+		b:    UnaryExpression{Expression: number(1), Operation: operation("-")},
+		want: true,
+	},
+	{
+		// The operator dropped here once made -5 into 5, which is why it is asked twice.
+		name: "unary, another operation",
+		a:    UnaryExpression{Expression: number(1), Operation: operation("-")},
+		b:    UnaryExpression{Expression: number(1), Operation: operation("!")},
+		want: false,
+	},
+	{
+		name: "unary, another expression",
+		a:    UnaryExpression{Expression: number(1), Operation: operation("-")},
+		b:    UnaryExpression{Expression: number(2), Operation: operation("-")},
+		want: false,
+	},
+
+	{
+		name: "if, alike",
+		a:    IfExpression{Test: number(1), Body: []Node{number(2)}},
+		b:    IfExpression{Test: number(1), Body: []Node{number(2)}},
+		want: true,
+	},
+	{
+		name: "if, another test",
+		a:    IfExpression{Test: number(1), Body: []Node{number(2)}},
+		b:    IfExpression{Test: number(3), Body: []Node{number(2)}},
+		want: false,
+	},
+	{
+		name: "if, another body",
+		a:    IfExpression{Test: number(1), Body: []Node{number(2)}},
+		b:    IfExpression{Test: number(1), Body: []Node{number(3)}},
+		want: false,
+	},
+	{
+		name: "if, a shorter body",
+		a:    IfExpression{Test: number(1), Body: []Node{number(2), number(3)}},
+		b:    IfExpression{Test: number(1), Body: []Node{number(2)}},
+		want: false,
+	},
+	{
+		name: "if, one of them with an else",
+		a:    IfExpression{Test: number(1), Else: &ElseExpression{Body: []Node{number(2)}}},
+		b:    IfExpression{Test: number(1)},
+		want: false,
+	},
+	{
+		name: "if, another else",
+		a:    IfExpression{Test: number(1), Else: &ElseExpression{Body: []Node{number(2)}}},
+		b:    IfExpression{Test: number(1), Else: &ElseExpression{Body: []Node{number(3)}}},
+		want: false,
+	},
+	{
+		name: "if, the same else",
+		a:    IfExpression{Test: number(1), Else: &ElseExpression{Body: []Node{number(2)}}},
+		b:    IfExpression{Test: number(1), Else: &ElseExpression{Body: []Node{number(2)}}},
+		want: true,
+	},
+
+	{
+		name: "block, alike",
+		a:    BlockExpression{Body: []Node{number(1)}},
+		b:    BlockExpression{Body: []Node{number(1)}},
+		want: true,
+	},
+	{
+		name: "block, another body",
+		a:    BlockExpression{Body: []Node{number(1)}},
+		b:    BlockExpression{Body: []Node{number(2)}},
+		want: false,
+	},
+
+	{
+		name: "defer, alike",
+		a:    DeferExpression{Block: BlockExpression{Body: []Node{number(1)}}},
+		b:    DeferExpression{Block: BlockExpression{Body: []Node{number(1)}}},
+		want: true,
+	},
+	{
+		name: "defer, another block",
+		a:    DeferExpression{Block: BlockExpression{Body: []Node{number(1)}}},
+		b:    DeferExpression{Block: BlockExpression{Body: []Node{number(2)}}},
+		want: false,
+	},
+
+	{
+		name: "ident, alike",
+		a:    IdentLiteral{Id: "x", Token: one, Value: number(1)},
+		b:    IdentLiteral{Id: "x", Token: one, Value: number(1)},
+		want: true,
+	},
+	{
+		name: "ident, another name",
+		a:    IdentLiteral{Id: "x", Value: number(1)},
+		b:    IdentLiteral{Id: "y", Value: number(1)},
+		want: false,
+	},
+	{
+		name: "ident, another value",
+		a:    IdentLiteral{Id: "x", Value: number(1)},
+		b:    IdentLiteral{Id: "x", Value: number(2)},
+		want: false,
+	},
+	{
+		name: "ident, another token",
+		a:    IdentLiteral{Id: "x", Token: one, Value: number(1)},
+		b:    IdentLiteral{Id: "x", Token: two, Value: number(1)},
+		want: false,
+	},
+
+	{
+		name: "identifier, alike",
+		a:    IdentifierLiteral{Value: "x", Token: one},
+		b:    IdentifierLiteral{Value: "x", Token: one},
+		want: true,
+	},
+	{name: "identifier, another name", a: word("x"), b: word("y"), want: false},
+	{
+		name: "identifier, another token",
+		a:    IdentifierLiteral{Value: "x", Token: one},
+		b:    IdentifierLiteral{Value: "x", Token: two},
+		want: false,
+	},
+
+	{name: "operation, alike", a: operation("+"), b: operation("+"), want: true},
+	{name: "operation, another value", a: operation("+"), b: operation("-"), want: false},
+
+	{
+		// The three prints differ only in how the value is read, so the format is the whole
+		// difference between printb and printd.
+		name: "print, another format",
+		a:    PrintStatement{Format: PrintBytes, Param: number(1)},
+		b:    PrintStatement{Format: PrintDecimal, Param: number(1)},
+		want: false,
+	},
+	{
+		name: "print, alike",
+		a:    PrintStatement{Format: PrintChars, Param: number(1)},
+		b:    PrintStatement{Format: PrintChars, Param: number(1)},
+		want: true,
+	},
+	{
+		name: "print, another parameter",
+		a:    PrintStatement{Format: PrintChars, Param: number(1)},
+		b:    PrintStatement{Format: PrintChars, Param: number(2)},
+		want: false,
+	},
+
+	{
+		name: "assert, alike",
+		a:    AssertStatement{Condition: number(1), Message: "holds", Token: one},
+		b:    AssertStatement{Condition: number(1), Message: "holds", Token: one},
+		want: true,
+	},
+	{
+		name: "assert, another message",
+		a:    AssertStatement{Condition: number(1), Message: "holds"},
+		b:    AssertStatement{Condition: number(1), Message: "does not"},
+		want: false,
+	},
+	{
+		name: "assert, another condition",
+		a:    AssertStatement{Condition: number(1), Message: "holds"},
+		b:    AssertStatement{Condition: number(2), Message: "holds"},
+		want: false,
+	},
+
+	{
+		name: "struct declaration, alike",
+		a:    StructDeclaration{Name: "Point", Fields: []string{"x", "y"}},
+		b:    StructDeclaration{Name: "Point", Fields: []string{"x", "y"}},
+		want: true,
+	},
+	{
+		name: "struct declaration, another name",
+		a:    StructDeclaration{Name: "Point", Fields: []string{"x", "y"}},
+		b:    StructDeclaration{Name: "Pair", Fields: []string{"x", "y"}},
+		want: false,
+	},
+	{
+		// The fields are positional, so their order is part of the shape.
+		name: "struct declaration, the fields the other way round",
+		a:    StructDeclaration{Name: "Point", Fields: []string{"x", "y"}},
+		b:    StructDeclaration{Name: "Point", Fields: []string{"y", "x"}},
+		want: false,
+	},
+
+	{
+		name: "struct literal, alike",
+		a:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},
+		b:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},
+		want: true,
+	},
+	{
+		name: "struct literal, another name",
+		a:    StructLiteral{Name: "Point", Values: []Node{number(1)}},
+		b:    StructLiteral{Name: "Pair", Values: []Node{number(1)}},
+		want: false,
+	},
+	{
+		name: "struct literal, another value",
+		a:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},
+		b:    StructLiteral{Name: "Point", Values: []Node{number(1), number(3)}},
+		want: false,
+	},
+	{
+		name: "struct literal, one value fewer",
+		a:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},
+		b:    StructLiteral{Name: "Point", Values: []Node{number(1)}},
+		want: false,
+	},
+
+	{
+		name: "field, alike",
+		a:    FieldExpression{Expression: word("p"), Index: 1},
+		b:    FieldExpression{Expression: word("p"), Index: 1},
+		want: true,
+	},
+	{
+		name: "field, another index",
+		a:    FieldExpression{Expression: word("p"), Index: 0},
+		b:    FieldExpression{Expression: word("p"), Index: 1},
+		want: false,
+	},
+	{
+		name: "field, another expression",
+		a:    FieldExpression{Expression: word("p"), Index: 1},
+		b:    FieldExpression{Expression: word("q"), Index: 1},
+		want: false,
+	},
+
+	{
+		name: "shaped, alike",
+		a:    ShapedExpression{Expression: word("v"), Struct: "Point"},
+		b:    ShapedExpression{Expression: word("v"), Struct: "Point"},
+		want: true,
+	},
+	{
+		name: "shaped, another struct",
+		a:    ShapedExpression{Expression: word("v"), Struct: "Point"},
+		b:    ShapedExpression{Expression: word("v"), Struct: "Pair"},
+		want: false,
+	},
+	{
+		name: "shaped, another expression",
+		a:    ShapedExpression{Expression: word("v"), Struct: "Point"},
+		b:    ShapedExpression{Expression: word("w"), Struct: "Point"},
+		want: false,
+	},
+
+	{
+		name: "callee, alike",
+		a:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		b:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		want: true,
+	},
+	{
+		name: "callee, another name",
+		a:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		b:    CalleeLiteral{Id: word("g"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		want: false,
+	},
+	{
+		name: "callee, another parameter",
+		a:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		b:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(2)}}},
+		want: false,
+	},
+	{
+		name: "callee, one parameter fewer",
+		a:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}, {Expression: number(2)}}},
+		b:    CalleeLiteral{Id: word("f"), Params: []ParameterLiteral{{Expression: number(1)}}},
+		want: false,
+	},
+
+	{
+		name: "tape, alike",
+		a:    TapeBracketExpression{Items: []Node{number(1), number(2)}},
+		b:    TapeBracketExpression{Items: []Node{number(1), number(2)}},
+		want: true,
+	},
+	{
+		name: "tape, another item",
+		a:    TapeBracketExpression{Items: []Node{number(1), number(2)}},
+		b:    TapeBracketExpression{Items: []Node{number(1), number(3)}},
+		want: false,
+	},
+	{
+		name: "tape, one item fewer",
+		a:    TapeBracketExpression{Items: []Node{number(1), number(2)}},
+		b:    TapeBracketExpression{Items: []Node{number(1)}},
+		want: false,
+	},
+
+	{
+		name: "feed, alike",
+		a:    FeedExpression{Nth: NumberLiteral{Value: 0, Token: one}},
+		b:    FeedExpression{Nth: NumberLiteral{Value: 0, Token: one}},
+		want: true,
+	},
+	{
+		name: "feed, another position",
+		a:    FeedExpression{Nth: number(0)},
+		b:    FeedExpression{Nth: number(1)},
+		want: false,
+	},
+
+	// A node the switch does not name falls to reflect.DeepEqual, which is what keeps a new
+	// node comparable before anyone writes a case for it.
+	{
+		name: "text, alike",
+		a:    TextLiteral{Value: []byte("hi"), Token: one},
+		b:    TextLiteral{Value: []byte("hi"), Token: one},
+		want: true,
+	},
+	{
+		name: "text, another value",
+		a:    TextLiteral{Value: []byte("hi")},
+		b:    TextLiteral{Value: []byte("ho")},
+		want: false,
+	},
+}
+
+func TestNodeEqualTellsNodesApart(t *testing.T) {
+	for _, tc := range comparisonCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := nodeEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("answered %v, want %v", got, tc.want)
+			}
+			// Comparing is symmetric: reading the arguments the other way round is the same
+			// question, and a case that only looks at the first one would answer differently.
+			if got := nodeEqual(tc.b, tc.a); got != tc.want {
+				t.Errorf("answered %v the other way round, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// ASTEqual compares the file as well as the trees, and the trees are what TestASTEqual in
+// shapes_test.go already asks about through real sources. The name is the half nothing
+// reached: two files holding the same expressions are still two files.
+func TestASTEqualComparesTheFilename(t *testing.T) {
+	a := AST{Filename: "main.ar", Nodes: []Node{number(1)}}
+	b := AST{Filename: "other.ar", Nodes: []Node{number(1)}}
+
+	if !ASTEqual(a, a) {
+		t.Error("a file does not compare equal to itself")
+	}
+	if ASTEqual(a, b) {
+		t.Error("two filenames compared equal")
+	}
+}
+
+// TokenEqual reads both halves of a token, and nothing else about it.
+func TestTokenEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b lexer.Token
+		want bool
+	}{
+		{name: "nothing against nothing", want: true},
+		{name: "nothing against a token", b: one, want: false},
+		{name: "a token against nothing", a: one, want: false},
+		{name: "alike", a: one, b: tok{[]byte("1"), lexer.TagNumber}, want: true},
+		{name: "another match", a: one, b: two, want: false},
+		{name: "another tag", a: one, b: oneAsIdent, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := TokenEqual(tc.a, tc.b); got != tc.want {
+				t.Errorf("answered %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The third dispatch refactor, and the worst number in the project: `nodeEqual` scored **107 of cognitive complexity**, more than three times the limit of 30.

## What it changes for the reader

The cause was repetition, not difficulty. Twenty-one cases spelled out the same three lines — assert the kind, give up if it is another one, compare — so the comparison, the only part that differed between them, sat buried in the middle of each repetition.

`sameKind` takes those three lines once. Every case is now a line naming the comparison that belongs to that node, and each comparison is a function small enough to read whole, sitting next to its neighbours instead of inside a switch.

It reuses what was already there: `blockEqual`, `elseEqual`, `identifierEqual` and `opEqual` already had exactly this shape. And `structLiteralEqual` and `tapeEqual` turn out to be `nodesEqual` — the loops they replace were spelling it out by hand.

The fallback to `reflect.DeepEqual` for a kind of node with no case stays, which is what keeps a node added tomorrow comparable before anyone writes one for it.

## What made this safe to do

`nodeEqual` is what every parser test believes: `ASTEqual` asks it whether the tree that came out of the parser is the tree that was expected. **Nothing ever asked `nodeEqual` anything.** A comparison that answers "equal" too easily would have made all of those tests agree with almost any tree, and said nothing while doing it — which is exactly the failure this refactor could introduce.

So the first commit is a table of pairs that must not be confused: the same kind of node, one field apart.

- the operands equal and the **operator** different (`1 + 2` against `1 - 2`, and the same for `bigger`/`smaller` and `and`/`or`);
- the parameter equal and the **print format** different, since that is the whole difference between `printb` and `printd`;
- a struct's **fields in the other order**, because they are positional;
- an `else` that only one of the two has;
- one item, value or parameter fewer in every node that holds a list;
- the same text under a **different tag**, since a token is not only its match.

Every pair is also asked the other way round: a case reading only its first argument answers differently.

Confirmed to bite before being trusted — dropping the format from the print comparison makes `printb` and `printd` compare equal, and the pair catches it.

`TestASTEqual` in `shapes_test.go` already covers the trees through real sources; the filename was the half nothing reached, and it gets a small test of its own.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- `make complexity` — `nodeEqual` leaves the gocognit list (7 → 6 functions over the limit). It trips `funlen` instead (49 statements for 21 cases), the same misreading cyclomatic makes of a lookup table, and the same note as #25: what made this function hard was repetition, not length.
- Each commit verified in its own `git worktree` with `make check`.

Left after this: `repl.Start` (41) and `ReadLine` (35), both in the REPL.