### PR TITLE
An RFC for serving HTTP with Aurora

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,7 +51,9 @@ without it.
 - **`.claude/agents/aurora-internals.md`** — how the compiler actually works, verified
   against the code rather than the docs.
 - **`docs/`** for the end user, **`docs/contributing/`** for contributors (English),
-  **`rfcs/`** for proposals and debt (Portuguese).
+  **`rfcs/`** for proposals and debt (Portuguese). A document still being discussed says so
+  at the top — `Status: proposal` or `Estado: proposta` — which is what keeps the suite from
+  running the examples of a language that does not exist yet.
 - **`docs/roadmap.md`** is the direction: anything the user can perceive gets an entry there.
 
 Conversation is usually pt-BR; code, comments and `docs/` stay in English.

--- a/internal/cli/docs_test.go
+++ b/internal/cli/docs_test.go
@@ -97,6 +97,12 @@ func documentationFiles(t *testing.T) []string {
 }
 
 // isProposal answers whether a document declares itself one, which it does at the top.
+//
+// In either language: what is written for the end user is in English and lives in docs/, and
+// what is still being discussed is in Portuguese and lives in rfcs/. A marker that only
+// spoke English would make every RFC look like documentation of a language that exists.
+//
+// The emphasis is stripped first, so a header reads the same whether or not it is bold.
 func isProposal(t *testing.T, path string) bool {
 	t.Helper()
 
@@ -108,7 +114,9 @@ func isProposal(t *testing.T, path string) bool {
 	if len(head) > 800 {
 		head = head[:800]
 	}
-	return strings.Contains(head, "Status: proposal")
+	head = strings.ReplaceAll(head, "*", "")
+
+	return strings.Contains(head, "Status: proposal") || strings.Contains(head, "Estado: proposta")
 }
 
 // runSnippet runs one standalone block and checks it did what it said it would.
@@ -250,5 +258,37 @@ func TestNoDocumentWithAuroraEscapesTheCheck(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("walking the repository: %v", err)
+	}
+}
+
+// A document that says it is a proposal is skipped, and it says so in the language it is
+// written in: docs/ is English and rfcs/ is Portuguese. Getting this wrong is quiet in the
+// worst way — the suite would run the examples of a language that does not exist yet, or
+// stop running the examples of one that does.
+func TestProposalIsRecognisedInEitherLanguage(t *testing.T) {
+	cases := []struct {
+		name string
+		head string
+		want bool
+	}{
+		{name: "english", head: "# Something\n\nStatus: proposal\n", want: true},
+		{name: "english in bold", head: "# Something\n\n**Status:** proposal · 2026-08-16\n", want: true},
+		{name: "portuguese", head: "# Alguma coisa\n\nEstado: proposta\n", want: true},
+		{name: "portuguese in bold", head: "# Alguma coisa\n\n**Estado:** proposta · 2026-08-16\n", want: true},
+		{name: "a document that claims nothing", head: "# Grammar\n\nHow Aurora reads.\n", want: false},
+		{name: "the word further down the page", head: "# Grammar\n\n" + strings.Repeat("x", 900) + "\nStatus: proposal\n", want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "doc.md")
+			if err := os.WriteFile(path, []byte(tc.head), 0o644); err != nil {
+				t.Fatalf("writing the document: %v", err)
+			}
+
+			if got := isProposal(t, path); got != tc.want {
+				t.Errorf("isProposal = %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,23 @@
+# RFCs
+
+Propostas, dívidas e discussões em aberto sobre a Aurora — **em português**, que é a língua
+em que o projeto é discutido. O que já está decidido e implementado mora em `docs/`, em
+inglês; aqui fica o que ainda está sendo pensado.
+
+Uma RFC não é um roadmap. O [roadmap](../docs/roadmap.md) diz **o que** falta e o que isso
+custa; uma RFC discute **como** fazer uma coisa específica, quais são as alternativas e por
+que uma foi escolhida. Uma proposta aceita e implementada vira documentação em `docs/` e o
+arquivo daqui é apagado — o git guarda o histórico.
+
+Toda RFC abre dizendo em que estado está:
+
+| Estado | Significa |
+|---|---|
+| **proposta** | escrita, ainda não decidida |
+| **aceita** | decidida, ainda não implementada |
+| **implementada** | virou código; o arquivo sai daqui na sequência |
+| **recusada** | decidida contra, e o porquê fica registrado |
+
+| Arquivo | Assunto | Estado |
+|---|---|---|
+| [http_server.md](http_server.md) | Servir HTTP com programas escritos em Aurora | proposta |

--- a/rfcs/http_server.md
+++ b/rfcs/http_server.md
@@ -1,0 +1,159 @@
+# Um servidor HTTP com Aurora
+
+**Estado:** proposta · **Data:** 2026-08-16
+
+Tudo que está descrito aqui como "hoje" foi conferido no código, não lembrado.
+
+---
+
+## Duas perguntas diferentes
+
+"Construir um servidor HTTP com Aurora" se parte em duas, e elas têm respostas opostas:
+
+**(A) Aurora como a linguagem do handler.** O host abre o socket, fala HTTP, e aplica um
+escopo Aurora a cada requisição. O programa é uma função de requisição para resposta.
+
+**(B) Aurora escrevendo o servidor.** O programa abre o socket, lê bytes da rede, parseia o
+protocolo e escreve a resposta — tudo em Aurora.
+
+**A proposta é (A)**, e a razão não é de esforço, é de arquitetura.
+
+(B) exige chamadas de sistema dentro do evaluator, o que quebra duas premissas de uma vez: um
+pacote vital deixa de ser puro (recebe valores e devolve valores) e o erro deixa de se
+resolver no host. Também exigiria tudo que (A) exige — valores maiores que uma fita, índice
+calculado em runtime, laços — e ainda mais. E o backend EVM, que está parado, ficaria ainda
+mais distante: `listen` não tem significado numa cadeia.
+
+(A) usa a premissa a favor em vez de contra ela. A linguagem continua pura; quem tem socket,
+timeout, endereço e erro de rede é o host, que é exatamente o lugar onde essas coisas já
+moram no projeto.
+
+---
+
+## O que a linguagem tem hoje
+
+| O que | Estado hoje | Onde |
+|---|---|---|
+| Valores entrando no programa | um vetor de palavras de 32 bytes, **estreitadas para uma fita cada** | `evaluator/environ/environ.go`, `internal/cli/args.go` |
+| Lendo esses valores | `feed(n)`, com o índice dando a volta no tamanho do vetor | `evaluator/builtin/functions.go` |
+| Valores saindo | o que `printb`/`printc`/`printd` escrevem, num `io.Writer` que o host escolhe | `evaluator/evaluator.go` |
+| O valor de cada expressão | o host recebe, por rótulo, o que cada expressão de topo deixou | `emitter.Program.Expressions` |
+| Escopo aplicável a valores | `defer { … }` produz um valor; `nome(a, b)` aplica | — |
+| Recursão | funciona | `examples/recursion.ar` |
+| Texto | é uma fita, então cabe **no máximo `tape_size` bytes** (32 no teto) | `parser/parser.go:153` |
+| Índice de `head`/`tail`/campo | é **imediato**: resolvido em tempo de compilação | `emitter/emitter.go:266` |
+| Estado mutável | não existe | `rfcs/state_management.md` (a escrever) |
+| Laço | não existe; o que existe é recursão | — |
+
+Duas dessas linhas são a história inteira desta RFC: **entrada e saída já passam pelo host**,
+e **nenhum valor pode ser maior que 32 bytes**.
+
+---
+
+## O primeiro passo já é possível hoje
+
+Isto é o que torna a proposta concreta em vez de uma lista de desejos. Com o que existe:
+
+- o host compila o programa **uma vez**;
+- por requisição, cria um evaluator novo com o método e o caminho como valores aplicados;
+- o corpo da resposta é **o que o programa imprimiu**, capturado pelo `io.Writer` que o host
+  já escolhe;
+- o status é **o valor da última expressão**, que o host já sabe ler — é assim que o REPL e o
+  playground mostram o valor de uma linha.
+
+```aurora
+#- Um handler. feed(0) é o método, feed(1) é o caminho.
+ident method = feed(0);
+
+if method equals "GET" {
+  printc "hello";
+  200;
+} else {
+  printc "no";
+  405;
+};
+```
+
+```sh
+aurora serve handler.ar --port 8080
+```
+
+Nenhuma palavra nova na linguagem, nenhum opcode novo, nenhuma mudança no emitter. É um host
+novo — irmão de `aurora run` — e mais nada.
+
+**O que essa fase honestamente não faz:** caminho maior que 32 bytes, corpo de requisição,
+cabeçalhos, resposta maior que o que se consegue imprimir por partes, e qualquer coisa que
+dependa de olhar dentro de um texto.
+
+---
+
+## As paredes, na ordem em que aparecem
+
+**1. Um valor maior que uma fita.** Uma requisição real tem quilobytes; `"Guilherme"` já não
+cabe em oito. Enquanto um valor for uma corrida fixa de bytes, o programa não segura uma URL
+longa, quanto mais um corpo. É o item maior do [roadmap](../docs/roadmap.md) e é o que
+destrava todo o resto.
+
+**2. Ler uma posição decidida em runtime.** `head t 2` compila e `head t i` não — o índice
+entra na instrução como imediato. Sem isso não existe parsear: nem separar caminho de query,
+nem achar o `:` de um cabeçalho, nem percorrer nada.
+
+**3. Construir um valor em runtime.** Não há concatenação. A resposta hoje só existe porque é
+impressa em pedaços; montar uma, guardá-la, medi-la e só então escrevê-la exige juntar.
+
+**4. Estado entre requisições.** Um contador, uma sessão, uma tabela de rotas. Hoje não há
+estado mutável nenhum. Pode ser resolvido funcionalmente — o host guarda o valor e o aplica
+na requisição seguinte —, e isso é uma decisão de projeto que vale escrever antes de precisar.
+
+**5. Concorrência.** Uma linguagem sem estado mutável é trivialmente paralela: um evaluator
+por requisição, nada compartilhado. Isso é uma vantagem rara e vale explicitar como decisão,
+não descobrir por acidente.
+
+As paredes 1, 2 e 3 são **a mesma obra** — é o que o roadmap já diz — e um servidor é a melhor
+razão que a linguagem já teve para encará-la: uma meta que o usuário percebe, contra a qual
+testar cada pedaço.
+
+---
+
+## Fases
+
+| Fase | O que entrega | O que exige da linguagem |
+|---|---|---|
+| **1** | `aurora serve`: método e caminho aplicados ao programa, status pelo valor da última expressão, corpo pelo que ele imprime | **nada** |
+| **2** | corpo de requisição e resposta montada como valor | valor maior que uma fita (parede 1) |
+| **3** | parsear caminho, query e cabeçalhos **em Aurora** | índice calculado (2) e concatenação (3) |
+| **4** | contador, sessão, rota declarada em dado | estado (4) |
+| **5** | um framework de verdade | nada disso; é biblioteca, e biblioteca precisa de módulos |
+
+A fase 1 é a que prova o contrato. As outras são a linguagem crescendo, com o servidor como
+critério de aceitação.
+
+---
+
+## Perguntas em aberto
+
+Nenhuma delas bloqueia a fase 1, mas todas mudam o desenho se decididas tarde:
+
+1. **Truncar por onde?** Um valor que entra é estreitado para uma fita mantendo os **últimos**
+   bytes (`byteutil.PaddingTape`). Para um número é o certo; para um caminho, `/usuarios/42`
+   virando `os/42` é pior que perder o fim. Vale decidir se entrada de texto trunca pela cauda.
+
+2. **Status por valor ou por builtin?** Usar o valor da última expressão é elegante e não custa
+   nada, mas amarra "o que a expressão respondeu" a "o que o HTTP devolve". A alternativa é um
+   builtin explícito, que é mais claro e é mais uma palavra na linguagem.
+
+3. **Onde mora `serve`?** Mais um comando do `aurora`, ou um binário próprio? Um comando é mais
+   simples; um binário separado mantém o CLI sobre compilar e rodar.
+
+4. **O que acontece quando o programa falha?** Proposta: 500 para o cliente, erro no log do
+   host, servidor de pé — erro se resolve no host, e uma requisição ruim não derruba as outras.
+
+5. **Isto some da EVM?** `serve` não tem significado numa cadeia. Vale dizer em voz alta que
+   este é um alvo do evaluator, como o REPL, e que não cria dívida no backend.
+
+---
+
+## O que fica fora, de propósito
+
+TLS, keep-alive, streaming, upload, WebSocket, roteamento com sintaxe própria, middleware.
+Nada disso é interessante enquanto um valor não puder ser maior que 32 bytes.


### PR DESCRIPTION
A plan for building an HTTP server with Aurora — and the first document in `rfcs/`, which until now was a rule with no folder.

## What the RFC argues

The question splits in two, and the halves have opposite answers:

- **Aurora as the language of the handler** — the host owns the socket and speaks HTTP, and applies an Aurora scope per request.
- **Aurora writing the server itself** — opening the socket, reading bytes, parsing the protocol, all in Aurora.

It argues for the first, **on architecture rather than effort**: the second needs system calls inside the evaluator, which ends both the purity of a vital package and errors being resolved in the host — and it would need everything the first needs, plus loops and I/O. The first turns the premises into an advantage: the program is a function from request to response, and whoever owns timeouts and network errors is the host, where those things already live.

## The part that makes it a plan

**Phase one needs nothing from the language.** Checked against the code, not remembered:

- values already enter a program through the host (`internal/cli/args.go` → `environ`);
- what a program prints already goes to a writer the host chooses;
- the host already reads the value of every top-level expression — that is how the REPL and the playground show the value of a line.

So a handler that answers a status and prints a body is **a new host and nothing else**: no keyword, no opcode, no change to the emitter.

What that phase cannot do — a path longer than 32 bytes, a request body, headers, looking inside text — is exactly the roadmap's largest item. The RFC then orders the walls behind it (a value larger than a tape, an index decided at runtime, building a value, state, concurrency) and says which phase each one unblocks.

Five open questions are listed, none of which blocks phase one but all of which get more expensive to answer late — including one worth deciding soon: a value entering a program is narrowed to a tape keeping its **last** bytes, which is right for a number and wrong for a path (`/usuarios/42` → `os/42`).

## One test change came with it

The suite skips a document that declares itself a proposal — it describes a language that does not exist yet, so its examples are meant to be rejected. The marker only spoke English, and `rfcs/` is Portuguese by rule, so an RFC with an Aurora block in it would have been run as if it were documentation.

It reads either language now, and reads through the emphasis. Verified by breaking it: an RFC with an Aurora block and no marker is reported by the walk that exists to catch exactly that.

`CLAUDE.md` records the marker so it is not folklore.