### PR TITLE
The editor explains a word and completes the next one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ All notable changes and release notes for Aurora are documented here.
 
 - **`aurora init`** writes `tape_size` under `[project]`.
 
+- **The playground answers what a word is and what can follow it.** Hover shows what the compiler knows — a keyword's description, an identifier's value, which tape of a run a field reads — and completion offers the keywords as snippets, the structs declared in the document, and, right after a dot, the fields of that struct and nothing else. The same answers the language server gives an editor, in the page.
+
 - **The playground colours the code and marks what does not compile**, using the same analyses the language server answers editors with — the colours are the lexer's semantic tokens and the marks are the parser's diagnostics. Nothing about the language is written a second time in JavaScript, so a keyword added to Aurora shows up in the page without anyone remembering to add it twice. Changing the tape size re-marks the document, since the width decides what fits.
 
   The page also registers the language properly now: `monaco.languages.register` sat outside the editor loader's callback, where Monaco does not exist yet, so the language was never registered at all.

--- a/cmd/playground/analysis.go
+++ b/cmd/playground/analysis.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"syscall/js"
 
+	"github.com/guiferpa/aurora/lsp"
 	"github.com/guiferpa/aurora/lsp/textdoc"
 )
 
@@ -37,6 +38,20 @@ func documentFrom(args []js.Value) textdoc.Document {
 	}
 }
 
+// positionFrom reads the place in the document a call is asking about. Both counts start at
+// zero here, as they do in the protocol; the page is what converts, since it is the editor
+// that counts from one.
+func positionFrom(args []js.Value) lsp.Position {
+	pos := lsp.Position{}
+	if len(args) > 1 {
+		pos.Line = args[1].Int()
+	}
+	if len(args) > 2 {
+		pos.Character = args[2].Int()
+	}
+	return pos
+}
+
 // marshal answers with JSON, which is what crosses to the page. A value that cannot be
 // encoded answers as nothing rather than as a broken string: an editor that colours nothing
 // is a worse day than one that colours late, and neither is worth stopping the page for.
@@ -62,6 +77,16 @@ func analyses() []js.Func {
 		return marshal(textdoc.SemanticTokensFor(documentFrom(args).Source))
 	})
 
+	hover := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return marshal(textdoc.HoverInfo(documentFrom(args), positionFrom(args)))
+	})
+
+	// Snippets are always on: the page is one editor and it is known to expand them, where a
+	// language server has to ask because it does not know who is listening.
+	completions := js.FuncOf(func(this js.Value, args []js.Value) any {
+		return marshal(textdoc.CompletionItemsFor(documentFrom(args), positionFrom(args), true))
+	})
+
 	// The legend names what the numbers in the token data mean, and the page has to be given
 	// it rather than told to keep a copy: the order is the wire format.
 	semanticLegend := js.FuncOf(func(this js.Value, args []js.Value) any {
@@ -74,6 +99,8 @@ func analyses() []js.Func {
 	js.Global().Set("auroraDiagnostics", diagnostics)
 	js.Global().Set("auroraSemanticTokens", semanticTokens)
 	js.Global().Set("auroraSemanticLegend", semanticLegend)
+	js.Global().Set("auroraHover", hover)
+	js.Global().Set("auroraCompletions", completions)
 
-	return []js.Func{diagnostics, semanticTokens, semanticLegend}
+	return []js.Func{diagnostics, semanticTokens, semanticLegend, hover, completions}
 }

--- a/playground/src/index.html
+++ b/playground/src/index.html
@@ -180,8 +180,11 @@ license that can be found in the LICENSE file.
         }
 
         // Monaco arrives through its own loader, so the modules below cannot know when the
-        // editor exists. This is how they are told.
-        document.dispatchEvent(new CustomEvent('editor-ready'));
+        // editor exists. This is how they are told — and both are handed over rather than
+        // left to be read off the window, which is not set at the same moment.
+        document.dispatchEvent(new CustomEvent('editor-ready', {
+          detail: { monaco: monaco, editor: window.editor },
+        }));
       });
     </script>
     <script src="wasm_exec.js"></script>

--- a/playground/src/language.js
+++ b/playground/src/language.js
@@ -30,6 +30,12 @@ function call(name, ...args) {
   }
 }
 
+// The protocol counts lines and characters from zero; Monaco counts lines and columns from
+// one. Everything crossing between the two goes through here.
+function toProtocol(position) {
+  return [position.lineNumber - 1, position.column - 1];
+}
+
 // Diagnostics count lines and characters from zero, and Monaco counts both from one.
 function toMarker(diagnostic) {
   const { start, end } = diagnostic.range;
@@ -52,6 +58,40 @@ function markDocument(monaco, model) {
   monaco.editor.setModelMarkers(model, OWNER, diagnostics.map(toMarker));
 }
 
+// What the compiler calls a completion and what Monaco calls one are the same list in a
+// different order, so the kinds are matched by name rather than by number.
+//
+// A kind with no entry is left to Monaco's default, which is a plain text suggestion: an
+// item is worth offering even when its icon is not the right one.
+const KINDS = {
+  5: 'Field',
+  6: 'Variable',
+  14: 'Keyword',
+  22: 'Struct',
+};
+
+const SNIPPET_FORMAT = 2;
+
+function toSuggestion(monaco, item, range) {
+  const kind = monaco.languages.CompletionItemKind[KINDS[item.kind]];
+  const suggestion = {
+    label: item.label,
+    detail: item.detail,
+    documentation: item.documentation,
+    kind: kind === undefined ? monaco.languages.CompletionItemKind.Text : kind,
+    insertText: item.insertText || item.label,
+    range,
+  };
+  // Monaco names this enum in the singular and its own documentation names it in the plural,
+  // so take whichever this build has. Reading the wrong one is not a missing snippet: it
+  // throws inside the provider and the suggestions never appear at all.
+  const rules = monaco.languages.CompletionItemInsertTextRule || monaco.languages.CompletionItemInsertTextRules;
+  if (item.insertTextFormat === SNIPPET_FORMAT && rules) {
+    suggestion.insertTextRules = rules.InsertAsSnippet;
+  }
+  return suggestion;
+}
+
 // The legend names what the numbers in the token data mean, and it is asked for rather than
 // kept here: its order is the wire format, and a copy would be one more thing to keep in
 // step with the lexer.
@@ -64,6 +104,42 @@ function semanticProvider(monaco, legend) {
       return { data: new Uint32Array(data) };
     },
     releaseDocumentSemanticTokens: () => {},
+  };
+}
+
+// Hover answers with lines, and Monaco renders markdown, where a single newline is not a
+// break. Each line becomes a paragraph of its own so it reads as it was written.
+function hoverProvider() {
+  return {
+    provideHover: (model, position) => {
+      const info = call('auroraHover', model.getValue(), ...toProtocol(position));
+      if (!info) return null;
+      return { contents: info.split('\n').map((value) => ({ value })) };
+    },
+  };
+}
+
+// What is offered depends on what sits in front of the cursor — right after a dot it is the
+// fields of that struct and nothing else — which is why the position goes across too.
+function completionProvider(monaco) {
+  return {
+    triggerCharacters: ['.'],
+    provideCompletionItems: (model, position) => {
+      const items = call('auroraCompletions', model.getValue(), ...toProtocol(position));
+      if (items === null) return { suggestions: [] };
+
+      // The word being typed is what the suggestion replaces. Without it Monaco inserts at
+      // the cursor and the half already typed stays where it is.
+      const word = model.getWordUntilPosition(position);
+      const range = {
+        startLineNumber: position.lineNumber,
+        endLineNumber: position.lineNumber,
+        startColumn: word.startColumn,
+        endColumn: word.endColumn,
+      };
+
+      return { suggestions: items.map((item) => toSuggestion(monaco, item, range)) };
+    },
   };
 }
 
@@ -92,14 +168,22 @@ function configureLanguage(monaco) {
 export function registerAuroraLanguage(monaco, editor) {
   configureLanguage(monaco);
 
-  // Semantic colouring is off until it is asked for. A theme can ask for it and this one
-  // does not — the editor is on the stock dark theme — so the editor is told directly. The
-  // token types are named after what a theme already colours (keyword, number, string), so
-  // vs-dark knows what to do with them without a rule of our own.
-  editor.updateOptions({ 'semanticHighlighting.enabled': true });
+  editor.updateOptions({
+    // Semantic colouring is off until it is asked for. A theme can ask for it and this one
+    // does not — the editor is on the stock dark theme — so the editor is told directly. The
+    // token types are named after what a theme already colours (keyword, number, string),
+    // so vs-dark knows what to do with them without a rule of our own.
+    'semanticHighlighting.enabled': true,
+    // Otherwise Monaco offers every word already in the document, next to what the compiler
+    // answered: after a dot, where the fields of a struct are the only thing that can
+    // follow, it would still offer "struct" and "ident" because they appear further up.
+    wordBasedSuggestions: 'off',
+  });
 
   const legend = call('auroraSemanticLegend') || { tokenTypes: [], tokenModifiers: [] };
   monaco.languages.registerDocumentSemanticTokensProvider(LANGUAGE, semanticProvider(monaco, legend));
+  monaco.languages.registerHoverProvider(LANGUAGE, hoverProvider());
+  monaco.languages.registerCompletionItemProvider(LANGUAGE, completionProvider(monaco));
 
   const model = editor.getModel();
   let settling = null;

--- a/playground/src/main.js
+++ b/playground/src/main.js
@@ -36,14 +36,17 @@ async function init() {
   }
 }
 
-// whenEditorReady runs fn once the editor exists, whichever of the two finished loading
-// first — the module and the editor's loader race, and either order is fine.
+// whenEditorReady runs fn with the editor and the monaco it belongs to, whichever of the two
+// finished loading first: this module and the editor's loader race, and either order is fine.
+//
+// Both are handed over by the event rather than read off the window, because the loader sets
+// the global at a moment of its own — reading it here found it undefined about as often as
+// not.
 function whenEditorReady(fn) {
-  if (window.editor) {
-    fn();
-    return;
+  document.addEventListener('editor-ready', (event) => fn(event.detail), { once: true });
+  if (window.editor && window.monaco) {
+    fn({ monaco: window.monaco, editor: window.editor });
   }
-  document.addEventListener('editor-ready', fn, { once: true });
 }
 
 function toDecimal(result) {
@@ -144,8 +147,11 @@ document.addEventListener("DOMContentLoaded", () => {
 
   // The editor is told what the language is only once both halves are up: the colours and
   // the marks come from the wasm module, and the editor is what they are attached to.
-  whenEditorReady(async () => {
+  let registered = false;
+  whenEditorReady(async ({ monaco, editor }) => {
     await running;
-    registerAuroraLanguage(window.monaco, window.editor);
+    if (registered) return; // the event and the check above can both fire
+    registered = true;
+    registerAuroraLanguage(monaco, editor);
   });
 });


### PR DESCRIPTION
Third and last of the three. Hover and completion in the playground, from the compiler rather than from a list of keywords kept in JavaScript.

## What it gives whoever opens the page

- **Hover** answers what the compiler knows: a keyword's description, an identifier's value, and — over a field — which tape of the run it reads.
- **Completion** offers the keywords as snippets, the structs declared in the document, and, right after a dot, the fields of that struct **and nothing else**.

Both are the same answers `aurorals` gives an editor. Nothing about the language is listed a second time here.

## Watching it work found three things

**Monaco was offering every word in the document** alongside what the compiler answered. After a dot — where the fields of a struct are the only thing that can follow — it still offered `struct` and `ident`, because they appear further up the file. Word-based suggestions are off for this editor now.

**The enum that marks an insert as a snippet is named in the singular by this build of Monaco** (`CompletionItemInsertTextRule`) and in the plural by its own documentation. Reading the wrong one does not quietly lose the snippet: it throws inside the provider, and then *no suggestion appears at all*. Whichever the build has is used.

**The editor and its `monaco` are handed over by the event** that says the editor is ready, rather than read off the window. The loader sets that global at a moment of its own, and reading it there found it undefined about as often as not — which is a race the previous PR was quietly winning.

## Verification

`make check` green; the Go half is covered by the tests `lsp/textdoc` already has, and the kinds and snippet formats it answers with are pinned there.

The page was **checked by looking**, as agreed — the harness stays on the roadmap. What the look confirmed:

| | |
|---|---|
| `p.` after `struct Point { x, y }` | exactly `x` and `y`, with the field icon and `field 0, one tape wide` |
| hover over `p.x` | `field x of struct Point` / `reads tape 0 of the run` |
| hover over `total` | `identifier: total` / `value: number` |
| typing `def` → accept | expands to `defer {` / newline / `}` with the cursor inside |


`playground/dist/` is left alone: it is the release artifact, and the deploy builds it from `src/`.
