### PR TITLE
A session, instead of one loop holding everything

### DIFF
--- a/cmd/aurora/repl.go
+++ b/cmd/aurora/repl.go
@@ -29,7 +29,7 @@ var replCmd = &cobra.Command{
 		if err := cli.ValidateTapeSize(tapeSize); err != nil {
 			return err
 		}
-		repl.Start(os.Stdin, loggers, tapeSize)
+		repl.Start(os.Stdin, os.Stdout, loggers, tapeSize)
 		return nil
 	},
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -92,6 +92,108 @@ func newLineReader(in io.Reader, out io.Writer) (lineReader, *History) {
 	}), hist
 }
 
+// session is one file typed a line at a time: what a line needs to be compiled and run, and
+// what it leaves behind for the line after it.
+//
+// It is a type rather than a handful of variables inside a loop because everything here
+// outlives the line that filled it — a name, a struct directive and a defer all have to
+// still be there on the next one.
+type session struct {
+	ev       *evaluator.Evaluator
+	out      io.Writer
+	tapeSize int
+	loggers  []string
+
+	// A parser is built per line, so the struct directives are held here: a struct declared
+	// on one line has to still be known on the next.
+	directives *parser.Directives
+	// Every line's instructions go into the same buffer, which is what keeps the range a
+	// defer recorded valid when it is called on a later line.
+	insts []emitter.Instruction
+
+	hist       *History
+	histWarned bool
+}
+
+// run compiles a line and runs it. An error is written and swallowed: a session survives a
+// line that does not compile, which is most of what a REPL is for.
+func (s *session) run(text string) {
+	program, err := s.compile(text)
+	if err != nil {
+		_, _ = fmt.Fprintln(s.out, err)
+		return
+	}
+	s.evaluate(program)
+}
+
+// compile takes the line through the three phases, showing what each one produced when -l
+// asked for it.
+func (s *session) compile(text string) (emitter.Program, error) {
+	line := bytes.NewBufferString(text)
+
+	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(line.Bytes())
+	if err != nil {
+		return emitter.Program{}, err
+	}
+	s.trace("lexer", func(w io.Writer) error { return trace.Tokens(w, tokens) })
+
+	ast, err := parser.New(parser.NewParserOptions{
+		Tokens:     tokens,
+		TapeSize:   s.tapeSize,
+		Directives: s.directives,
+	}).Parse()
+	if err != nil {
+		return emitter.Program{}, err
+	}
+	s.trace("parser", func(w io.Writer) error { return trace.AST(w, ast) })
+
+	program, err := emitter.New(emitter.NewEmitterOptions{
+		TapeSize: s.tapeSize,
+	}).EmitProgram(ast)
+	if err != nil {
+		return emitter.Program{}, err
+	}
+	s.trace("emitter", func(w io.Writer) error { return trace.Instructions(w, program.Instructions) })
+
+	return program, nil
+}
+
+// trace writes what a phase produced, when -l named that phase. The phases return what they
+// made; showing it is decided here, in the host.
+func (s *session) trace(phase string, write func(w io.Writer) error) {
+	if !slices.Contains(s.loggers, phase) {
+		return
+	}
+	if err := write(s.out); err != nil {
+		_, _ = fmt.Fprintln(s.out, err)
+	}
+}
+
+// evaluate runs the line's expressions one at a time, so a line holding several of them
+// answers where each one happens rather than all of them at the end.
+func (s *session) evaluate(program emitter.Program) {
+	offset := len(s.insts)
+	s.insts = append(s.insts, program.Instructions...)
+
+	for _, expr := range program.Expressions {
+		temps, err := s.ev.EvaluateRange(s.insts, uint64(offset+expr.From), uint64(offset+expr.To))
+		render(s.out, temps, byteutil.ToHex(expr.Label), err)
+		if err != nil {
+			return
+		}
+	}
+}
+
+// remember records the line before it is evaluated, so a line that fails to compile is still
+// recallable. A history that cannot be written is said once, on stderr — it is about the
+// environment and not about the session, which carries on either way.
+func (s *session) remember(text string) {
+	if err := s.hist.Append(text); err != nil && !s.histWarned {
+		s.histWarned = true
+		_, _ = fmt.Fprintf(os.Stderr, "warning: could not write history: %v\n", err)
+	}
+}
+
 // Start runs a session, reading from in and writing everything it has to say to out — the
 // prompt, the value of each line, and the errors that did not stop the session.
 //
@@ -100,32 +202,28 @@ func newLineReader(in io.Reader, out io.Writer) (lineReader, *History) {
 // language proves itself and no test could see a single line of it.
 func Start(in io.Reader, out io.Writer, loggers []string, tapeSize int) {
 	tapeSize = byteutil.TapeSize(tapeSize)
-	ev := evaluator.New(evaluator.NewEvaluatorOptions{
-		Output:   out,
-		TapeSize: tapeSize,
-	})
-
 	reader, hist := newLineReader(in, out)
-	editing, interactive := reader.(*editor)
 
-	csig := make(chan os.Signal, 1)
-	signal.Notify(csig, os.Interrupt)
-	go func() {
-		<-csig
+	s := &session{
+		ev: evaluator.New(evaluator.NewEvaluatorOptions{
+			Output:   out,
+			TapeSize: tapeSize,
+		}),
+		out:        out,
+		tapeSize:   tapeSize,
+		loggers:    loggers,
+		directives: parser.NewDirectives(),
+		hist:       hist,
+	}
+
+	editing, interactive := reader.(*editor)
+	leaveOnInterrupt(out, func() {
 		// os.Exit skips defers, so leave raw mode here before quitting.
 		if interactive {
 			editing.Restore()
 		}
-		_, _ = fmt.Fprintln(out, "Bye :)")
-		os.Exit(0)
-	}()
+	})
 
-	var instsBuffer []emitter.Instruction
-	// One session is one file typed a line at a time, and a parser is built per line, so the
-	// struct directives are held here: a struct declared on one line has to still be known
-	// on the next.
-	directives := parser.NewDirectives()
-	histWarned := false
 	for {
 		text, err := reader.ReadLine()
 		if errors.Is(err, errInterrupt) { // Ctrl+C: drop the line, prompt again
@@ -141,66 +239,19 @@ func Start(in io.Reader, out io.Writer, loggers []string, tapeSize int) {
 			continue
 		}
 
-		// Record before evaluating so a line that fails to compile is still recallable.
-		if err := hist.Append(text); err != nil && !histWarned {
-			histWarned = true
-			_, _ = fmt.Fprintf(os.Stderr, "warning: could not write history: %v\n", err)
-		}
-
-		line := bytes.NewBufferString(text)
-
-		tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(line.Bytes())
-		if err != nil {
-			_, _ = fmt.Fprintln(out, err)
-			continue
-		}
-		if slices.Contains(loggers, "lexer") {
-			if err := trace.Tokens(out, tokens); err != nil {
-				_, _ = fmt.Fprintln(out, err)
-			}
-		}
-
-		ast, err := parser.New(parser.NewParserOptions{
-			Tokens:     tokens,
-			TapeSize:   tapeSize,
-			Directives: directives,
-		}).Parse()
-		if err != nil {
-			_, _ = fmt.Fprintln(out, err)
-			continue
-		}
-		// The phases return what they made; showing it is decided here.
-		if slices.Contains(loggers, "parser") {
-			if err := trace.AST(out, ast); err != nil {
-				_, _ = fmt.Fprintln(out, err)
-			}
-		}
-
-		program, err := emitter.New(emitter.NewEmitterOptions{
-			TapeSize: tapeSize,
-		}).EmitProgram(ast)
-		if err != nil {
-			_, _ = fmt.Fprintln(out, err)
-			continue
-		}
-		if slices.Contains(loggers, "emitter") {
-			if err := trace.Instructions(out, program.Instructions); err != nil {
-				_, _ = fmt.Fprintln(out, err)
-			}
-		}
-
-		// Append to buffer so defer from/to indices stay valid when calling later.
-		offset := len(instsBuffer)
-		instsBuffer = append(instsBuffer, program.Instructions...)
-
-		// One expression at a time, so a line holding several of them prints each value
-		// where it happens rather than all of them at the end.
-		for _, expr := range program.Expressions {
-			temps, err := ev.EvaluateRange(instsBuffer, uint64(offset+expr.From), uint64(offset+expr.To))
-			render(out, temps, byteutil.ToHex(expr.Label), err)
-			if err != nil {
-				break
-			}
-		}
+		s.remember(text)
+		s.run(text)
 	}
+}
+
+// leaveOnInterrupt says goodbye on Ctrl+C, after giving the terminal back.
+func leaveOnInterrupt(out io.Writer, restore func()) {
+	csig := make(chan os.Signal, 1)
+	signal.Notify(csig, os.Interrupt)
+	go func() {
+		<-csig
+		restore()
+		_, _ = fmt.Fprintln(out, "Bye :)")
+		os.Exit(0)
+	}()
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -74,10 +74,10 @@ func (s *scannerReader) ReadLine() (string, error) {
 
 // newLineReader picks the editor for a terminal and the scanner for anything else.
 // The history is shared with the caller so it can record accepted lines.
-func newLineReader(in io.Reader) (lineReader, *History) {
+func newLineReader(in io.Reader, out io.Writer) (lineReader, *History) {
 	f, ok := in.(*os.File)
 	if !ok || !isTTY(f) {
-		return &scannerReader{scanner: bufio.NewScanner(in), out: os.Stdout}, LoadHistory("")
+		return &scannerReader{scanner: bufio.NewScanner(in), out: out}, LoadHistory("")
 	}
 
 	// Without a home directory the history stays in memory; that is no reason to break the REPL.
@@ -87,19 +87,25 @@ func newLineReader(in io.Reader) (lineReader, *History) {
 	}
 	hist := LoadHistory(path)
 
-	return newEditor(f, os.Stdout, prompt, hist, func() (func(), error) {
+	return newEditor(f, out, prompt, hist, func() (func(), error) {
 		return enterRaw(f)
 	}), hist
 }
 
-func Start(in io.Reader, loggers []string, tapeSize int) {
+// Start runs a session, reading from in and writing everything it has to say to out — the
+// prompt, the value of each line, and the errors that did not stop the session.
+//
+// Where it writes is the host's to decide, and it used to be os.Stdout from the inside,
+// which is also why nothing could read a session back: the REPL is one of the two places the
+// language proves itself and no test could see a single line of it.
+func Start(in io.Reader, out io.Writer, loggers []string, tapeSize int) {
 	tapeSize = byteutil.TapeSize(tapeSize)
 	ev := evaluator.New(evaluator.NewEvaluatorOptions{
-		Output:   os.Stdout,
+		Output:   out,
 		TapeSize: tapeSize,
 	})
 
-	reader, hist := newLineReader(in)
+	reader, hist := newLineReader(in, out)
 	editing, interactive := reader.(*editor)
 
 	csig := make(chan os.Signal, 1)
@@ -110,7 +116,7 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 		if interactive {
 			editing.Restore()
 		}
-		fmt.Println("Bye :)")
+		_, _ = fmt.Fprintln(out, "Bye :)")
 		os.Exit(0)
 	}()
 
@@ -127,7 +133,7 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 		}
 		if err != nil { // Ctrl+D or end of piped input
 			if interactive {
-				fmt.Println("Bye :)")
+				_, _ = fmt.Fprintln(out, "Bye :)")
 			}
 			return
 		}
@@ -145,12 +151,12 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 
 		tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(line.Bytes())
 		if err != nil {
-			fmt.Println(err)
+			_, _ = fmt.Fprintln(out, err)
 			continue
 		}
 		if slices.Contains(loggers, "lexer") {
-			if err := trace.Tokens(os.Stdout, tokens); err != nil {
-				fmt.Println(err)
+			if err := trace.Tokens(out, tokens); err != nil {
+				_, _ = fmt.Fprintln(out, err)
 			}
 		}
 
@@ -160,13 +166,13 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 			Directives: directives,
 		}).Parse()
 		if err != nil {
-			fmt.Println(err)
+			_, _ = fmt.Fprintln(out, err)
 			continue
 		}
 		// The phases return what they made; showing it is decided here.
 		if slices.Contains(loggers, "parser") {
-			if err := trace.AST(os.Stdout, ast); err != nil {
-				fmt.Println(err)
+			if err := trace.AST(out, ast); err != nil {
+				_, _ = fmt.Fprintln(out, err)
 			}
 		}
 
@@ -174,12 +180,12 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 			TapeSize: tapeSize,
 		}).EmitProgram(ast)
 		if err != nil {
-			fmt.Println(err)
+			_, _ = fmt.Fprintln(out, err)
 			continue
 		}
 		if slices.Contains(loggers, "emitter") {
-			if err := trace.Instructions(os.Stdout, program.Instructions); err != nil {
-				fmt.Println(err)
+			if err := trace.Instructions(out, program.Instructions); err != nil {
+				_, _ = fmt.Fprintln(out, err)
 			}
 		}
 
@@ -191,7 +197,7 @@ func Start(in io.Reader, loggers []string, tapeSize int) {
 		// where it happens rather than all of them at the end.
 		for _, expr := range program.Expressions {
 			temps, err := ev.EvaluateRange(instsBuffer, uint64(offset+expr.From), uint64(offset+expr.To))
-			render(os.Stdout, temps, byteutil.ToHex(expr.Label), err)
+			render(out, temps, byteutil.ToHex(expr.Label), err)
 			if err != nil {
 				break
 			}

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -9,8 +9,8 @@ import (
 // took its writer. These go in the way a shell pipe does — lines in, everything the session
 // said out — so what is pinned here is the REPL as someone uses it, not its parts.
 
-// session types the lines given and answers with everything that was written back.
-func session(t *testing.T, lines string, loggers []string, tapeSize int) string {
+// typed types the lines given and answers with everything the session wrote back.
+func typed(t *testing.T, lines string, loggers []string, tapeSize int) string {
 	t.Helper()
 	out := &strings.Builder{}
 	Start(strings.NewReader(lines), out, loggers, tapeSize)
@@ -66,7 +66,7 @@ func TestSessionAnswersWithTheTape(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := session(t, tc.lines, nil, 0)
+			got := typed(t, tc.lines, nil, 0)
 			for _, want := range tc.want {
 				if !strings.Contains(got, want) {
 					t.Errorf("session wrote %q, want it to contain %q", got, want)
@@ -78,7 +78,7 @@ func TestSessionAnswersWithTheTape(t *testing.T) {
 
 // The width of a value is the session's, so a narrower tape wraps rather than growing.
 func TestSessionHonoursTheTapeSize(t *testing.T) {
-	got := session(t, "255 + 1;\n", nil, 1)
+	got := typed(t, "255 + 1;\n", nil, 1)
 
 	if !strings.Contains(got, "= [0]") {
 		t.Errorf("session wrote %q, want a one-byte tape holding zero", got)
@@ -100,7 +100,7 @@ func TestSessionSurvivesALineThatFails(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := session(t, tc.lines, nil, 0)
+			got := typed(t, tc.lines, nil, 0)
 
 			if !strings.Contains(got, tc.fails) {
 				t.Errorf("session wrote %q, want it to say %q", got, tc.fails)
@@ -114,7 +114,7 @@ func TestSessionSurvivesALineThatFails(t *testing.T) {
 
 // A blank line is not an expression: it prompts again and says nothing.
 func TestSessionSaysNothingForABlankLine(t *testing.T) {
-	got := session(t, "\n   \n", nil, 0)
+	got := typed(t, "\n   \n", nil, 0)
 
 	if strings.Contains(got, "=") {
 		t.Errorf("session wrote %q, want nothing but prompts", got)
@@ -136,7 +136,7 @@ func TestSessionShowsOnlyThePhaseThatWasAsked(t *testing.T) {
 
 	for phase, mark := range marks {
 		t.Run(phase, func(t *testing.T) {
-			got := session(t, line, []string{phase}, 0)
+			got := typed(t, line, []string{phase}, 0)
 
 			if !strings.Contains(got, mark) {
 				t.Errorf("asked for %s, session wrote %q", phase, got)
@@ -152,7 +152,7 @@ func TestSessionShowsOnlyThePhaseThatWasAsked(t *testing.T) {
 		})
 	}
 
-	if got := session(t, line, nil, 0); strings.Contains(got, "OpAdd") {
+	if got := typed(t, line, nil, 0); strings.Contains(got, "OpAdd") {
 		t.Errorf("a session that asked for nothing wrote %q", got)
 	}
 }

--- a/repl/session_test.go
+++ b/repl/session_test.go
@@ -1,0 +1,158 @@
+package repl
+
+import (
+	"strings"
+	"testing"
+)
+
+// A session is one file typed a line at a time, and nothing could read one back until Start
+// took its writer. These go in the way a shell pipe does — lines in, everything the session
+// said out — so what is pinned here is the REPL as someone uses it, not its parts.
+
+// session types the lines given and answers with everything that was written back.
+func session(t *testing.T, lines string, loggers []string, tapeSize int) string {
+	t.Helper()
+	out := &strings.Builder{}
+	Start(strings.NewReader(lines), out, loggers, tapeSize)
+	return out.String()
+}
+
+func TestSessionAnswersWithTheTape(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines string
+		want  []string
+	}{
+		{name: "arithmetic", lines: "1 + 2;\n", want: []string{"= [0 0 0 0 0 0 0 3]"}},
+		{
+			// Text is a tape of its bytes, so this is what "hi" is, not a reading of it.
+			name:  "text",
+			lines: `"hi";` + "\n",
+			want:  []string{"= [0 0 0 0 0 0 104 105]"},
+		},
+		{
+			name:  "an identifier holds on the next line",
+			lines: "ident x = 7;\nx * 2;\n",
+			want:  []string{"= [0 0 0 0 0 0 0 14]"},
+		},
+		{
+			// The directives are held across lines: a struct declared on one line has to still
+			// be known on the next, and a parser is built per line.
+			name:  "a struct declared on one line is built on the next",
+			lines: "struct Point { x, y };\nident p = Point{10, 20};\np.y;\n",
+			want:  []string{"= [0 0 0 0 0 0 0 20]"},
+		},
+		{
+			// The instructions of every line stay in one buffer, which is what keeps a defer's
+			// range valid when it is called later.
+			name:  "a defer written on one line is called on the next",
+			lines: "ident double = defer { feed(0) * 2; };\ndouble(21);\n",
+			want:  []string{"= [0 0 0 0 0 0 0 42]"},
+		},
+		{
+			// One expression at a time, so each value is written where it happens.
+			name:  "several expressions on one line",
+			lines: "1; 2; 3;\n",
+			want:  []string{"= [0 0 0 0 0 0 0 1]", "= [0 0 0 0 0 0 0 2]", "= [0 0 0 0 0 0 0 3]"},
+		},
+		{
+			// What a program prints is its own writing, and it lands before the value of the
+			// line that printed it.
+			name:  "what the line printed comes before its value",
+			lines: "printd 65;\n",
+			want:  []string{"65"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := session(t, tc.lines, nil, 0)
+			for _, want := range tc.want {
+				if !strings.Contains(got, want) {
+					t.Errorf("session wrote %q, want it to contain %q", got, want)
+				}
+			}
+		})
+	}
+}
+
+// The width of a value is the session's, so a narrower tape wraps rather than growing.
+func TestSessionHonoursTheTapeSize(t *testing.T) {
+	got := session(t, "255 + 1;\n", nil, 1)
+
+	if !strings.Contains(got, "= [0]") {
+		t.Errorf("session wrote %q, want a one-byte tape holding zero", got)
+	}
+}
+
+// A line that does not compile is answered and forgotten: the session is still there for the
+// next one, which is most of what a REPL is for.
+func TestSessionSurvivesALineThatFails(t *testing.T) {
+	cases := []struct {
+		name  string
+		lines string
+		fails string
+	}{
+		{name: "a line that does not parse", lines: "1 +;\n2;\n", fails: "unexpected token"},
+		{name: "a name that was never set", lines: "nope;\n2;\n", fails: "identifier"},
+		{name: "a division by zero", lines: "1 / 0;\n2;\n", fails: "divide by zero"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := session(t, tc.lines, nil, 0)
+
+			if !strings.Contains(got, tc.fails) {
+				t.Errorf("session wrote %q, want it to say %q", got, tc.fails)
+			}
+			if !strings.Contains(got, "= [0 0 0 0 0 0 0 2]") {
+				t.Errorf("session wrote %q, want the line after the failure to have run", got)
+			}
+		})
+	}
+}
+
+// A blank line is not an expression: it prompts again and says nothing.
+func TestSessionSaysNothingForABlankLine(t *testing.T) {
+	got := session(t, "\n   \n", nil, 0)
+
+	if strings.Contains(got, "=") {
+		t.Errorf("session wrote %q, want nothing but prompts", got)
+	}
+	if strings.Count(got, prompt) != 3 {
+		t.Errorf("session wrote %d prompts, want one per line and one for the end", strings.Count(got, prompt))
+	}
+}
+
+// -l shows what a phase produced, and only the phase that was named: the trace is the host's
+// doing, and a session that was not asked shows none of it.
+func TestSessionShowsOnlyThePhaseThatWasAsked(t *testing.T) {
+	const line = "1 + 2;\n"
+	marks := map[string]string{
+		"lexer":   "SEMICOLON: 3B",
+		"parser":  "BinaryExpression",
+		"emitter": "OpAdd",
+	}
+
+	for phase, mark := range marks {
+		t.Run(phase, func(t *testing.T) {
+			got := session(t, line, []string{phase}, 0)
+
+			if !strings.Contains(got, mark) {
+				t.Errorf("asked for %s, session wrote %q", phase, got)
+			}
+			for other, otherMark := range marks {
+				if other == phase {
+					continue
+				}
+				if strings.Contains(got, otherMark) {
+					t.Errorf("asked for %s and %s showed up as well", phase, other)
+				}
+			}
+		})
+	}
+
+	if got := session(t, line, nil, 0); strings.Contains(got, "OpAdd") {
+		t.Errorf("a session that asked for nothing wrote %q", got)
+	}
+}


### PR DESCRIPTION
The fourth dispatch refactor, and the one I put there myself: `Start` scored **41 of cognitive complexity**, and it went over the limit when the loggers moved out of the phases and into the host.

## What it changes for the reader

`Start` was the whole REPL in one function — the pipeline, the tracing, the history, the signal handler and the loop that reads a line, all nested inside each other. The pipeline was never the loop's business.

`session` is what a line needs and what it leaves behind for the line after it. It is a type rather than five variables in a loop because **everything in it outlives the line that filled it**: a name, a struct directive and a defer all have to still be there on the next one. That is the fact the loop was carrying implicitly, and it is now written down next to the fields that hold it.

What is left of `Start` is the wiring and the loop over lines. `compile`, `evaluate`, `trace` and `remember` each say one thing, and the three repetitions of "if `-l` named this phase, write what it produced, and say so if writing failed" became one. `leaveOnInterrupt` takes the goodbye out of the middle of the setup, and with it the knowledge of whether the terminal has to be given back first.

## What made this safe to do

**The REPL had no test of its own.** The editor, the history and the rendering had tests; the loop that joins them had none — and `CLAUDE.md` says the language proves itself in the evaluator and in the REPL.

Nothing could read a session back either, because `Start` wrote to `os.Stdout` from the inside. The first commit gives it the writer, like every other host entry point here; only the command decides that the writer is `os.Stdout`.

The second commit then goes in the way a shell pipe does — lines in, everything the session said out — and pins what **only a session** does, not what a phase does:

- a name, a struct directive and a defer written on one line still hold on the next;
- a line that does not compile is answered and forgotten, and the session takes the next one (asked of a parse error, an unknown name and a division by zero);
- several expressions on one line each answer where they happen;
- `-l` shows the phase that was named **and no other**;
- a blank line prompts again and says nothing;
- the tape size is the session's, so `255 + 1` is `[0]` at one byte.

Both were confirmed to bite: building the directives per line breaks the struct case, and dropping the shared instruction buffer sends the defer case running into the wrong instructions until it is killed.

REPL coverage goes from **60.5% to 79.7%**.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- `make complexity` — `Start` leaves the gocognit list (4 → 3 functions over the limit), and adds nothing to `funlen`.
- Each commit verified in its own `git worktree` with `make check`.

Left after this: `ReadLine` (35), the last one that is not amnestied.