### PR TITLE
The playground picks its tape size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes and release notes for Aurora are documented here.
 
 - **`aurora init`** writes `tape_size` under `[project]`.
 
+- **The playground picks its tape size**, and starts at 32 bytes rather than the language's 8. The page opens on `printc "Hello, World!";` — thirteen bytes, which does not fit an eight-byte tape, so the first thing it used to do was refuse its own example. Changing the width re-runs the program at once: the output on screen is never the output of a different width than the one shown.
+
 ---
 
 ## v0.4.0-alpha — 2026-08-15

--- a/byteutil/tape.go
+++ b/byteutil/tape.go
@@ -1,6 +1,11 @@
 package byteutil
 
-import "github.com/holiman/uint256"
+import (
+	"strconv"
+	"strings"
+
+	"github.com/holiman/uint256"
+)
 
 // A tape is how every value in Aurora is represented: a fixed run of bytes, big-endian,
 // right-aligned. How many bytes is a property of the program being compiled, not of the
@@ -26,6 +31,21 @@ func TapeSize(size int) int {
 	}
 	if size > MaxTapeSize {
 		return MaxTapeSize
+	}
+	return size
+}
+
+// ParseTapeSize reads a tape size written as text, answering with fallback when the text is
+// not a number a tape can be.
+//
+// It exists for a host that takes the size from outside the program — a form control, a
+// query string — where the value arrives as text and a bad one is not worth stopping for.
+// The fallback is the caller's because a host may start from a width of its own: the
+// playground opens at 32, not at the language's 8.
+func ParseTapeSize(text string, fallback int) int {
+	size, err := strconv.Atoi(strings.TrimSpace(text))
+	if err != nil || size < MinTapeSize || size > MaxTapeSize {
+		return fallback
 	}
 	return size
 }

--- a/byteutil/tape_parse_test.go
+++ b/byteutil/tape_parse_test.go
@@ -1,0 +1,38 @@
+package byteutil
+
+import "testing"
+
+// A host that reads the size from outside the program gets it as text, and text can be
+// anything. What it must never be is a reason to stop: a bad value falls back to the width
+// the host starts from, which is not always the language's.
+func TestParseTapeSize(t *testing.T) {
+	const fallback = 32
+
+	cases := []struct {
+		name string
+		text string
+		want int
+	}{
+		{name: "a size", text: "16", want: 16},
+		{name: "the narrowest", text: "1", want: 1},
+		{name: "the widest", text: "32", want: 32},
+		{name: "written with spaces around it", text: " 8 ", want: 8},
+
+		{name: "nothing", text: "", want: fallback},
+		{name: "not a number", text: "wide", want: fallback},
+		{name: "a number no tape can be", text: "0", want: fallback},
+		{name: "wider than the EVM word", text: "33", want: fallback},
+		{name: "negative", text: "-1", want: fallback},
+		// The fallback is the caller's, and it is not normalized on the way out: a host
+		// that says 32 gets 32, where TapeSize would have answered with the language's 8.
+		{name: "a number with something after it", text: "8px", want: fallback},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := ParseTapeSize(tc.text, fallback); got != tc.want {
+				t.Errorf("ParseTapeSize(%q) = %d, want %d", tc.text, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -17,10 +17,30 @@ import (
 	"github.com/guiferpa/aurora/version"
 )
 
+// defaultTapeSize is the width the playground starts at, and it is wider than the language's
+// default of 8 on purpose.
+//
+// Someone meeting Aurora here writes text before they write anything else, and the page opens
+// on printc "Hello, World!" — thirteen bytes, which does not fit an eight-byte tape. Being
+// told so as a first experience teaches nothing about tapes and everything about giving up.
+// The control says what the width is, so the number is on screen rather than assumed.
+const defaultTapeSize = 32
+
 var (
 	document js.Value
 	eval     func() js.Func
 )
+
+// tapeSize reads the width the page is set to. Anything the page cannot answer for — no
+// control, a value that is not a number, a number outside what a tape can be — falls back to
+// the playground's own default rather than to the language's.
+func tapeSize() int {
+	el := document.Call("getElementById", "tape-size")
+	if !el.Truthy() {
+		return defaultTapeSize
+	}
+	return byteutil.ParseTapeSize(el.Get("value").String(), defaultTapeSize)
+}
 
 func init() {
 	document = js.Global().Get("document")
@@ -33,6 +53,8 @@ func init() {
 			value := editor.Call("getValue").String()
 			bs := bytes.NewBufferString(value)
 			debug := document.Call("getElementById", "debug-mode").Get("checked").Bool()
+			// Read for every run, so changing the width is a matter of running again.
+			size := tapeSize()
 			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs.Bytes())
 			if err != nil {
 				fmt.Println(err)
@@ -45,7 +67,8 @@ func init() {
 				}
 			}
 			ast, err := parser.New(parser.NewParserOptions{
-				Tokens: tokens,
+				Tokens:   tokens,
+				TapeSize: size,
 			}).Parse()
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))
@@ -59,7 +82,9 @@ func init() {
 					return nil
 				}
 			}
-			program, err := emitter.New(emitter.NewEmitterOptions{}).EmitProgram(ast)
+			program, err := emitter.New(emitter.NewEmitterOptions{
+				TapeSize: size,
+			}).EmitProgram(ast)
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))
 				return nil
@@ -74,7 +99,8 @@ func init() {
 			ev := evaluator.New(evaluator.NewEvaluatorOptions{
 				// The print builtins each format their own reading of a tape, so what
 				// arrives here is the finished line and the page only has to show it.
-				Output: ToPlaygroundWriter("output"),
+				Output:   ToPlaygroundWriter("output"),
+				TapeSize: size,
 			})
 
 			// One top-level expression at a time, reporting its value before moving on.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -122,6 +122,12 @@ value already; this one is the exception, and it is the only thing lost.
 
 ## Tooling
 
+- **The playground has nothing testing it.** `cmd/playground` builds only for `js/wasm`, so
+  `go test ./...` never compiles it, and there is no runner for the page itself. What can be
+  tested has been pushed down — reading a tape size out of text lives in `byteutil`, with its
+  own cases — and the rest, the control and the re-run it triggers, is checked by looking at
+  the page. A `go_js_wasm_exec` harness, or a headless page driving Run, would close it.
+
 - The playground workflow runs on push to `main`, which at a version bump happens seconds
   before the tag exists — the deployed page then reports the previous version. Every release
   needs `gh workflow run playground.yml` by hand. Triggering on `push: tags` would fix it.

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -197,6 +197,11 @@ license that can be found in the LICENSE file.
               Bytes per value. Every value in Aurora is a tape this wide, so the width
               decides what a program means: at one byte 255 + 1 is 0, and text only fits
               while it is shorter than a tape.
+
+              The value of each option is what the compiler reads, and it has to stay a bare
+              number: the unit belongs in the label. A value of "32 bytes" is not a size, and
+              the reader falls back to the default rather than failing — so the control would
+              go on looking right while every width compiled at 32.
             -->
             <label id="tape-size-label" for="tape-size" title="Bytes per value: every value is a tape this wide">
               <span id="tape-size-text">Tape</span>

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -201,12 +201,12 @@ license that can be found in the LICENSE file.
             <label id="tape-size-label" for="tape-size" title="Bytes per value: every value is a tape this wide">
               <span id="tape-size-text">Tape</span>
               <select id="tape-size">
-                <option value="1">1</option>
-                <option value="2">2</option>
-                <option value="4">4</option>
-                <option value="8">8</option>
-                <option value="16">16</option>
-                <option value="32" selected>32</option>
+                <option value="1">1 byte</option>
+                <option value="2">2 bytes</option>
+                <option value="4">4 bytes</option>
+                <option value="8">8 bytes</option>
+                <option value="16">16 bytes</option>
+                <option value="32" selected>32 bytes</option>
               </select>
             </label>
             <label id="debug-mode-label" for="debug-mode">

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -115,14 +115,23 @@ license that can be found in the LICENSE file.
       #output > li.error {
         color: #ff0000;
       }
-      #debug-mode-label {
+      #settings {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+      }
+      #debug-mode-label, #tape-size-label {
         display: flex;
         align-items: center;
         gap: 4px;
         padding: 4px;
       }
-      #debug-mode-label:hover {
+      #debug-mode-label:hover, #tape-size-label:hover {
         cursor: pointer;
+      }
+      #tape-size {
+        font: inherit;
+        padding: 2px;
       }
       #divider {
         width: 1px;
@@ -183,10 +192,28 @@ license that can be found in the LICENSE file.
       <div id="actions">
         <div id="info">
           <span id="version"></span>
+          <div id="settings">
+            <!--
+              Bytes per value. Every value in Aurora is a tape this wide, so the width
+              decides what a program means: at one byte 255 + 1 is 0, and text only fits
+              while it is shorter than a tape.
+            -->
+            <label id="tape-size-label" for="tape-size" title="Bytes per value: every value is a tape this wide">
+              <span id="tape-size-text">Tape</span>
+              <select id="tape-size">
+                <option value="1">1</option>
+                <option value="2">2</option>
+                <option value="4">4</option>
+                <option value="8">8</option>
+                <option value="16">16</option>
+                <option value="32" selected>32</option>
+              </select>
+            </label>
             <label id="debug-mode-label" for="debug-mode">
               <input type="checkbox" id="debug-mode">
               <span id="debug-mode-text">Debug</span>
             </label>
+          </div>
         </div>
         <ul id="output"></ul>
         <div id="controls">

--- a/playground/src/main.js
+++ b/playground/src/main.js
@@ -107,9 +107,22 @@ document.addEventListener("DOMContentLoaded", () => {
   mob.observe($output, { childList: true });
 
   const $clear = document.getElementById('clear');
-  $clear.addEventListener('click', () => {
+  const clearOutput = () => {
     $output.innerHTML = '';
     $clear.disabled = true;
+  };
+  $clear.addEventListener('click', clearOutput);
+
+  // The width of a tape decides what a program means — at one byte 255 + 1 is 0 — so what
+  // is on screen stops being the output of the program the moment it changes. Rather than
+  // leave the two disagreeing, the program runs again at the new width.
+  //
+  // The button is disabled until the wasm module is ready, and a click on a disabled button
+  // does nothing, so this cannot run before there is anything to run it with.
+  const $tapeSize = document.getElementById('tape-size');
+  $tapeSize.addEventListener('change', () => {
+    clearOutput();
+    document.getElementById('runner').click();
   });
 
   init();


### PR DESCRIPTION
A control for the tape size in the playground, starting at **32 bytes**, and changing it re-runs the program at once.

## Why it matters here

Every value in Aurora is a tape as wide as the program says, and the playground said nothing — it compiled at the language's default of 8 with no way to ask for another width. That is the one setting someone learning the language most wants to move: it is what makes `255 + 1` answer `0`, and what decides how much text fits in a value.

## Why 32 and not 8

The page opens on `printc "Hello, World!";` — **thirteen bytes, which does not fit an eight-byte tape**. The first thing the playground did was refuse its own example, and being told that as a first experience teaches nothing about tapes.

Worth calling out, because it is a real trade: a program written in the playground at 32 can fail under `aurora run`, which defaults to 8. The control makes the number visible instead of assumed, and the width a project compiles at is now `tape_size` under `[project]` (#30) — so the answer to "why does this fail on my machine" is on screen in both places.

## Hot reload

Changing the width **runs the program again**. The width decides what the program *means*, so what is on screen stops being its output the moment it changes; re-running is what keeps the number shown and the result shown from disagreeing, instead of leaving stale output under a new setting.

The Run button is disabled until the wasm module is ready and a click on a disabled button does nothing, so the re-run cannot fire before there is anything to run.

## What is tested, and what is not

`cmd/playground` builds only for `js/wasm`: `go test ./...` never compiles it, and there is no runner for the page. So the part with actual behaviour was pushed down to where it can be tested — **`byteutil.ParseTapeSize`**, with the success and failure cases a value arriving as text needs: a size, spaces around it, empty, not a number, `0`, `33`, negative, `8px`.

What is left in the wasm entry point is `getElementById` and a fallback. **I checked that by looking at the page in a browser, and that is not a test** — it is recorded in `docs/roadmap.md` as the gap it is, with the two ways to close it (`go_js_wasm_exec`, or a headless page driving Run).

What the look confirmed, for the record:

| width | `printc "Hello, World!";` | `printd 255 + 1;` |
|---|---|---|
| 32 | `Hello, World!` | `256` |
| 8 | `(error) text is 13 bytes but a tape holds 8` | `256` |
| 2 | — | `256` |
| 1 | — | `0` |

Changing the control produced each of those without touching Run.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- Each commit verified in its own `git worktree` with `make check`.
- `playground/dist/` is left alone: it is the release artifact, and the deploy workflow builds it from `src/`.

The CHANGELOG entry joins the **Unreleased** section from #30.