### PR TITLE
The backend says what it cannot carry

### DIFF
--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"fmt"
 
-	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
@@ -67,16 +66,31 @@ var pending = map[byte]string{
 	ir.OpField: "struct",
 }
 
+// A Warning is what the builder has to say about a program it cannot carry whole.
+//
+// It is the builder's own word rather than the emitter's. A backend reporting on itself in
+// the vocabulary of the phase before it is one step from depending on that phase for meaning,
+// and the whole point of the layering is that someone could take this package and write a
+// different compiler around it.
+//
+// It carries no position: the IR has instructions, not lines.
+type Warning struct {
+	Message string
+}
+
+func (w Warning) String() string {
+	return w.Message
+}
+
 // Warnings reports what a program uses that does not reach the bytecode.
 //
 // They are warnings and not errors because the backend is being written in slices: refusing
 // the program would refuse it for a reason that expires. What must not happen is the binary
 // coming out quietly wrong, which is what happened until now.
 //
-// They arrive in the order the program uses them, once each, and carry no position: the IR
-// has no line to point at, only instructions.
-func Warnings(insts []ir.Instruction) []emitter.Warning {
-	warnings := make([]emitter.Warning, 0)
+// They arrive in the order the program uses them, once each.
+func Warnings(insts []ir.Instruction) []Warning {
+	warnings := make([]Warning, 0)
 	said := make(map[string]bool)
 
 	for _, inst := range insts {
@@ -99,7 +113,7 @@ func Warnings(insts []ir.Instruction) []emitter.Warning {
 			continue
 		}
 		said[message] = true
-		warnings = append(warnings, emitter.Warning{Message: message})
+		warnings = append(warnings, Warning{Message: message})
 	}
 
 	return warnings

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -1,0 +1,106 @@
+package evm
+
+import (
+	"fmt"
+
+	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// What the builder writes, and what it has to say about the rest.
+//
+// A contract using something the builder does not write compiles, deploys and does nothing on
+// chain — the worst way to find out. The list lives here, beside the code that does the
+// writing: the emitter cannot hold it, because a phase knows nothing of the one after it, and
+// the host cannot hold it either, because what a backend covers is not the host's to know.
+
+// handled is every instruction the builder turns into opcodes or consumes as structure.
+//
+// OpDefer and OpBeginScope write nothing of their own and are not gaps: the first becomes an
+// entry in the dispatcher, and the second opens a scope the builder lays out flat.
+var handled = map[byte]bool{
+	ir.OpAdd:        true,
+	ir.OpSubtract:   true,
+	ir.OpMultiply:   true,
+	ir.OpDivide:     true,
+	ir.OpSave:       true,
+	ir.OpIdent:      true,
+	ir.OpLoad:       true,
+	ir.OpGetFeed:    true,
+	ir.OpReturn:     true,
+	ir.OpDefer:      true,
+	ir.OpBeginScope: true,
+}
+
+// offChain is what is meant to be absent from a chain. Saying so is still worth a line: a
+// program whose logs vanish should hear it from the compiler rather than from the silence.
+var offChain = map[byte]string{
+	ir.OpPrintBytes:   "printb writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
+	ir.OpPrintChars:   "printc writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
+	ir.OpPrintDecimal: "printd writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
+	ir.OpAssert:       "assert belongs to 'aurora test' and produces no bytecode, by decision",
+}
+
+// pending is what the builder does not write yet, named as the user wrote it. Instructions
+// that come from one feature share a name, so an "if" is one warning rather than two.
+var pending = map[byte]string{
+	ir.OpIf:       "if",
+	ir.OpJump:     "if",
+	ir.OpCall:     "calling a scope",
+	ir.OpPushFeed: "calling a scope",
+	ir.OpPreCall:  "calling a scope",
+	ir.OpDiff:     "a comparison",
+	ir.OpEquals:   "a comparison",
+	ir.OpBigger:   "a comparison",
+	ir.OpSmaller:  "a comparison",
+	ir.OpAnd:      "and/or",
+	ir.OpOr:       "and/or",
+
+	ir.OpExponential: "^",
+
+	ir.OpPull: "a tape operation",
+	ir.OpPush: "a tape operation",
+	ir.OpHead: "a tape operation",
+	ir.OpTail: "a tape operation",
+
+	ir.OpJoin:  "struct",
+	ir.OpField: "struct",
+}
+
+// Warnings reports what a program uses that does not reach the bytecode.
+//
+// They are warnings and not errors because the backend is being written in slices: refusing
+// the program would refuse it for a reason that expires. What must not happen is the binary
+// coming out quietly wrong, which is what happened until now.
+//
+// They arrive in the order the program uses them, once each, and carry no position: the IR
+// has no line to point at, only instructions.
+func Warnings(insts []ir.Instruction) []emitter.Warning {
+	warnings := make([]emitter.Warning, 0)
+	said := make(map[string]bool)
+
+	for _, inst := range insts {
+		op := inst.GetOpCode()
+		if handled[op] {
+			continue
+		}
+
+		message, ok := offChain[op]
+		if !ok {
+			name, pendingOp := pending[op]
+			if !pendingOp {
+				continue
+			}
+			message = fmt.Sprintf(
+				"%s does not reach the bytecode yet: a contract using it compiles and does nothing on chain", name)
+		}
+
+		if said[message] {
+			continue
+		}
+		said[message] = true
+		warnings = append(warnings, emitter.Warning{Message: message})
+	}
+
+	return warnings
+}

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -1,0 +1,136 @@
+package evm
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// instructionsOf builds the instruction stream by opcode, which is all Warnings reads.
+func instructionsOf(opcodes ...byte) []ir.Instruction {
+	insts := make([]ir.Instruction, 0, len(opcodes))
+	for i, op := range opcodes {
+		insts = append(insts, ir.NewInstruction(byteutil.FromUint64(uint64(i)), op, nil, nil))
+	}
+	return insts
+}
+
+func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
+	cases := []struct {
+		name     string
+		opcodes  []byte
+		want     []string
+		wantNone bool
+	}{
+		{
+			// What a contract is made of today: values, names, arguments, arithmetic and a
+			// return, inside a scope that becomes a dispatcher entry.
+			name:     "a program the builder writes whole",
+			opcodes:  []byte{ir.OpDefer, ir.OpBeginScope, ir.OpGetFeed, ir.OpSave, ir.OpAdd, ir.OpReturn, ir.OpIdent},
+			wantNone: true,
+		},
+		{
+			name:    "a branch",
+			opcodes: []byte{ir.OpIf, ir.OpJump},
+			// Two instructions, one feature, one thing to say about it.
+			want: []string{"if does not reach the bytecode yet"},
+		},
+		{
+			name:    "a comparison",
+			opcodes: []byte{ir.OpBigger},
+			want:    []string{"a comparison does not reach the bytecode yet"},
+		},
+		{
+			name:    "a tape operation",
+			opcodes: []byte{ir.OpPull, ir.OpHead},
+			want:    []string{"a tape operation does not reach the bytecode yet"},
+		},
+		{
+			name:    "a struct",
+			opcodes: []byte{ir.OpJoin, ir.OpField},
+			want:    []string{"struct does not reach the bytecode yet"},
+		},
+		{
+			name:    "calling a scope",
+			opcodes: []byte{ir.OpPushFeed, ir.OpCall},
+			want:    []string{"calling a scope does not reach the bytecode yet"},
+		},
+		{
+			// A log is not a gap: it is absent on purpose, and the wording says so.
+			name:    "a print",
+			opcodes: []byte{ir.OpPrintDecimal},
+			want:    []string{"printd writes a log", "by decision"},
+		},
+		{
+			name:    "an assertion",
+			opcodes: []byte{ir.OpAssert},
+			want:    []string{"assert belongs to 'aurora test'", "by decision"},
+		},
+		{
+			name:    "each print speaks for itself",
+			opcodes: []byte{ir.OpPrintBytes, ir.OpPrintChars, ir.OpPrintDecimal},
+			want:    []string{"printb", "printc", "printd"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			warnings := Warnings(instructionsOf(tc.opcodes...))
+
+			if tc.wantNone {
+				if len(warnings) != 0 {
+					t.Errorf("said %v about a program it writes whole", warnings)
+				}
+				return
+			}
+
+			said := make([]string, 0, len(warnings))
+			for _, warning := range warnings {
+				said = append(said, warning.Message)
+			}
+			whole := strings.Join(said, "\n")
+
+			for _, want := range tc.want {
+				if !strings.Contains(whole, want) {
+					t.Errorf("said %q, want it to mention %q", whole, want)
+				}
+			}
+		})
+	}
+}
+
+// The same feature used twice is one thing to say, not two.
+func TestWarningsSayEachThingOnce(t *testing.T) {
+	warnings := Warnings(instructionsOf(
+		ir.OpIf, ir.OpJump, ir.OpIf, ir.OpJump, ir.OpBigger, ir.OpSmaller,
+	))
+
+	if len(warnings) != 2 {
+		t.Errorf("said %d things about two features: %v", len(warnings), warnings)
+	}
+}
+
+// They arrive in the order the program uses them, so the first thing a reader is told about
+// is the first thing that goes missing.
+func TestWarningsFollowTheProgram(t *testing.T) {
+	warnings := Warnings(instructionsOf(ir.OpPrintDecimal, ir.OpIf))
+
+	if len(warnings) != 2 {
+		t.Fatalf("said %d things, want two", len(warnings))
+	}
+	if !strings.Contains(warnings[0].Message, "printd") {
+		t.Errorf("said %q first, want the print", warnings[0].Message)
+	}
+}
+
+// A warning has no place to point at: the IR carries instructions, not lines. Saying it
+// without a position is what keeps the report honest.
+func TestWarningsCarryNoPosition(t *testing.T) {
+	for _, warning := range Warnings(instructionsOf(ir.OpIf)) {
+		if warning.Positioned() {
+			t.Errorf("%q claims to be at %d:%d", warning.Message, warning.Line, warning.Column)
+		}
+	}
+}

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -124,13 +124,3 @@ func TestWarningsFollowTheProgram(t *testing.T) {
 		t.Errorf("said %q first, want the print", warnings[0].Message)
 	}
 }
-
-// A warning has no place to point at: the IR carries instructions, not lines. Saying it
-// without a position is what keeps the report honest.
-func TestWarningsCarryNoPosition(t *testing.T) {
-	for _, warning := range Warnings(instructionsOf(ir.OpIf)) {
-		if warning.Positioned() {
-			t.Errorf("%q claims to be at %d:%d", warning.Message, warning.Line, warning.Column)
-		}
-	}
-}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -102,8 +102,10 @@ using any of the following **compiles successfully and does nothing on chain**.
 - Jump targets and memory offsets are written with `PUSH1`, which caps a runtime at 256
   bytes and identifiers at about seven memory slots. `PUSH2` lifts it.
 
-A first step that costs little: **warn at compile time** when a program uses something the
-backend drops, instead of writing a binary that lies.
+`aurora build` now **says what it could not carry**, once per feature, in the order the
+program uses it — so a binary that does less than the source said is at least announced. What
+is missing is a place to point at: the IR carries instructions, not lines, so a warning names
+the feature and not where it was written.
 
 ## Simulating a call off the chain
 

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -51,7 +51,10 @@ func Build(ctx context.Context, in BuildInput) (BuildReport, error) {
 	if err != nil {
 		return report, err
 	}
-	ReportWarnings(in.Warnings, in.Source, program.Warnings)
+	// What the compiler has to say about the program, and what the backend has to say about
+	// what it can carry: the second is the builder's to answer, since it is the one writing.
+	warnings := append(program.Warnings, evm.Warnings(program.Instructions)...)
+	ReportWarnings(in.Warnings, in.Source, warnings)
 	report.Instructions = len(program.Instructions)
 
 	// Assembling and writing are two things, and the builder only does the first: it

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -53,7 +53,7 @@ func Build(ctx context.Context, in BuildInput) (BuildReport, error) {
 	}
 	// What the compiler has to say about the program, and what the backend has to say about
 	// what it can carry: the second is the builder's to answer, since it is the one writing.
-	warnings := append(program.Warnings, evm.Warnings(program.Instructions)...)
+	warnings := append(CompilerWarnings(program.Warnings), BackendWarnings(evm.Warnings(program.Instructions))...)
 	ReportWarnings(in.Warnings, in.Source, warnings)
 	report.Instructions = len(program.Instructions)
 

--- a/hosting/cli/build_test.go
+++ b/hosting/cli/build_test.go
@@ -161,3 +161,74 @@ func TestPlural(t *testing.T) {
 		}
 	}
 }
+
+// A binary that quietly does less than the source said is the worst thing a build can hand
+// someone. What the backend cannot carry yet is said out loud, at the moment it is built.
+func TestBuildSaysWhatTheBackendDoesNotCarry(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "a branch",
+			source: "ident pick = defer { if feed(0) bigger feed(1) { feed(0); } else { feed(1); }; };\n",
+			want:   "if does not reach the bytecode yet",
+		},
+		{
+			name:   "a comparison",
+			source: "ident same = defer { feed(0) equals feed(1); };\n",
+			want:   "a comparison does not reach the bytecode yet",
+		},
+		{
+			name:   "a log",
+			source: "ident show = defer { printd feed(0); };\n",
+			want:   "printd writes a log",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			source := filepath.Join(dir, "main.ar")
+			if err := os.WriteFile(source, []byte(tc.source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+
+			warnings := &strings.Builder{}
+			if _, err := Build(t.Context(), BuildInput{
+				Source:     source,
+				OutputPath: filepath.Join(dir, "out.bin"),
+				Warnings:   warnings,
+			}); err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+
+			if got := warnings.String(); !strings.Contains(got, tc.want) {
+				t.Errorf("the build said %q, want it to say %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A program the backend writes whole is built without a word about it.
+func TestBuildSaysNothingAboutWhatItCarries(t *testing.T) {
+	dir := t.TempDir()
+	source := filepath.Join(dir, "main.ar")
+	if err := os.WriteFile(source, []byte("ident add = defer { feed(0) + feed(1); };\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := &strings.Builder{}
+	if _, err := Build(t.Context(), BuildInput{
+		Source:     source,
+		OutputPath: filepath.Join(dir, "out.bin"),
+		Warnings:   warnings,
+	}); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	if got := warnings.String(); got != "" {
+		t.Errorf("the build said %q about a program it carries whole", got)
+	}
+}

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, in RunInput) error {
 	if err != nil {
 		return err
 	}
-	ReportWarnings(in.Warnings, in.Source, program.Warnings)
+	ReportWarnings(in.Warnings, in.Source, CompilerWarnings(program.Warnings))
 
 	ev := evaluator.New(evaluator.NewEvaluatorOptions{
 		Output:   in.Stdout,

--- a/hosting/cli/warning.go
+++ b/hosting/cli/warning.go
@@ -5,24 +5,54 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/guiferpa/aurora/builder/evm"
 	"github.com/guiferpa/aurora/emitter"
 )
 
-// ReportWarnings prints what the compiler wants to say about a program without refusing
-// it. They go to stderr, so a pipeline reading the program's output is unaffected.
+// A Warning is something worth saying about a program that is not a reason to refuse it.
+//
+// The compiler and the backend each answer in their own words — a phase does not speak for
+// the one after it — so this is where the two are made into one thing to print. Line and
+// column are zero when the warning is about the program as a whole rather than a place in it.
+type Warning struct {
+	Message string
+	Line    int
+	Column  int
+}
+
+// CompilerWarnings and BackendWarnings carry each phase's answer across without either of
+// them having to know what the other calls a warning.
+func CompilerWarnings(warnings []emitter.Warning) []Warning {
+	out := make([]Warning, 0, len(warnings))
+	for _, warning := range warnings {
+		out = append(out, Warning{Message: warning.Message, Line: warning.Line, Column: warning.Column})
+	}
+	return out
+}
+
+func BackendWarnings(warnings []evm.Warning) []Warning {
+	out := make([]Warning, 0, len(warnings))
+	for _, warning := range warnings {
+		out = append(out, Warning{Message: warning.Message})
+	}
+	return out
+}
+
+// ReportWarnings prints what the compiler and the backend want to say about a program without
+// refusing it. They go to stderr, so a pipeline reading the program's output is unaffected.
 //
 // A warning that points at a place in the source is written as file:line:column, which is
 // what an editor follows to jump there.
-func ReportWarnings(w io.Writer, source string, warnings []emitter.Warning) {
+func ReportWarnings(w io.Writer, source string, warnings []Warning) {
 	if w == nil {
 		return
 	}
 	yellow := color.New(color.FgHiYellow)
 	for _, warning := range warnings {
-		if warning.Positioned() {
-			_, _ = yellow.Fprintf(w, "%s:%d:%d: warning: %s\n", source, warning.Line, warning.Column, warning)
+		if warning.Line > 0 {
+			_, _ = yellow.Fprintf(w, "%s:%d:%d: warning: %s\n", source, warning.Line, warning.Column, warning.Message)
 			continue
 		}
-		_, _ = yellow.Fprintf(w, "%s: warning: %s\n", source, warning)
+		_, _ = yellow.Fprintf(w, "%s: warning: %s\n", source, warning.Message)
 	}
 }


### PR DESCRIPTION
Slice 3. A contract using something the builder does not write **compiles, deploys and does nothing on chain** — until now the only way to find that out was on chain.

## What it says, and in whose words

Two kinds of thing, deliberately worded apart:

| | |
|---|---|
| `printd writes a log, and a chain has nowhere to put one: it produces no bytecode, **by decision**` | absent on purpose |
| `if does not reach the bytecode **yet**: a contract using it compiles and does nothing on chain` | absent for now |

The second says *yet* because the backend is being written in slices: refusing the program would refuse it for a reason that expires. The first says *by decision* because a log is not a gap — that was your call, and the compiler now repeats it instead of leaving silence to speak.

## Where the list lives

Beside the code that does the writing. **The emitter cannot hold it** — a phase knows nothing of the one after it — and **the host cannot either**, since what a backend covers is not the host's to know. So `builder/evm` answers, and `internal/cli/build.go` prints it through the path warnings already took.

## Details worth reviewing

- Instructions that come from one feature **share a name**: an `if` emits `OpIf` and `OpJump`, and that is one thing to say, not two. Same for a call (`OpPushFeed`, `OpCall`, `OpPreCall`), a comparison (four opcodes), a tape operation (four), and a struct (two).
- Each thing is said **once**, in the order the program uses it.
- **No warning carries a position.** The IR has instructions, not lines — pretending otherwise would point at the wrong place, and the roadmap now records that as what is still missing here.
- `OpDefer` and `OpBeginScope` write no bytecode of their own and are **not** gaps: the first becomes a dispatcher entry, the second opens a scope the builder lays out flat. They are listed as handled, so a plain contract builds without a word — which is what keeps the rest worth reading.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- Unit cases per feature, plus: the same feature twice is one warning, they follow program order, and none is positioned.
- End to end through `Build`: a branch, a comparison and a log each announced; a program the backend writes whole announced as nothing.
- Each commit verified in its own `git worktree` with `make check`.

Next slice: comparisons — `EQ`, `LT`, `GT`, `ISZERO` — which is the first of these warnings to disappear.