### PR TITLE
The editor colours Aurora and shows what does not compile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,10 @@ All notable changes and release notes for Aurora are documented here.
 
 - **`aurora init`** writes `tape_size` under `[project]`.
 
+- **The playground colours the code and marks what does not compile**, using the same analyses the language server answers editors with — the colours are the lexer's semantic tokens and the marks are the parser's diagnostics. Nothing about the language is written a second time in JavaScript, so a keyword added to Aurora shows up in the page without anyone remembering to add it twice. Changing the tape size re-marks the document, since the width decides what fits.
+
+  The page also registers the language properly now: `monaco.languages.register` sat outside the editor loader's callback, where Monaco does not exist yet, so the language was never registered at all.
+
 - **The playground picks its tape size**, and starts at 32 bytes rather than the language's 8. The page opens on `printc "Hello, World!";` — thirteen bytes, which does not fit an eight-byte tape, so the first thing it used to do was refuse its own example. Changing the width re-runs the program at once: the output on screen is never the output of a different width than the one shown.
 
 ---

--- a/cmd/playground/analysis.go
+++ b/cmd/playground/analysis.go
@@ -1,0 +1,79 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"encoding/json"
+	"syscall/js"
+
+	"github.com/guiferpa/aurora/lsp/textdoc"
+)
+
+// The page is a third client of the analyses the language server answers with, next to the
+// editor plugin and the CLI's own use of the phases: the colours come from the lexer and the
+// marks from the parser.
+//
+// Writing them again in JavaScript — a Monarch grammar, a list of keywords — is the drift
+// this avoids. A keyword added to the language shows up here without anyone remembering to
+// add it twice.
+
+// playgroundFile is the name the page's document goes by. It decides file-scoped rules, and
+// it is deliberately not a test file: assert stays refused here, as it was before the page
+// analysed anything at all.
+const playgroundFile = "playground.ar"
+
+// documentFrom gathers what an analysis reads out of the call from the page. The width comes
+// from the control, which is how the marks agree with what Run does: the same number reaches
+// both.
+func documentFrom(args []js.Value) textdoc.Document {
+	source := ""
+	if len(args) > 0 {
+		source = args[0].String()
+	}
+	return textdoc.Document{
+		Filename: playgroundFile,
+		Source:   source,
+		TapeSize: tapeSize(),
+	}
+}
+
+// marshal answers with JSON, which is what crosses to the page. A value that cannot be
+// encoded answers as nothing rather than as a broken string: an editor that colours nothing
+// is a worse day than one that colours late, and neither is worth stopping the page for.
+func marshal(v any) any {
+	bs, err := json.Marshal(v)
+	if err != nil {
+		return nil
+	}
+	return string(bs)
+}
+
+// analyses registers what the page needs to mark and colour a document.
+//
+// Each takes the source as it stands and answers from scratch: a document being typed is
+// small, and the alternative — telling the page how to describe a change — is a protocol,
+// which is what the editor plugin has and the page does not need.
+func analyses() []js.Func {
+	diagnostics := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return marshal(textdoc.ValidateCode(documentFrom(args)))
+	})
+
+	semanticTokens := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return marshal(textdoc.SemanticTokensFor(documentFrom(args).Source))
+	})
+
+	// The legend names what the numbers in the token data mean, and the page has to be given
+	// it rather than told to keep a copy: the order is the wire format.
+	semanticLegend := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return marshal(map[string]any{
+			"tokenTypes":     textdoc.SemanticTokenTypes,
+			"tokenModifiers": textdoc.SemanticTokenModifiers,
+		})
+	})
+
+	js.Global().Set("auroraDiagnostics", diagnostics)
+	js.Global().Set("auroraSemanticTokens", semanticTokens)
+	js.Global().Set("auroraSemanticLegend", semanticLegend)
+
+	return []js.Func{diagnostics, semanticTokens, semanticLegend}
+}

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -129,6 +129,10 @@ func main() {
 	evalrunner := eval()
 	defer evalrunner.Release()
 
+	for _, analysis := range analyses() {
+		defer analysis.Release()
+	}
+
 	document.Call("getElementById", "version").Set("innerText", fmt.Sprintf("Aurora version: %s", version.VERSION))
 	document.Call("getElementById", "runner").Call("addEventListener", "click", evalrunner)
 

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -155,6 +155,11 @@ license that can be found in the LICENSE file.
     <script>
       require.config({ paths: { vs: "https://cdn.jsdelivr.net/npm/monaco-editor@0.52.0/min/vs" }});
       require(["vs/editor/editor.main"], function () {
+        // Registering the language has to happen once the loader has answered, and before
+        // anything is configured for it: it used to sit after this call, where monaco does
+        // not exist yet, so nothing was ever registered at all.
+        monaco.languages.register({ id: "aurora" });
+
         window.editor = monaco.editor.create(document.getElementById('editor'), {
           value: "printc \"Hello, World!\";",
           language: "aurora",
@@ -173,9 +178,11 @@ license that can be found in the LICENSE file.
         if ($loading) {
             $loading.classList.add('hidden');
         }
-      });
 
-      monaco.languages.register({ id: "aurora" });
+        // Monaco arrives through its own loader, so the modules below cannot know when the
+        // editor exists. This is how they are told.
+        document.dispatchEvent(new CustomEvent('editor-ready'));
+      });
     </script>
     <script src="wasm_exec.js"></script>
     <script type="module" src="resize.js"></script>

--- a/playground/src/language.js
+++ b/playground/src/language.js
@@ -1,0 +1,119 @@
+// What the editor knows about Aurora comes from the compiler, not from a grammar written
+// here a second time: the colours are the lexer's semantic tokens and the marks are the
+// parser's diagnostics, the same two the language server answers editors with.
+//
+// The wasm module publishes them on the window. Until it is up they are simply absent, and
+// every call below answers with nothing rather than waiting — the document is coloured on
+// the next keystroke instead.
+
+const LANGUAGE = 'aurora';
+const OWNER = 'aurora';
+
+// How long to sit on a keystroke before analysing. Long enough that typing a word is one
+// analysis and not five, short enough to feel like the editor is keeping up.
+const SETTLE_MS = 150;
+
+const MARKER_ERROR = 8; // monaco.MarkerSeverity.Error
+
+// call runs one of the analyses the wasm module published, and answers with null while it is
+// not there yet or when it could not answer.
+function call(name, ...args) {
+  const fn = window[name];
+  if (typeof fn !== 'function') return null;
+  const answer = fn(...args);
+  if (typeof answer !== 'string') return null;
+  try {
+    return JSON.parse(answer);
+  } catch (err) {
+    console.error(`aurora: ${name} answered with something that is not JSON`, err);
+    return null;
+  }
+}
+
+// Diagnostics count lines and characters from zero, and Monaco counts both from one.
+function toMarker(diagnostic) {
+  const { start, end } = diagnostic.range;
+  return {
+    startLineNumber: start.line + 1,
+    startColumn: start.character + 1,
+    endLineNumber: end.line + 1,
+    endColumn: end.character + 1,
+    message: diagnostic.message,
+    severity: MARKER_ERROR,
+    source: diagnostic.source,
+  };
+}
+
+function markDocument(monaco, model) {
+  // The width is not passed: the analyses read the control themselves, the same one Run
+  // reads, so a mark and a result cannot come from two different widths.
+  const diagnostics = call('auroraDiagnostics', model.getValue());
+  if (diagnostics === null) return;
+  monaco.editor.setModelMarkers(model, OWNER, diagnostics.map(toMarker));
+}
+
+// The legend names what the numbers in the token data mean, and it is asked for rather than
+// kept here: its order is the wire format, and a copy would be one more thing to keep in
+// step with the lexer.
+function semanticProvider(monaco, legend) {
+  return {
+    getLegend: () => legend,
+    provideDocumentSemanticTokens: (model) => {
+      const data = call('auroraSemanticTokens', model.getValue());
+      if (data === null) return null;
+      return { data: new Uint32Array(data) };
+    },
+    releaseDocumentSemanticTokens: () => {},
+  };
+}
+
+// What the editor needs to be told about the shape of the language: a comment runs to the
+// end of the line, and these brackets come in pairs. It is configuration rather than
+// knowledge — Monaco closes a brace for you, and the compiler has nothing to say about that.
+function configureLanguage(monaco) {
+  monaco.languages.setLanguageConfiguration(LANGUAGE, {
+    comments: { lineComment: '#-' },
+    brackets: [['{', '}'], ['(', ')'], ['[', ']']],
+    autoClosingPairs: [
+      { open: '{', close: '}' },
+      { open: '(', close: ')' },
+      { open: '[', close: ']' },
+      { open: '"', close: '"' },
+    ],
+    surroundingPairs: [
+      { open: '{', close: '}' },
+      { open: '(', close: ')' },
+      { open: '[', close: ']' },
+      { open: '"', close: '"' },
+    ],
+  });
+}
+
+export function registerAuroraLanguage(monaco, editor) {
+  configureLanguage(monaco);
+
+  // Semantic colouring is off until it is asked for. A theme can ask for it and this one
+  // does not — the editor is on the stock dark theme — so the editor is told directly. The
+  // token types are named after what a theme already colours (keyword, number, string), so
+  // vs-dark knows what to do with them without a rule of our own.
+  editor.updateOptions({ 'semanticHighlighting.enabled': true });
+
+  const legend = call('auroraSemanticLegend') || { tokenTypes: [], tokenModifiers: [] };
+  monaco.languages.registerDocumentSemanticTokensProvider(LANGUAGE, semanticProvider(monaco, legend));
+
+  const model = editor.getModel();
+  let settling = null;
+  const mark = () => {
+    clearTimeout(settling);
+    settling = setTimeout(() => markDocument(monaco, model), SETTLE_MS);
+  };
+
+  editor.onDidChangeModelContent(mark);
+
+  // The width decides what is an error — text of nine bytes fits a sixteen-byte tape and not
+  // an eight-byte one — so the marks are stale the moment it changes.
+  const control = document.getElementById('tape-size');
+  if (control) control.addEventListener('change', mark);
+
+  mark();
+}

--- a/playground/src/main.js
+++ b/playground/src/main.js
@@ -1,3 +1,5 @@
+import { registerAuroraLanguage } from './language.js';
+
 function nothing(result) {
   return "<nothing>";
 }
@@ -25,10 +27,23 @@ async function init() {
       go.importObject,
     );
     document.getElementById("runner").disabled = false;
-    await go.run(instance);
+    // go.run never resolves: the Go program blocks so that what it published stays callable.
+    // It does run main up to that block before returning, which is when the analyses and the
+    // runner appear.
+    go.run(instance).catch((err) => console.error(err));
   } catch (err) {
     console.error(err);
   }
+}
+
+// whenEditorReady runs fn once the editor exists, whichever of the two finished loading
+// first — the module and the editor's loader race, and either order is fine.
+function whenEditorReady(fn) {
+  if (window.editor) {
+    fn();
+    return;
+  }
+  document.addEventListener('editor-ready', fn, { once: true });
 }
 
 function toDecimal(result) {
@@ -125,5 +140,12 @@ document.addEventListener("DOMContentLoaded", () => {
     document.getElementById('runner').click();
   });
 
-  init();
+  const running = init();
+
+  // The editor is told what the language is only once both halves are up: the colours and
+  // the marks come from the wasm module, and the editor is what they are attached to.
+  whenEditorReady(async () => {
+    await running;
+    registerAuroraLanguage(window.monaco, window.editor);
+  });
 });


### PR DESCRIPTION
Second of three. The playground stops being a text box with a Run button: the same analyses the language server answers editors with now reach the page.

## What it gives whoever opens the page

- **Colours from the lexer.** Comments, keywords, numbers, text and identifiers, each in its own colour.
- **Errors where they are.** The parser's message, underlined at the token it points at, 150ms after you stop typing.
- **Both redone when the tape size changes**, because the width decides what fits — a mark from another width is stale.

## No second copy of the language

The usual way to colour a language in Monaco is a Monarch grammar and a keyword list, written in JavaScript. That is the same knowledge the lexer already has, written a second time, drifting from the first the day someone adds a keyword.

So the wasm module publishes what `lsp/textdoc` already answers — diagnostics, semantic tokens, and the legend that says what the token numbers mean — and the page asks. **The LSP's semantic token encoding is byte-for-byte what Monaco's provider expects**, which is what makes this a wiring job rather than a translation.

The document is called `playground.ar`, which keeps `assert` refused there exactly as it was. The width comes from the control, the same one Run reads, so a mark and a result cannot disagree about how wide a value is.

## Two things found on the way

**The language was never registered.** `monaco.languages.register({ id: "aurora" })` sat *after* the loader's callback, where `monaco` does not exist yet. Configuring the language failed with `Cannot set configuration for unknown language aurora`, which is how it surfaced. It moves inside the callback, before the editor is created.

**Semantic colouring stays off until asked for.** A theme can ask for it; the stock dark theme this page uses does not. Setting `semanticHighlighting.enabled` on the editor is the switch — I had a custom theme doing it and dropped it, since the token types are named after what a theme already colours (`keyword`, `number`, `string`), so `vs-dark` knows what to do with them without a rule of our own.

## Cost

Measured before writing any of it: **+73 KB gzipped** (1.11 MB → 1.18 MB of what the browser downloads), for the whole of `lsp/textdoc` linked in.

## Verification, and what is still missing

`make check` is green, and the Go half is covered by the tests `lsp/textdoc` already has.

The JS half was **checked by looking at the page** — again — because `cmd/playground` builds only for `js/wasm` and the page has no runner. `docs/roadmap.md` already records that gap. Given this is the second PR to lean on it, I would rather build the harness before the third: **say the word and the next PR is a headless page driving Run and the analyses, with hover and completion landing on top of it already covered.**

What the look confirmed:

| | |
|---|---|
| `#- greets` / `struct` / `30` / `"hi"` | each in its own colour |
| `ident total = 30 +;` | underlined at column 19, `unexpected token ;` |
| tape size 32 → 8 with 24 bytes of text | marked without touching Run |

`playground/dist/` is left alone: it is the release artifact, and the deploy builds it from `src/`.