### PR TITLE
The chain and the evaluator answer the same thing

### DIFF
--- a/.claude/agents/aurora-standards.md
+++ b/.claude/agents/aurora-standards.md
@@ -14,9 +14,11 @@ Answer in the language the user writes in (the maintainer usually writes pt-BR).
 
 ## What matters now
 
-The language proves itself in the **evaluator** and in the **REPL**. The EVM backend is **parked on purpose** until the behaviour there settles — only then does it get decided *how* to compile it.
+The language proves itself in the **evaluator** and in the **REPL**, and the EVM backend exists so that **the same program answers the same thing on a chain and off it**: Aurora is for simulating an on-chain call off-chain.
 
-So: a new feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped without it, and that is the expectation, not a debt to apologise for.
+The backend was parked while the behaviour settled, and is being un-parked in slices. Each slice is proved by the differential harness in `internal/cli/evm_harness_test.go` — same source, compiled and deployed to an EVM in memory, called, and compared against the evaluator. A change to the backend that the harness does not cover is a change nobody can vouch for.
+
+So: a new feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped without it, and that is the expectation, not a debt to apologise for. And the print builtins are **logs**: they do not compile to bytecode, by decision.
 
 ## The four architecture premises
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,12 +5,19 @@ of bytes, `tape_size` wide. It runs on its own evaluator and assembles to EVM by
 
 ## What matters now
 
-The language proves itself in the **evaluator** and in the **REPL**. The EVM backend is
-**parked on purpose** until the behaviour there settles — only then does it get decided
-*how* to compile to the EVM.
+The language proves itself in the **evaluator** and in the **REPL**, and the point of the EVM
+backend is that **the same program answers the same thing on a chain and off it** — Aurora
+exists to let an on-chain call be simulated off-chain.
 
-A feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped
+The backend was parked while the behaviour settled. It is being un-parked in slices, each one
+proved by the differential harness (`internal/cli/evm_harness_test.go`): the same source
+compiled, deployed to an EVM in memory, called, and compared against the evaluator.
+
+A feature still does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped
 without it.
+
+**The print builtins are logs, not contract instructions**, and do not compile to bytecode.
+That is a decision, not a gap.
 
 ## The four premises
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,12 +77,25 @@ pick something else.
 
 ## The EVM backend
 
-The gap here is wider than it looks, and it is silent, which is the dangerous part: a
-contract using any of the following **compiles successfully and does nothing on chain**.
+The point of the backend is that **the same program answers the same thing on a chain and off
+it**. Since the differential harness exists (`internal/cli/evm_harness_test.go`) that is no
+longer a hope: an EVM is built in memory, the contract is deployed and called, and the answer
+is compared against the evaluator. Arithmetic across a dispatcher is proved; everything below
+is not.
 
-- `if`, `jump`, `call`, `printb`/`printc`/`printd`, `assert`, the tape operations, and the
-  struct instructions (`OpJoin`, `OpField`) produce no bytecode at all. `WriteCode` covers
-  arithmetic, `OpSave`, `OpIdent`, `OpLoad`, `OpGetFeed` and `OpReturn`.
+The gap is wider than it looks, and it is silent, which is the dangerous part: a contract
+using any of the following **compiles successfully and does nothing on chain**.
+
+- `if`, `jump`, `call`, `assert`, the tape operations, and the struct instructions (`OpJoin`,
+  `OpField`) produce no bytecode at all. `WriteCode` covers arithmetic, `OpSave`, `OpIdent`,
+  `OpLoad`, `OpGetFeed` and `OpReturn`. They are not refusals — a tape is at most 32 bytes and
+  an EVM word is exactly 32, a struct is a run of words in memory, and a call is a jump with a
+  return address. They are simply not written yet.
+- **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
+  says on the way is for whoever is watching it run, not for the chain.
+- **Arithmetic is not masked to the tape width.** At `--tape-size 1`, `255 + 1` is `0` in the
+  evaluator and `256` on chain: the EVM wraps at 2²⁵⁶ and the tape wraps at 2⁸. The harness
+  reports it; the fix is a mask after every operation.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.
   On chain they are the only way a contract says anything, and they are the honest target for
   whatever Aurora ends up calling logging.
@@ -91,6 +104,14 @@ contract using any of the following **compiles successfully and does nothing on 
 
 A first step that costs little: **warn at compile time** when a program uses something the
 backend drops, instead of writing a binary that lies.
+
+## Simulating a call off the chain
+
+`aurora call` speaks to a network and nothing else, so there is no way to ask for one scope by
+name with these arguments and have the evaluator answer — the call has to be written into the
+source. The differential harness works around it by appending the call to the program, which
+is exactly the shape of what is missing: a local call that takes a function and its arguments
+and answers from the evaluator, the same way the chain would.
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -17,19 +17,33 @@ require (
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProjectZKM/Ziren/crates/go-runtime/zkvm_runtime v0.0.0-20251001021608-1fe7b43fc4d6 // indirect
 	github.com/StackExchange/wmi v1.2.1 // indirect
+	github.com/VictoriaMetrics/fastcache v1.13.0 // indirect
 	github.com/bits-and-blooms/bitset v1.20.0 // indirect
+	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/consensys/gnark-crypto v0.18.0 // indirect
 	github.com/crate-crypto/go-eth-kzg v1.4.0 // indirect
 	github.com/crate-crypto/go-ipa v0.0.0-20240724233137-53bbb0ceb27a // indirect
 	github.com/deckarep/golang-set/v2 v2.6.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 // indirect
+	github.com/emicklei/dot v1.6.2 // indirect
 	github.com/ethereum/c-kzg-4844/v2 v2.1.5 // indirect
+	github.com/ethereum/go-bigmodexpfix v0.0.0-20250911101455-f9e208c548ab // indirect
 	github.com/ethereum/go-verkle v0.2.2 // indirect
+	github.com/ferranbt/fastssz v0.1.4 // indirect
 	github.com/go-ole/go-ole v1.3.0 // indirect
+	github.com/gofrs/flock v0.12.1 // indirect
+	github.com/golang/snappy v1.0.0 // indirect
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/klauspost/cpuid/v2 v2.0.9 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/minio/sha256-simd v1.0.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.1 // indirect
+	github.com/olekukonko/tablewriter v0.0.5 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/spf13/pflag v1.0.6 // indirect
 	github.com/supranational/blst v0.3.16-0.20250831170142-f48500c1fdbe // indirect
@@ -38,4 +52,5 @@ require (
 	golang.org/x/crypto v0.36.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect
 	golang.org/x/sys v0.37.0 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,8 @@ github.com/StackExchange/wmi v1.2.1 h1:VIkavFPXSjcnS+O8yTq7NI32k0R5Aj+v39y29VYDO
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VictoriaMetrics/fastcache v1.13.0 h1:AW4mheMR5Vd9FkAPUv+NH6Nhw+fmbTMGMsNAoA/+4G0=
 github.com/VictoriaMetrics/fastcache v1.13.0/go.mod h1:hHXhl4DA2fTL2HTZDJFXWgW0LNjo6B+4aj2Wmng3TjU=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156 h1:eMwmnE/GDgah4HI848JfFxHt+iPb26b4zyfspmqY0/8=
+github.com/allegro/bigcache v1.2.1-0.20190218064605-e24eb225f156/go.mod h1:Cb/ax3seSYIx7SuZdm2G2xzfwmv3TPSk2ucNfQESPXM=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bits-and-blooms/bitset v1.20.0 h1:2F+rfL86jE2d/bmw7OhqUg2Sj/1rURkBn3MdfoPyRVU=
@@ -47,6 +49,10 @@ github.com/decred/dcrd/crypto/blake256 v1.0.0 h1:/8DMNYp9SGi5f0w7uCm6d6M4OU2rGFK
 github.com/decred/dcrd/crypto/blake256 v1.0.0/go.mod h1:sQl2p6Y26YV+ZOcSTP6thNdn47hh8kt6rqSlvmrXFAc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1 h1:YLtO71vCjJRCBcrPMtQ9nqBsqpA1m5sE92cU+pd5Mcc=
 github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1/go.mod h1:hyedUtir6IdtD/7lIxGeCxkaw7y45JueMRL4DIyJDKs=
+github.com/dlclark/regexp2 v1.7.0 h1:7lJfhqlPssTb1WQx4yvTHN0uElPEv52sbaECrAQxjAo=
+github.com/dlclark/regexp2 v1.7.0/go.mod h1:DHkYz0B9wPfa6wondMfaivmHpzrQ3v9q8cnmRbL6yW8=
+github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3 h1:+3HCtB74++ClLy8GgjUQYeC8R4ILzVcIe8+5edAJJnE=
+github.com/dop251/goja v0.0.0-20230605162241-28ee0ee714f3/go.mod h1:QMWlm50DNe14hD7t24KEqZuUdC9sOTy8W6XbCU1mlw4=
 github.com/emicklei/dot v1.6.2 h1:08GN+DD79cy/tzN6uLCT84+2Wk9u+wvqP+Hkx/dIR8A=
 github.com/emicklei/dot v1.6.2/go.mod h1:DeV7GvQtIw4h2u73RKBkkFdvVAz0D9fzeJrgPW6gy/s=
 github.com/ethereum/c-kzg-4844/v2 v2.1.5 h1:aVtoLK5xwJ6c5RiqO8g8ptJ5KU+2Hdquf6G3aXiHh5s=
@@ -66,6 +72,8 @@ github.com/getsentry/sentry-go v0.27.0/go.mod h1:lc76E2QywIyW8WuBnwl8Lc4bkmQH4+w
 github.com/go-ole/go-ole v1.2.5/go.mod h1:pprOEPIfldk/42T2oK7lQ4v4JSDwmV0As9GaiUsvbm0=
 github.com/go-ole/go-ole v1.3.0 h1:Dt6ye7+vXGIKZ7Xtk4s6/xVdGDQynvom7xCFEdWr6uE=
 github.com/go-ole/go-ole v1.3.0/go.mod h1:5LS6F96DhAwUc7C+1HLexzMXY1xGRSryjyPPKW6zv78=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible h1:W1iEw64niKVGogNgBN3ePyLFfuisuzeidWPMPWmECqU=
+github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/gofrs/flock v0.12.1 h1:MTLVXXHf8ekldpJk3AKicLij9MdwOWkZ+a/jHHZby9E=
 github.com/gofrs/flock v0.12.1/go.mod h1:9zxTsyu5xtJ9DK+1tFZyibEV7y3uwDxPPfbxeeHCoD0=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
@@ -76,6 +84,8 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/golang/snappy v1.0.0 h1:Oy607GVXHs7RtbggtPBnr2RmDArIsAefDwvrdWvRhGs=
 github.com/golang/snappy v1.0.0/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904 h1:4/hN5RUoecvl+RmJRE2YxKWtnnQls6rQjjW5oV7qg2U=
+github.com/google/pprof v0.0.0-20230207041349-798e818bf904/go.mod h1:uglQLonpP8qtYCYyzA+8c/9qtqgA3qsXGYqCPKARAFg=
 github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0Ufc=
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpxn4uE=
@@ -94,6 +104,7 @@ github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7Bd
 github.com/jackpal/go-nat-pmp v1.0.2/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=
 github.com/klauspost/compress v1.16.0 h1:iULayQNOReoYUe+1qtKOqw9CwJv3aNQu8ivo7lw1HU4=
 github.com/klauspost/compress v1.16.0/go.mod h1:ntbaceVETuRiXiv4DpjP66DpAtAGkEQskQzEyD//IeE=
+github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.9 h1:lgaqFMSdTdQYdZ04uHyN2d/eKdOMyi2YLSvlQIBFYa4=
 github.com/klauspost/cpuid/v2 v2.0.9/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -109,6 +120,7 @@ github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovk
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/matttproud/golang_protobuf_extensions v1.0.4 h1:mmDVorXM7PCGKw94cs5zkfA9PSy5pEvNWRP0ET0TIVo=
@@ -143,6 +155,8 @@ github.com/prometheus/common v0.42.0 h1:EKsfXEYo4JpWMHH5cg+KOUWeuJSov1Id8zGR8eeI
 github.com/prometheus/common v0.42.0/go.mod h1:xBwqVerjNdUDjgODMpudtOMwlOwf2SaTr1yjz4b7Zbc=
 github.com/prometheus/procfs v0.9.0 h1:wzCHvIvM5SxWqYvwgVL7yJY8Lz3PKn49KQtpgMYJfhI=
 github.com/prometheus/procfs v0.9.0/go.mod h1:+pB4zwohETzFnmlpe6yd2lSc+0/46IYZRB/chUwxUZY=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta h1:H/EbCuXPeTV3lpKeXGPpEV9gsUpkqOOVnWapUyeWro4=
+github.com/prysmaticlabs/gohashtree v0.0.4-beta/go.mod h1:BFdtALS+Ffhg3lGQIHv9HDWuHS8cTvHZzrHWxwOtGOs=
 github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
@@ -195,6 +209,8 @@ golang.org/x/time v0.9.0/go.mod h1:3BpzKBy/shNhVucY/MWOyx10tF3SFh9QdLuxbVysPQM=
 google.golang.org/protobuf v1.34.2 h1:6xV6lTsCfpGD21XK49h7MhtcApnLqkfYgPcdHftf6hg=
 google.golang.org/protobuf v1.34.2/go.mod h1:qYOHts0dSfpeUzUFpOMr/WGzszTmLH+DiWniOlNbLDw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1 h1:bBRl1b0OH9s/DuPhuXpNl+VtCaJXFZ5/uEFST95x9zc=
 gopkg.in/natefinch/lumberjack.v2 v2.2.1/go.mod h1:YD8tP3GAjkrDg1eZH7EGmyESg/lsYskCTPBJVb9jqSc=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=

--- a/internal/cli/evm_harness_test.go
+++ b/internal/cli/evm_harness_test.go
@@ -1,0 +1,138 @@
+package cli
+
+import (
+	"io"
+	"math/big"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/core/vm/runtime"
+	"github.com/guiferpa/aurora/builder/evm"
+)
+
+// Aurora exists to let a call be simulated off the chain, which only means something if the
+// two answers are the same. Nothing checked that: the builder's tests read the shape of the
+// bytecode — its size, its selectors, that it comes out the same twice — and never once ran
+// it.
+//
+// go-ethereum is already a dependency, so an EVM can be built in memory here: the constructor
+// runs the way a chain would run it, the runtime it returns is installed, and a call arrives
+// through the same encoder "aurora call" uses. What comes back is compared against what the
+// evaluator answers for the same source.
+
+// onChain compiles the source, installs it in an EVM of its own, and calls one of its scopes
+// through calldata built exactly as the CLI builds it.
+func onChain(t *testing.T, source, function string, args []string, tapeSize int) []byte {
+	t.Helper()
+
+	path := writeAt(t, t.TempDir(), "contract.ar", source)
+	program, err := Compile(path, tapeSize, nil, io.Discard)
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+
+	bytecode, err := evm.NewBuilder(program.Instructions, evm.NewBuilderOptions{TapeSize: tapeSize}).Build()
+	if err != nil {
+		t.Fatalf("building: %v", err)
+	}
+
+	cfg := &runtime.Config{GasLimit: 10_000_000, Value: big.NewInt(0)}
+	_, address, _, err := runtime.Create(bytecode, cfg)
+	if err != nil {
+		t.Fatalf("deploying: %v", err)
+	}
+
+	// The same two encoders "aurora call" uses, so what is proven here is the path someone
+	// actually takes rather than one built for the test.
+	calldata := append(EncodeSelector(function), ParseArgs(args)...)
+
+	returned, _, err := runtime.Call(address, calldata, cfg)
+	if err != nil {
+		t.Fatalf("calling %s: %v", function, err)
+	}
+	return returned
+}
+
+// offChain answers what the evaluator makes of the same call.
+//
+// The call has to be written into the source, because there is no way to ask the evaluator
+// for one scope by name with these arguments — the closest thing, "aurora call", only speaks
+// to a network. That is the gap this harness makes visible.
+func offChain(t *testing.T, source, call string, tapeSize int) string {
+	t.Helper()
+
+	path := writeAt(t, t.TempDir(), "program.ar", source+"\nprintd "+call+";\n")
+	out := &strings.Builder{}
+	if err := Run(t.Context(), RunInput{Source: path, TapeSize: tapeSize, Stdout: out}); err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	return strings.TrimSpace(out.String())
+}
+
+// decimalOf reads what a contract returned as the number it is. A return is one word, and a
+// tape is right-aligned inside it, so the whole word is the value.
+func decimalOf(returned []byte) string {
+	return new(big.Int).SetBytes(returned).String()
+}
+
+// The first program to cross the whole path: compiled, deployed, called, and answered for by
+// both backends.
+func TestAddAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `ident add = defer { feed(0) + feed(1); };`
+
+	cases := []struct {
+		name string
+		args []string
+		call string
+	}{
+		{name: "small", args: []string{"1", "2"}, call: "add(1, 2)"},
+		{name: "larger", args: []string{"1000", "337"}, call: "add(1000, 337)"},
+		{name: "zero", args: []string{"0", "0"}, call: "add(0, 0)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			returned := onChain(t, source, "add", tc.args, 0)
+			want := offChain(t, source, tc.call, 0)
+
+			if got := decimalOf(returned); got != want {
+				t.Errorf("the chain answered %s and the evaluator %s", got, want)
+			}
+		})
+	}
+}
+
+// A contract holds as many scopes as it has names, and the selector is what tells them apart.
+func TestEachScopeAnswersForItself(t *testing.T) {
+	const source = `ident add = defer { feed(0) + feed(1); };
+ident multiply = defer { feed(0) * feed(1); };`
+
+	cases := []struct {
+		function string
+		call     string
+	}{
+		{function: "add", call: "add(6, 7)"},
+		{function: "multiply", call: "multiply(6, 7)"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.function, func(t *testing.T) {
+			returned := onChain(t, source, tc.function, []string{"6", "7"}, 0)
+			want := offChain(t, source, tc.call, 0)
+
+			if got := decimalOf(returned); got != want {
+				t.Errorf("the chain answered %s and the evaluator %s", got, want)
+			}
+		})
+	}
+}
+
+// A name the contract does not have reaches the no-match STOP, which answers with nothing —
+// it does not run the first scope it finds.
+func TestAnUnknownNameAnswersWithNothing(t *testing.T) {
+	const source = `ident add = defer { feed(0) + feed(1); };`
+
+	if returned := onChain(t, source, "subtract", []string{"1", "2"}, 0); len(returned) != 0 {
+		t.Errorf("a name that is not there answered %v", returned)
+	}
+}


### PR DESCRIPTION
Slice 1 of un-parking the EVM backend. It adds no opcode: it adds the way to know whether any of them work.

## The problem it closes

Aurora exists so that an **on-chain call can be simulated off-chain**. Nothing checked that the two sides agreed. The builder's tests read the *shape* of the bytecode — its size, its selectors, that it comes out the same twice — and **never once ran it**. Whether a contract Aurora compiles does anything at all was an opinion.

go-ethereum is already a dependency, so the EVM is built here in memory: the constructor runs the way a chain runs it, the runtime it returns is installed, and the call arrives through **the same two encoders `aurora call` uses** (`EncodeSelector`, `ParseArgs`) — so what is proved is the path someone actually takes, not one built for the test.

## What is now known to work

| | |
|---|---|
| `add(a, b)` and `multiply(a, b)` | deployed, called, answering exactly what the evaluator answers |
| two scopes in one contract | each reached by its own selector |
| a name the contract does not have | reaches the no-match `STOP` instead of running the first scope it finds |

That is the first time anyone has known this rather than assumed it.

## What it found on its first run

**Arithmetic is not masked to the tape width.**

```
--tape-size 1, add(255, 1):   evaluator 0   ·   chain 256
```

The EVM wraps at 2²⁵⁶ and a tape wraps at 2⁸. The existing tape-size tests check the width of the `PUSH` and never the result of a sum, so nothing noticed. Reproduced with the harness and left for **slice 2**, which is the mask — the failing case lands green there rather than red here.

## Documentation the harness makes true or false

`CLAUDE.md`, `.claude/agents/aurora-standards.md` and `docs/roadmap.md` all said the backend was parked. What un-parks it is not a decision to work on it — it is having a way to know. They now say that every slice is proved by the harness, and that a backend change the harness does not cover is one nobody can vouch for.

Three things the roadmap said that were wrong or incomplete:

- nothing executed the bytecode;
- the **print builtins were listed as a gap** when they are a decision — they are logs, not contract instructions, and do not compile;
- the missing opcodes read as refusals, when a tape is at most 32 bytes and an EVM word is exactly 32, a struct is a run of words in memory, and a call is a jump with a return address. They are unwritten, not impossible.

It also gained the gap the harness had to work around: **there is no way to ask the evaluator for one scope by name with these arguments.** `aurora call` only speaks to a network, so the harness appends the call to the source. A local call is the obvious shape of what is missing, and it is the project's own goal.

## Cost

`go mod tidy` adds **sixteen indirect modules** (fastcache, snappy, fastssz, tablewriter and friends): `core/vm` needs the state a chain has. No new direct dependency — go-ethereum was already one — and nothing outside the test reaches them. Worth a look, since it is the price of having a real EVM in CI.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- The harness runs under `make test`; no new target.
- Each commit verified in its own `git worktree` with `make check`.

Next slice: the mask, with `add(255, 1)` at one byte turning green.