### PR TITLE
A value on chain is as wide as the tape says

### DIFF
--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -95,6 +95,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				WritePush(want, byteutil.FromUint64(4294967295), byteutil.DefaultTapeSize)
 				WritePush(want, byteutil.FromUint64(4294967295), byteutil.DefaultTapeSize)
 				WriteAdd(want)
+				WriteMask(want, byteutil.DefaultTapeSize)
 				WriteReturn(want)
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)
@@ -126,9 +127,10 @@ func TestPickRuntimeCode(t *testing.T) {
 			//nolint:errcheck
 			func(got []byte) error {
 				want := bytes.NewBuffer(make([]byte, 0))
-				WriteGetArg(want, byteutil.FromUint64(1))
-				WriteGetArg(want, byteutil.FromUint64(0))
+				WriteGetArg(want, byteutil.FromUint64(1), byteutil.DefaultTapeSize)
+				WriteGetArg(want, byteutil.FromUint64(0), byteutil.DefaultTapeSize)
 				WriteSubtract(want)
+				WriteMask(want, byteutil.DefaultTapeSize)
 				WriteReturn(want)
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -22,6 +22,28 @@ func WritePush(w io.Writer, operand []byte, size int) (int, error) {
 	return 0, nil
 }
 
+// WriteMask cuts the value on top of the stack down to the tape width.
+//
+// A tape of N bytes holds values modulo 2^(8N) — that is what the evaluator does, keeping the
+// last N bytes of every result. The EVM works in words of 32 bytes and wraps at 2^256, so
+// without this the same program answers two different things: at one byte, 255 + 1 is 0 in
+// the evaluator and 256 on chain.
+//
+// At the full width the mask is every bit set, so nothing is written: the common case pays
+// nothing for this.
+func WriteMask(w io.Writer, size int) (int, error) {
+	size = byteutil.TapeSize(size)
+	if size >= byteutil.MaxTapeSize {
+		return 0, nil
+	}
+
+	mask := bytes.Repeat([]byte{0xff}, size)
+	if _, err := w.Write(append([]byte{OpPush1 + byte(size-1)}, mask...)); err != nil {
+		return 0, err
+	}
+	return w.Write([]byte{OpAnd})
+}
+
 // WriteAdd emits ADD. Lowering guarantees [left, right] on stack (LIFO); Builder is mechanical.
 func WriteAdd(w io.Writer) (int, error) {
 	return w.Write([]byte{OpAdd})
@@ -84,13 +106,21 @@ func WriteReturn(w io.Writer) (int, error) {
 	return w.Write([]byte{OpPush1, 0x20, OpPush1, 0x00, OpReturn})
 }
 
-func WriteGetArg(w io.Writer, left []byte) (int, error) {
+// WriteGetArg reads an argument out of the calldata and cuts it to the tape width.
+//
+// An argument arrives as a 32-byte word whatever the tape is, and the evaluator narrows it to
+// a tape on the way in (environ.NewEnviron). Reading the whole word here would let a caller
+// hand a contract a value its own language cannot hold.
+func WriteGetArg(w io.Writer, left []byte, size int) (int, error) {
 	index := byteutil.ToUint64(left)
 	offset := GetCalldataArgsOffset(index)
 	if _, err := w.Write([]byte{OpPush1, offset}); err != nil {
 		return 0, err
 	}
-	return w.Write([]byte{OpCallDataLoad})
+	if _, err := w.Write([]byte{OpCallDataLoad}); err != nil {
+		return 0, err
+	}
+	return WriteMask(w, size)
 }
 
 func WriteStop(w io.Writer) (int, error) {
@@ -196,16 +226,25 @@ func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize 
 			if _, err := WriteAdd(bs); err != nil {
 				return 0, err
 			}
+			if _, err := WriteMask(bs, tapeSize); err != nil {
+				return 0, err
+			}
 		}
 
 		if op == ir.OpMultiply {
 			if _, err := WriteMultiply(bs); err != nil {
 				return 0, err
 			}
+			if _, err := WriteMask(bs, tapeSize); err != nil {
+				return 0, err
+			}
 		}
 
 		if op == ir.OpSubtract {
 			if _, err := WriteSubtract(bs); err != nil {
+				return 0, err
+			}
+			if _, err := WriteMask(bs, tapeSize); err != nil {
 				return 0, err
 			}
 		}
@@ -241,7 +280,7 @@ func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize 
 		}
 
 		if op == ir.OpGetFeed {
-			if _, err := WriteGetArg(bs, inst.GetLeft()); err != nil {
+			if _, err := WriteGetArg(bs, inst.GetLeft(), tapeSize); err != nil {
 				return 0, err
 			}
 		}

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -130,15 +130,17 @@ func TestWriteLoad(t *testing.T) {
 	}
 }
 
+// An argument arrives as a whole 32-byte word and is cut to the tape on the way in, the same
+// as the evaluator does when it narrows the arguments it was handed.
 func TestWriteGetArg(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
 	index := byteutil.FromUint64(0)
-	if _, err := WriteGetArg(bs, index); err != nil {
+	if _, err := WriteGetArg(bs, index, byteutil.DefaultTapeSize); err != nil {
 		t.Errorf("Error writing get arg: %v", err)
 		return
 	}
 	got := bs.Bytes()
-	expected := []byte{OpPush1, 0x20, OpCallDataLoad}
+	expected := []byte{OpPush1, 0x20, OpCallDataLoad, OpPush8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, OpAnd}
 	if !bytes.Equal(got, expected) {
 		t.Errorf("GetArg: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 	}
@@ -241,5 +243,43 @@ func TestWriteBodyCode(t *testing.T) {
 		if got, expected := bs.Bytes(), c.FnExpected(); !bytes.Equal(got, expected) {
 			t.Errorf("EVM body code: name: %v, got: %v, expected: %v", c.Name, byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 		}
+	}
+}
+
+// A tape of N bytes holds values modulo 2^(8N), and the EVM wraps at 2^256 — so every result
+// that could have left the width is cut back to it. At the full width there is nothing to
+// cut, and the common case pays nothing.
+func TestWriteMask(t *testing.T) {
+	cases := []struct {
+		name string
+		size int
+		want []byte
+	}{
+		{name: "one byte", size: 1, want: []byte{OpPush1, 0xff, OpAnd}},
+		{name: "two bytes", size: 2, want: []byte{OpPush2, 0xff, 0xff, OpAnd}},
+		{
+			name: "the default",
+			size: byteutil.DefaultTapeSize,
+			want: []byte{OpPush8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, OpAnd},
+		},
+		{name: "the full word masks nothing", size: byteutil.MaxTapeSize, want: []byte{}},
+		// Zero means unset, which is the default width rather than a mask of nothing.
+		{
+			name: "unset",
+			size: 0,
+			want: []byte{OpPush8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, OpAnd},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bs := bytes.NewBuffer(make([]byte, 0))
+			if _, err := WriteMask(bs, tc.size); err != nil {
+				t.Fatalf("WriteMask: %v", err)
+			}
+			if got := bs.Bytes(); !bytes.Equal(got, tc.want) {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -78,10 +78,11 @@ pick something else.
 ## The EVM backend
 
 The point of the backend is that **the same program answers the same thing on a chain and off
-it**. Since the differential harness exists (`internal/cli/evm_harness_test.go`) that is no
+it**. Since the differential harness exists (`hosting/cli/evm_harness_test.go`) that is no
 longer a hope: an EVM is built in memory, the contract is deployed and called, and the answer
-is compared against the evaluator. Arithmetic across a dispatcher is proved; everything below
-is not.
+is compared against the evaluator. Arithmetic across a dispatcher is proved, at any tape width
+— a result that leaves the width is cut back to it, the way the evaluator does — and
+everything below is not.
 
 The gap is wider than it looks, and it is silent, which is the dangerous part: a contract
 using any of the following **compiles successfully and does nothing on chain**.
@@ -93,9 +94,6 @@ using any of the following **compiles successfully and does nothing on chain**.
   return address. They are simply not written yet.
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.
-- **Arithmetic is not masked to the tape width.** At `--tape-size 1`, `255 + 1` is `0` in the
-  evaluator and `256` on chain: the EVM wraps at 2²⁵⁶ and the tape wraps at 2⁸. The harness
-  reports it; the fix is a mask after every operation.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.
   On chain they are the only way a contract says anything, and they are the honest target for
   whatever Aurora ends up calling logging.

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -56,20 +57,43 @@ func onChain(t *testing.T, source, function string, args []string, tapeSize int)
 	return returned
 }
 
-// offChain answers what the evaluator makes of the same call.
+// offChain answers what the evaluator makes of the same call, with the arguments arriving the
+// same way they arrive on chain: encoded by ParseArgs and narrowed to a tape on the way in.
 //
-// The call has to be written into the source, because there is no way to ask the evaluator
-// for one scope by name with these arguments — the closest thing, "aurora call", only speaks
-// to a network. That is the gap this harness makes visible.
-func offChain(t *testing.T, source, call string, tapeSize int) string {
+// The call still has to be written into the source, because there is no way to ask the
+// evaluator for one scope by name — the closest thing, "aurora call", only speaks to a
+// network. That is the gap this harness makes visible. What it must not do is write the
+// arguments in as literals: a literal is checked against the tape when it is compiled, so
+// "add(300, 0)" on a one-byte tape is refused at compile time while the same 300 arriving as
+// calldata is simply narrowed.
+func offChain(t *testing.T, source, function string, args []string, tapeSize int) string {
 	t.Helper()
 
-	path := writeAt(t, t.TempDir(), "program.ar", source+"\nprintd "+call+";\n")
+	feeds := make([]string, 0, len(args))
+	for i := range args {
+		feeds = append(feeds, fmt.Sprintf("feed(%d)", i))
+	}
+	probe := fmt.Sprintf("printd %s(%s);", function, strings.Join(feeds, ", "))
+
+	path := writeAt(t, t.TempDir(), "program.ar", source+"\n"+probe+"\n")
 	out := &strings.Builder{}
-	if err := newSession(t, sessionOpts{tapeSize: tapeSize, stdout: out}).Run(t.Context(), path); err != nil {
+	session := newSession(t, sessionOpts{tapeSize: tapeSize, stdout: out, args: args})
+	if err := session.Run(t.Context(), path); err != nil {
 		t.Fatalf("running: %v", err)
 	}
 	return strings.TrimSpace(out.String())
+}
+
+// agree runs the same call through both backends and reports when they answer differently.
+func agree(t *testing.T, source, function string, args []string, tapeSize int) {
+	t.Helper()
+
+	returned := onChain(t, source, function, args, tapeSize)
+	want := offChain(t, source, function, args, tapeSize)
+
+	if got := decimalOf(returned); got != want {
+		t.Errorf("the chain answered %s and the evaluator %s", got, want)
+	}
 }
 
 // decimalOf reads what a contract returned as the number it is. A return is one word, and a
@@ -86,21 +110,15 @@ func TestAddAnswersTheSameOnChainAndOff(t *testing.T) {
 	cases := []struct {
 		name string
 		args []string
-		call string
 	}{
-		{name: "small", args: []string{"1", "2"}, call: "add(1, 2)"},
-		{name: "larger", args: []string{"1000", "337"}, call: "add(1000, 337)"},
-		{name: "zero", args: []string{"0", "0"}, call: "add(0, 0)"},
+		{name: "small", args: []string{"1", "2"}},
+		{name: "larger", args: []string{"1000", "337"}},
+		{name: "zero", args: []string{"0", "0"}},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			returned := onChain(t, source, "add", tc.args, 0)
-			want := offChain(t, source, tc.call, 0)
-
-			if got := decimalOf(returned); got != want {
-				t.Errorf("the chain answered %s and the evaluator %s", got, want)
-			}
+			agree(t, source, "add", tc.args, 0)
 		})
 	}
 }
@@ -110,22 +128,9 @@ func TestEachScopeAnswersForItself(t *testing.T) {
 	const source = `ident add = defer { feed(0) + feed(1); };
 ident multiply = defer { feed(0) * feed(1); };`
 
-	cases := []struct {
-		function string
-		call     string
-	}{
-		{function: "add", call: "add(6, 7)"},
-		{function: "multiply", call: "multiply(6, 7)"},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.function, func(t *testing.T) {
-			returned := onChain(t, source, tc.function, []string{"6", "7"}, 0)
-			want := offChain(t, source, tc.call, 0)
-
-			if got := decimalOf(returned); got != want {
-				t.Errorf("the chain answered %s and the evaluator %s", got, want)
-			}
+	for _, function := range []string{"add", "multiply"} {
+		t.Run(function, func(t *testing.T) {
+			agree(t, source, function, []string{"6", "7"}, 0)
 		})
 	}
 }
@@ -137,5 +142,65 @@ func TestAnUnknownNameAnswersWithNothing(t *testing.T) {
 
 	if returned := onChain(t, source, "subtract", []string{"1", "2"}, 0); len(returned) != 0 {
 		t.Errorf("a name that is not there answered %v", returned)
+	}
+}
+
+// A tape of N bytes holds values modulo 2^(8N); the EVM wraps at 2^256. Every one of these
+// disagreed before the results were cut back to the width — the chain answered 256 where the
+// evaluator answered 0 — and nothing noticed, because the tape-size tests read the width of a
+// PUSH and never the result of a sum.
+func TestArithmeticWrapsAtTheTapeWidthOnBothSides(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		function string
+		args     []string
+		tapeSize int
+	}{
+		{
+			name:     "a sum past the top of a one-byte tape",
+			source:   `ident add = defer { feed(0) + feed(1); };`,
+			function: "add", args: []string{"255", "1"}, tapeSize: 1,
+		},
+		{
+			name:     "a product past the top",
+			source:   `ident multiply = defer { feed(0) * feed(1); };`,
+			function: "multiply", args: []string{"16", "16"}, tapeSize: 1,
+		},
+		{
+			// Under zero the value comes back from the other end, and how far depends on the
+			// width: 255 on one byte, not 2^256 - 1.
+			name:     "a difference under zero",
+			source:   `ident subtract = defer { feed(0) - feed(1); };`,
+			function: "subtract", args: []string{"0", "1"}, tapeSize: 1,
+		},
+		{
+			// An argument arrives as a whole word whatever the tape is, and the evaluator
+			// narrows it on the way in. Reading the whole word on chain let a caller hand a
+			// contract a value its own language cannot hold.
+			name:     "an argument wider than the tape",
+			source:   `ident add = defer { feed(0) + feed(1); };`,
+			function: "add", args: []string{"300", "0"}, tapeSize: 1,
+		},
+		{
+			name:     "two bytes",
+			source:   `ident add = defer { feed(0) + feed(1); };`,
+			function: "add", args: []string{"65535", "2"}, tapeSize: 2,
+		},
+		{
+			// This is why every result is cut and not only the one that leaves: a sum, a
+			// difference and a product agree either way, because wrapping and adding can be
+			// done in either order. A division cannot. At one byte 255 + 1 is 0, and 0 / 2 is
+			// 0 — but 256 / 2 is 128, and cutting that afterwards still answers 128.
+			name:     "a division after a sum that left the width",
+			source:   `ident half = defer { (feed(0) + feed(1)) / feed(2); };`,
+			function: "half", args: []string{"255", "1", "2"}, tapeSize: 1,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, tc.function, tc.args, tc.tapeSize)
+		})
 	}
 }


### PR DESCRIPTION
Slice 2. The bug the harness found on its first run, fixed and pinned.

## What was wrong

A tape of N bytes holds values modulo 2⁸ᴺ — the evaluator keeps the last N bytes of every result. The EVM works in words of 32 bytes and wraps at 2²⁵⁶. So the same program answered two different things:

```
--tape-size 1, add(255, 1):   evaluator 0   ·   chain 256
```

For a language whose point is that an on-chain call can be simulated off-chain, that is the worst kind of bug: silent, and in the one property everything else rests on.

## The fix

Every result that could leave the width is cut back to it, and an argument is cut on the way in — it arrives as a whole word whatever the tape is, and reading all of it let a caller hand a contract a value **its own language cannot hold**.

At the full width the mask is every bit set, so nothing is written: the common case pays nothing.

## Why it stood

`builder/evm/tape_size_test.go` checks the width of a `PUSH` and never the result of a sum. The shape was right and the arithmetic was wrong, and no test in the package could tell the difference. That is exactly the hole the harness exists to cover.

## The harness was asking the wrong question

Fixing it exposed a second thing. The off-chain side wrote the call into the source **with its arguments as literals**, and a literal is checked against the tape when it compiles: `add(300, 0)` on a one-byte tape is refused before it runs, while the same `300` arriving as calldata is simply narrowed. The two sides were not being asked the same question.

Now the arguments go in **as arguments**, through the same `ParseArgs` the chain call uses, and the source only says which scope to apply them to.

## What is now proved at any width

| case | before |
|---|---|
| a sum past the top of a one-byte tape | chain 256, evaluator 0 |
| a product past the top | chain 256, evaluator 0 |
| a difference under zero | chain 2²⁵⁶−1, evaluator 255 |
| an argument wider than the tape | chain 300, evaluator 44 |
| the same on two bytes | chain 65537, evaluator 1 |
| a division after a sum that left the width | chain 128, evaluator 0 |

Each answers the same on both sides now, and each would have disagreed before.

The last one is why the cut is after **every** operation and not only before the return. A sum, a difference and a product agree either way — wrapping and adding commute. A division does not: at one byte `255 + 1` is `0` and `0 / 2` is `0`, but `256 / 2` is `128`, and cutting *that* afterwards still answers `128`.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- `WriteMask` has its own cases, including the full width writing nothing and zero meaning the default rather than a mask of nothing.
- The two builder tests that spelled out expected bytecode now spell out the mask too — they state the new truth rather than being loosened.
- Each commit verified in its own `git worktree` with `make check`.

## Rebased onto the architecture work

This was opened before the architecture programme landed and sat 44 commits behind. Rebased onto `main`; nothing it decided was invalidated, only where things live:

- `internal/cli/evm_harness_test.go` → `hosting/cli/evm_harness_test.go`.
- `emitter.Instruction` / `emitter.Op*` → `ir.*` inside `WriteCode`.
- `Run(ctx, RunInput{Args: …})` → `newSession(…, sessionOpts{args: …}).Run(ctx, path)`. `sessionOpts` already carries `args` and hands them to the evaluator through the same `ParseArgs`, so the off-chain side needs nothing new.
- The roadmap paragraph this touches still pointed at `internal/cli/evm_harness_test.go`, which no longer exists; corrected in the same line it rewrites. The other stale `internal/cli` mentions in `docs/development.md` are left alone — they are not this change's business.

The slice this announced as next, *the compiler says what it cannot carry*, has since shipped as #38.
