### PR TITLE
The architecture, decided — and the way there

### DIFF
--- a/.claude/agents/aurora-standards.md
+++ b/.claude/agents/aurora-standards.md
@@ -16,29 +16,50 @@ Answer in the language the user writes in (the maintainer usually writes pt-BR).
 
 The language proves itself in the **evaluator** and in the **REPL**, and the EVM backend exists so that **the same program answers the same thing on a chain and off it**: Aurora is for simulating an on-chain call off-chain.
 
-The backend was parked while the behaviour settled, and is being un-parked in slices. Each slice is proved by the differential harness in `internal/cli/evm_harness_test.go` — same source, compiled and deployed to an EVM in memory, called, and compared against the evaluator. A change to the backend that the harness does not cover is a change nobody can vouch for.
+**The backend is on stand-by** while the architecture lands. What it gained before stopping is the differential harness in `internal/cli/evm_harness_test.go` — same source, compiled and deployed to an EVM in memory, called, and compared against the evaluator. A change to the backend that the harness does not cover is a change nobody can vouch for, which is why nothing is written there until the packages are where they belong.
 
 So: a new feature does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped without it, and that is the expectation, not a debt to apologise for. And the print builtins are **logs**: they do not compile to bytecode, by decision.
 
-## The four architecture premises
+## The architecture: two layers, five kinds of package
 
-**1. Every function says what it does and why it exists.** Briefly. A loose fragment of code only gets a comment when the algorithm is hard to follow — commenting the obvious is noise that ages badly.
+The code is **hosting** — the logic of one kind of interaction — and **vital** — the pipeline that turns source into something that runs. Everything else exists to serve one of the two.
 
-**2. A vital or auxiliary package knows nothing about the rest of the project.** Everything is parameterised, to the point where someone can take a part of it and build a **different compiler**.
+```
+(lexer) → {tokens} → (parser) → {tree} → (emitter) → {IR} → (builder) │ (evaluator)
+```
 
-**3. Errors are resolved in the host.** A phase returns an error; it does not write. This is what stops a package from eating the error output by printing to stderr mid-execution.
+Between parentheses are the phases; between braces, what crosses between them. That drawing is the whole architecture: the parentheses are **vital**, the braces are **wire**.
 
-**4. A vital package is pure**: it takes values and returns values, predictably. Packages that read source files and the manifest exist, and they are not vital.
+| kind | what it is | imports | is imported by |
+|---|---|---|---|
+| **vital** | a step of the pipeline: `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
+| **wire** | what crosses a boundary: the token chain, the tree, the IR, a warning | **nothing of the project** | everyone |
+| **util** | behaviour worth reusing that never touches the world: `byteutil`, `logger` as a formatter | **nothing of the project** | everyone |
+| **hosting** | one kind of interaction: `internal/cli`, `repl`, `lsp` | wire, util, shared | `main` |
+| **shared** | serves the hosting *layer*, not one interaction: `fileutil`, `manifest`, `internal/trace` | wire, util | hosting, `main` |
 
-### The three kinds of package
+The two that are easy to confuse:
 
-| kind | who | may depend on |
-|---|---|---|
-| **Phase** — a step of compilation | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | **earlier** phases and auxiliaries |
-| **Auxiliary** — a step of nothing | `byteutil`, `fileutil`, `logger`, `manifest` | **nothing** of the project |
-| **Host** — assembles phases to serve someone | `cmd/*`, `repl`, `internal/cli`, `lsp` | anything; **nothing depends on it** |
+- **wire against util.** A util is behaviour you may reuse and nobody is obliged to. A wire package is *data crossing a boundary*, and two phases sharing exactly that type is the point — a phase declaring its own version of it is the mistake the kind exists to prevent. Wire holds the shape and the vocabulary (the types, the constructors, the constants) and never an algorithm: what *interprets* the vocabulary — laying an instruction out for a human — is presentation and belongs to `internal/trace`.
+- **hosting against shared.** A hosting package serves one interaction and is a leaf: only `main` depends on it. A shared package serves the layer, may be imported by any host, may touch the world, and **must not know which interaction is using it**. That last half is what keeps it from becoming the drawer where cohesion goes to die.
 
-Dependency runs one way: `lexer ← parser ← emitter ← {evaluator, builder/evm}`. A phase never knows the next one, and none of them knows a host.
+### The four rules
+
+**1. No package knows another.** What would tie two together is injected. The exceptions are wire and util, which know nothing of the project and may be known by all — that is what makes them safe to import.
+
+**2. A vital package is pure**: no I/O, and nothing done that is not returned. What a program printed comes back as a value; the host decides what to do with it. Returning it *including when the program fails* is part of the rule — a program that prints three lines and then breaks must not lose the three.
+
+**3. Errors are resolved in hosting.** A package returns an error. It never writes one, and it never ends the process.
+
+**4. I/O happens in hosting, and injection happens only in `main`.** No wiring anywhere else — not in a host, not in a vital.
+
+**A sub-package has the kind of its parent.** `evaluator/environ` and `evaluator/builtin` are vital; `lsp/textdoc`, `lsp/state` and `lsp/messenger` are hosting. A sub-package that needs I/O takes the port and calls it — it never decides to write.
+
+### The tree does not obey this yet
+
+Saying otherwise would make this document a lie, and a reviewer would be right to reject code that follows it. What is true today, measured: every phase imports the one before it, four places assemble phases and only one is `main`, and the evaluator writes to a writer while the program runs.
+
+**[rfcs/phase_coupling.md](../../rfcs/phase_coupling.md)** holds the migration: the artefacts get their own packages first (IR, then tree, then tokens), assembly moves to `main` after that, and the evaluator returns what the program said instead of writing it. Until that lands, judge a change by whether it moves toward the table or away from it — and say which.
 
 ## Tests
 
@@ -131,8 +152,9 @@ The linter catches complexity, formatting and forbidden imports. **You catch wha
 4. **A verification done by hand.** If the change was confirmed by running something in a terminal, that run belongs in the suite. This is the rule broken most often, and the one that costs the most later.
 5. **A user-perceivable change that never reached `docs/roadmap.md` or the CHANGELOG.**
 6. **A claim in documentation with nothing running it.** Every ```aurora block is executed by the suite; a new one has to survive that.
-7. **A phase that writes, reads a file, or knows a host.** Errors are resolved in the host; a vital package is pure.
-8. **A pull request nobody can hold in their head.** If it cannot be reviewed in forty minutes, say where it splits — usually along package lines, because the packages are the seams.
+7. **A vital package that writes, reads a file, ends the process, or knows another package.** Errors are resolved in hosting; a vital package takes values and gives values back. A new import from a vital to anything that is not wire or util is a finding on its own.
+8. **Wiring outside `main`.** A phase constructed anywhere else is the rule being lost one call at a time.
+9. **A pull request nobody can hold in their head.** If it cannot be reviewed in forty minutes, say where it splits — usually along package lines, because the packages are the seams.
 
 ## How you report
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,10 @@ The language proves itself in the **evaluator** and in the **REPL**, and the poi
 backend is that **the same program answers the same thing on a chain and off it** — Aurora
 exists to let an on-chain call be simulated off-chain.
 
-The backend was parked while the behaviour settled. It is being un-parked in slices, each one
-proved by the differential harness (`internal/cli/evm_harness_test.go`): the same source
-compiled, deployed to an EVM in memory, called, and compared against the evaluator.
+**The backend is on stand-by** while the architecture lands. What it gained before stopping is
+the differential harness (`internal/cli/evm_harness_test.go`) — the same source compiled,
+deployed to an EVM in memory, called, and compared against the evaluator — so whatever is
+written next is provable rather than believed.
 
 A feature still does **not** need bytecode to be finished. `struct` and text-as-a-tape shipped
 without it.
@@ -19,23 +20,46 @@ without it.
 **The print builtins are logs, not contract instructions**, and do not compile to bytecode.
 That is a decision, not a gap.
 
-## The four premises
+## Two layers, five kinds of package
 
-1. **Every function says what it does and why it exists.** Briefly. A loose fragment gets a
-   comment only when the algorithm is hard to follow.
-2. **A vital or auxiliary package knows nothing about the rest of the project** — enough
-   that someone could take a part of it and build a different compiler.
-3. **Errors are resolved in the host.** A phase returns an error; it does not write.
-4. **A vital package is pure**: values in, values out.
+The code is **hosting** — the logic of one kind of interaction — and **vital** — the pipeline
+that turns source into something that runs. Everything else exists to serve one of the two.
 
-| kind | who | may depend on |
-|---|---|---|
-| phase | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | earlier phases, auxiliaries |
-| auxiliary | `byteutil`, `fileutil`, `logger`, `manifest` | nothing of the project |
-| host | `cmd/*`, `repl`, `internal/cli`, `lsp` | anything; nothing depends on it |
+```
+(lexer) → {tokens} → (parser) → {tree} → (emitter) → {IR} → (builder) │ (evaluator)
+```
+
+Between parentheses are the phases; between braces, what crosses between them.
+
+| kind | who | imports | is imported by |
+|---|---|---|---|
+| **vital** | `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
+| **wire** | what crosses: tokens, tree, IR, warnings | **nothing of the project** | everyone |
+| **util** | reusable behaviour that never touches the world: `byteutil`, `logger` | **nothing of the project** | everyone |
+| **hosting** | one interaction: `internal/cli`, `repl`, `lsp` | wire, util, shared | `main` |
+| **shared** | serves the hosting layer, not one interaction: `fileutil`, `manifest`, `internal/trace` | wire, util | hosting, `main` |
+
+**The four rules that follow:**
+
+1. **No package knows another** — except wire and util, which know nothing of the project and
+   may be known by all. What would tie two together is injected instead.
+2. **A vital package is pure**: no I/O, and nothing done that is not returned. What a program
+   printed comes back as a value, so the host decides what to do with it.
+3. **Errors are resolved in hosting.** A package returns an error; it never writes one, and it
+   never ends the process.
+4. **I/O happens in hosting, and injection happens only in `main`.** Nothing is wired
+   together anywhere else.
+
+**A sub-package has the kind of its parent** — `evaluator/builtin` is vital, `lsp/textdoc` is
+hosting. One that needs I/O takes the port and calls it; it never decides to write.
+
+The tree does not obey this yet. What it costs, in which order, and what it finds today is in
+[rfcs/phase_coupling.md](rfcs/phase_coupling.md).
 
 ## Working here
 
+- **Every function says what it does and why it exists.** Briefly. A loose fragment gets a
+  comment only when the algorithm is hard to follow.
 - **A success case and an error case** for every implementation; an integration test for
   anything the user perceives. Never verify by running and throw it away — if you had to
   execute it to believe it, it becomes a test.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -20,4 +20,4 @@ Toda RFC abre dizendo em que estado está:
 
 | Arquivo | Assunto | Estado |
 |---|---|---|
-| [phase_coupling.md](phase_coupling.md) | Fases não se conhecem: artefatos como pacotes, montagem no `main` | proposta |
+| [phase_coupling.md](phase_coupling.md) | Fases não se conhecem: artefatos como pacotes, montagem no `main` | aceita |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -20,4 +20,4 @@ Toda RFC abre dizendo em que estado está:
 
 | Arquivo | Assunto | Estado |
 |---|---|---|
-| [phase_coupling.md](phase_coupling.md) | Uma fase importa a anterior; a premissa diz que não deveria | proposta |
+| [phase_coupling.md](phase_coupling.md) | Fases não se conhecem: artefatos como pacotes, montagem no `main` | proposta |

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,23 @@
+# RFCs
+
+Propostas, dívidas e discussões em aberto sobre a Aurora — **em português**, que é a língua em
+que o projeto é discutido. O que já está decidido e implementado mora em `docs/`, em inglês;
+aqui fica o que ainda está sendo pensado.
+
+Uma RFC não é um roadmap. O [roadmap](../docs/roadmap.md) diz **o que** falta e o que isso
+custa; uma RFC discute **como** resolver uma coisa específica, quais são as alternativas e por
+que uma foi escolhida. Uma proposta aceita e implementada vira documentação em `docs/` e o
+arquivo daqui é apagado — o git guarda o histórico.
+
+Toda RFC abre dizendo em que estado está:
+
+| Estado | Significa |
+|---|---|
+| **proposta** | escrita, ainda não decidida |
+| **aceita** | decidida, ainda não implementada |
+| **implementada** | virou código; o arquivo sai daqui na sequência |
+| **recusada** | decidida contra, e o porquê fica registrado |
+
+| Arquivo | Assunto | Estado |
+|---|---|---|
+| [phase_coupling.md](phase_coupling.md) | Uma fase importa a anterior; a premissa diz que não deveria | proposta |

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -1,66 +1,43 @@
-# Fases não se conhecem: o que isso exige do projeto
+# Fases não se conhecem: o caminho até lá
 
-**Estado:** proposta · **Data:** 2026-08-17
+**Estado:** aceita · **Data:** 2026-08-17
 
-Veio do review do PR #38 — o `builder/evm` importa o `emitter` — e cresceu quando as regras
-foram fixadas. Fica registrado aqui o que elas exigem e o que elas encontram no código de hoje.
+Veio do review do PR #38 — o `builder/evm` importa o `emitter` — e virou a arquitetura do
+projeto. A taxonomia está decidida e escrita no [CLAUDE.md](../CLAUDE.md) e no agente de
+padrões; o que fica aqui é **o caminho da árvore de hoje até ela**, com o custo de cada etapa.
 
 Tudo abaixo foi medido.
 
 ---
 
-## As regras, como ficaram
-
-1. **Pacote não tem interdependência com pacote.** O que ligaria um ao outro se resolve por
-   injeção de dependência. **Exceto pacotes auxiliares.**
-2. **Pacote vital é puro:** sem I/O, e sem processamento que não devolva nada.
-3. **Erro se trata na camada de hosting.** Nada de erro resolvido magicamente dentro de um
-   pacote.
-4. **I/O só na camada de hosting, e injeção só em arquivos do pacote `main`.** Nenhum
-   entrelaçamento entre vitais, nem entre hosting e vital, que não seja por injeção.
-
-E o encadeamento das fases:
+## O desenho é o argumento
 
 ```
-(Lexer) → {cadeia de tokens} → (Parser) → {árvore abstrata} → (Emitter) → {código intermediário} → (Builder)
+(lexer) → {tokens} → (parser) → {árvore} → (emitter) → {IR} → (builder) │ (evaluator)
 ```
 
----
+Entre parênteses estão as **fases**; entre chaves, os **artefatos**. E nenhum artefato tem
+pacote próprio: a cadeia de tokens mora no `lexer`, a árvore no `parser`, o IR no `emitter`.
 
-## O que o desenho já diz
+É daí que vem o acoplamento. Não é o builder querendo conhecer o emitter — é **o artefato
+guardado dentro de quem o produziu**. Enquanto o IR morar no emitter, quem lê IR importa o
+emitter.
 
-Vale reparar no que esse encadeamento nomeia. Entre parênteses estão as **fases**; entre
-chaves, os **artefatos**. São coisas de naturezas diferentes, e hoje as chaves não existem
-como pacote: a cadeia de tokens mora no `lexer`, a árvore mora no `parser`, o código
-intermediário mora no `emitter`.
-
-É daí que vem o acoplamento. Não é o `builder` querendo conhecer o `emitter` — é o artefato
-que ele lê estar guardado dentro de quem o produziu. Enquanto o IR morar no emitter, quem lê
-IR importa o emitter.
-
-**Injeção sozinha não resolve isso.** Se o Lexer produz uma cadeia de tokens e o Parser a
-consome, os dois precisam nomear esse tipo. Injetar o *comportamento* não elimina o tipo do
-*dado*. Restam dois caminhos:
-
-- **o artefato vira pacote auxiliar** — e a regra 1 já abre essa exceção, porque um auxiliar
-  não conhece nada do projeto;
-- **cada fase declara a interface do que consome**, e o `main` converte — o que, para fatias,
-  é uma cópia a cada fronteira, e para constantes (tags, opcodes) é uma tabela de tradução no
-  `main`, onde um mapa incompleto vira bytecode errado em silêncio em vez de erro de
-  compilação.
-
-O primeiro é o que o encadeamento acima descreve. As chaves viram pacotes.
+**Injeção sozinha não alcança isso.** Se o Lexer produz uma cadeia de tokens e o Parser a
+consome, os dois precisam nomear esse tipo; injetar o *comportamento* não elimina o tipo do
+*dado*. Por isso os artefatos viram uma categoria própria — **wire** — que não conhece nada do
+projeto e pode ser conhecida por todos. As chaves do desenho viram pacotes.
 
 ## O que as regras encontram hoje
 
 | Regra | Estado |
 |---|---|
-| Fase não conhece fase | ✗ `parser→lexer`, `emitter→parser`, `evaluator→emitter`, `builder/evm→emitter` |
+| Nenhum pacote conhece outro | ✗ `parser→lexer`, `emitter→parser`, `evaluator→emitter`, `builder/evm→emitter` |
 | Injeção só no `main` | ✗ quatro lugares montam fases, e **só um é `main`** |
-| I/O só no hosting | ✗ o evaluator recebe um `io.Writer` e **escreve durante a avaliação** |
-| Erro no hosting | ✓ as fases devolvem erro, não escrevem |
+| I/O só em hosting | ✗ o evaluator escreve durante a avaliação; `logger` escreve e chama `os.Exit(2)` |
+| Erro em hosting | ✗ o `logger` encerra o processo por conta própria |
 
-Os quatro lugares que montam fases:
+Quem monta fases hoje:
 
 | Onde | Pacote | Monta |
 |---|---|---|
@@ -72,68 +49,61 @@ Os quatro lugares que montam fases:
 E o `builder/evm` nomeia **33 constantes de opcode** do emitter. Não é a forma que o prende —
 é o vocabulário.
 
-## A regra 2 encontra o que ninguém tinha olhado
+## As etapas
 
-O evaluator guarda um `io.Writer` e os builtins de print escrevem nele **enquanto o programa
-roda**. Foi injetado pelo host, o que atende a regra 4, mas não a 2: é I/O dentro de um pacote
-vital.
+Artefatos primeiro, montagem por último. As três primeiras tiram a interdependência **sem
+tocar em assinatura de host**, o que faz a quarta — que atravessa o projeto — ficar bem menor.
 
-É o mesmo problema que tirou os loggers de dentro das fases, e o roadmap já registra a versão
-dele que sobrou — o traço do evaluator só volta se ele **devolver** o traço em vez de escrever.
-Com a regra 2 escrita assim, o print cai no mesmo lugar: um evaluator puro devolveria o que o
-programa disse, e quem escreve seria o host.
+**1. O IR vira `wire`.** `Instruction` e os opcodes saem do `emitter`. É o artefato com mais
+consumidores — `builder/evm`, `evaluator`, `internal/cli`, `internal/trace`, `repl` — e o mais
+barato de mover: 37 + 41 linhas de declaração, sem comportamento. Depois disso, `emitter`,
+`evaluator` e `builder/evm` dependem do mesmo pacote e de nenhum outro.
 
-Isso tem um custo que precisa ser dito: hoje o print sai **na hora**, no meio da execução. Um
-evaluator que devolve tudo no fim muda o que o usuário vê num programa longo, e num REPL muda
-quando a linha aparece.
+**2. A árvore vira `wire`.** Mesmo desenho, custo maior: o emitter faz `switch` sobre vinte e
+um tipos concretos de nó.
 
-## Proposta
+**3. A cadeia de tokens vira `wire`.** `Token` e as tags saem do `lexer`.
 
-**Primeiro os artefatos, depois a montagem.**
+**4. `logger` vira util de formatação.** Hoje ele escreve em `os.Stderr` e chama `os.Exit(2)`
+— um pacote decidindo o fim do processo. Passa a devolver a mensagem formatada; cada hosting
+escreve, e o `os.Exit` sobe para `cmd/*`. É a etapa que conserta a regra 3.
 
-**Etapa 1 — o código intermediário vira pacote.** `Instruction` e os opcodes saem do `emitter`
-para um auxiliar (`ir`, ou o nome que se escolher). É o artefato com mais consumidores —
-`builder/evm`, `evaluator`, `internal/cli`, `internal/trace`, `repl` — e o mais barato de
-mover: `opcodes.go` tem 37 linhas e `instruction.go` 41, só declaração, sem comportamento.
-Depois disso, `emitter → ir`, `evaluator → ir`, `builder/evm → ir`, e nenhuma fase importa
-outra fase por causa do IR.
+**5. `fileutil`, `manifest` e `internal/trace` viram `shared`.** Eles servem a camada de
+hosting, não uma interação. Util não toca no mundo; esses três tocam.
 
-**Etapa 2 — a árvore vira pacote.** Mesmo desenho, custo bem maior: o emitter faz `switch`
-sobre vinte e um tipos concretos de nó. Vale fazer depois da etapa 1, com o desenho já visto
-de pé.
+**6. A montagem sobe para o `main`.** Cada host declara a interface do que precisa e o `main`
+injeta as fases prontas. É a etapa que muda mais assinatura: `internal/cli` deixa de importar
+`lexer`, `parser` e `emitter`.
 
-**Etapa 3 — a cadeia de tokens vira pacote.** `Token` e as tags saem do `lexer`.
+**7. O evaluator devolve o que o programa disse.** Os builtins de print param de escrever. Duas
+coisas a decidir junto, e nenhuma é detalhe:
 
-**Etapa 4 — a montagem sobe para o `main`.** Cada host declara a interface do que precisa e o
-`main` injeta as fases prontas. É a etapa que muda mais assinatura: `internal/cli` deixa de
-importar `lexer`, `parser` e `emitter`, e passa a receber o que compila.
+- a saída tem que voltar **mesmo quando a avaliação falha** — um programa que imprime três
+  linhas e depois estoura não pode perder as três;
+- o usuário deixa de ver a saída **na hora**. Num programa longo, e principalmente no REPL,
+  muda quando a linha aparece.
 
-**Etapa 5 — o evaluator devolve o que o programa disse**, em vez de escrever. Depois de
-decidir o que fazer com a saída na hora certa.
+## Consequência para o que já foi feito
 
-A ordem importa: as etapas 1 a 3 tiram a interdependência sem mexer em assinatura de host. A
-4 é a que atravessa o projeto inteiro, e fica muito mais fácil quando os artefatos já têm casa.
-
-## O que já foi resolvido
-
-No próprio #38: o `Warnings()` do builder devolvia `emitter.Warning`, ou seja, o backend
-falava de si mesmo no vocabulário da fase anterior. O builder passou a ter o seu, e o host
-junta os dois para imprimir.
+No #38 o `Warnings()` do builder deixou de devolver `emitter.Warning` e ganhou um tipo próprio,
+com o host convertendo os dois. **Com `wire`, isso encolhe**: aviso é dado que atravessa da
+fase para o host, ou seja, é wire. Um `wire.Warning` só, e nenhuma conversão. O conserto do #38
+continua certo sob a regra que existia na época; a etapa 1 o simplifica.
 
 ## O que não é problema
 
-O `main` importar tudo é o desenho. E um pacote auxiliar ser importado por qualquer um é a
-exceção da regra 1 — é o que torna os artefatos possíveis.
+O `main` importar tudo é o desenho. E wire e util serem importados por qualquer um é a exceção
+que torna os artefatos possíveis — sem ela, nada disso fecha.
 
 ## Perguntas em aberto
 
-1. **Nome dos pacotes de artefato.** `ir`, `ast`, `token`? Ou um `contract/` com os três
-   dentro?
+1. **Nome dos pacotes.** `wire/ir`, `wire/ast`, `wire/token` — um pacote por artefato, para
+   que o builder não importe a árvore junto com o IR.
 2. **O que viaja junto com o IR?** `Program`, `Expression` e `Label` moram no emitter e
-   atravessam para o host. `ResolveOpCode` e `Format` são apresentação — talvez pertençam ao
-   `internal/trace`.
-3. **`internal/cli` continua existindo?** Ele é host mas não é `main`. Ou ele passa a receber
-   tudo injetado, ou o que ele faz sobe para `cmd/aurora`.
-4. **O print sai na hora ou no fim?** A regra 2 pede que o evaluator devolva; o usuário hoje vê
+   atravessam para o host: são wire. `Format` desenha uma instrução para humano — é
+   apresentação, e vai para `internal/trace`. `ResolveOpCode` dá nome a um opcode: dá para
+   argumentar que o nome é parte do vocabulário e fica no wire.
+3. **`internal/cli` continua existindo?** Ele é hosting mas não é `main`. Ou recebe tudo
+   injetado, ou o que ele faz sobe para `cmd/aurora`.
+4. **O print sai na hora ou no fim?** A regra pede que o evaluator devolva; o usuário hoje vê
    sair no meio da execução.
-5. **O LSP e o playground também?** Os dois montam fases; o playground já é `main`, o LSP não.

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -1,0 +1,125 @@
+# Uma fase importa a anterior; a premissa diz que não deveria
+
+**Estado:** proposta · **Data:** 2026-08-17
+
+Veio do review do PR #38: o `builder/evm` importa o `emitter`. Ficou como está naquele PR, e
+o problema está registrado aqui.
+
+Tudo abaixo foi medido no código.
+
+---
+
+## As duas leituras da mesma regra
+
+O `CLAUDE.md` diz duas coisas que podem ser lidas como diferentes.
+
+A **premissa 2**: *um pacote vital ou auxiliar não conhece o resto do projeto — a ponto de
+alguém pegar uma parte e construir outro compilador.*
+
+A **tabela**, logo abaixo:
+
+| kind | who | may depend on |
+|---|---|---|
+| phase | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | **earlier phases**, auxiliaries |
+
+Uma proíbe conhecer o resto do projeto; a outra autoriza conhecer as fases anteriores. Hoje o
+código segue a tabela:
+
+```
+lexer        → (nada)
+parser       → lexer
+emitter      → lexer, parser
+evaluator    → lexer, parser, emitter
+builder/evm  → lexer, parser, emitter
+```
+
+Isso não é recente nem é de um pacote só: é a forma do projeto desde fevereiro.
+
+## O que está acoplado, exatamente
+
+Duas coisas bem diferentes, que vale separar antes de decidir:
+
+| | O que é | Exemplo |
+|---|---|---|
+| **A forma** | a interface do dado que atravessa | `[]emitter.Instruction`, `parser.Node`, `[]lexer.Token` |
+| **O vocabulário** | o significado, em constantes | `emitter.OpAdd`, `lexer.TagSum`, os tipos concretos de nó |
+
+O `builder/evm` nomeia **33 constantes de opcode** do emitter. Não é a forma que o prende ao
+emitter — é o significado.
+
+E o IR não tem um consumidor, tem cinco: `builder/evm`, `evaluator`, `internal/cli`,
+`internal/trace` e `repl`. Ele já se comporta como contrato público; só não mora num lugar
+que diga isso.
+
+## As opções
+
+**1. Manter, e escrever que o IR é o contrato.** Custo zero. O compilador continua acusando
+quando um opcode muda de número. Perde-se a premissa como está escrita: ninguém pega o
+`builder/evm` sozinho, porque leva o `emitter` junto.
+
+**2. Injetar só a forma.** Cada fase declara a interface que consome; o host converte as
+fatias, já que Go não converte `[]emitter.Instruction` em `[]evm.Instruction`. Parece
+progresso e não é: as 33 constantes continuam vindo do emitter. É a opção que dá trabalho e
+não entrega a premissa.
+
+**3. Injetar forma e significado.** O host passa a tabela que liga o vocabulário do IR às
+operações do backend:
+
+```go
+evm.NewBuilder(insts, evm.Options{
+    Writers: map[byte]evm.WriteFunc{emitter.OpAdd: evm.WriteAdd, ...},
+})
+```
+
+Entrega a premissa: o builder deixa de nomear o emitter. Custa caro — a tabela migra para o
+host, e o `Lowering` também classifica por opcode (`IsOperand`, `IsBinaryValueConsumer`), então
+precisa do mesmo tratamento. E tem um preço que não é de linhas: **hoje um opcode renomeado é
+erro de compilação; com tabela injetada vira mapa incompleto e bytecode errado em silêncio.**
+
+**4. Tirar o contrato de dentro do emitter.** `Instruction` e os opcodes viram um pacote
+auxiliar — `ir`, ou o nome que se escolher — que não conhece nada do projeto. Aí:
+
+```
+emitter      → ir
+evaluator    → ir
+builder/evm  → ir
+```
+
+Nenhuma fase importa outra fase, sem cerimônia de injeção e sem perder a checagem em tempo de
+compilação. É o desenho que a biblioteca padrão do Go usa: `go/token` e `go/ast` existem
+separados de `go/parser` justamente porque são o contrato, não a fase.
+
+O tamanho: `emitter/opcodes.go` tem 37 linhas e `emitter/instruction.go` tem 41 — declarações,
+sem comportamento. Mover é barato; o que custa é atualizar os cinco consumidores e decidir o
+que mais vai junto.
+
+## Recomendação
+
+**Opção 4, começando pelo IR.** É a que torna a premissa verdadeira em vez de negociada, e a
+única que faz isso sem trocar erro de compilação por erro de silêncio.
+
+A AST (`parser.Node` e os tipos de nó que o emitter percorre) tem o mesmo problema e é bem
+maior — o emitter faz `switch` sobre vinte e um tipos concretos. Vale decidir depois, com o IR
+já fora, para ver se o mesmo desenho se sustenta.
+
+## O que já foi resolvido
+
+No próprio #38, um acoplamento que não era desse tipo: o `Warnings()` do builder devolvia
+`emitter.Warning`, ou seja, o backend falava de si mesmo no vocabulário da fase anterior. O
+builder passou a ter o seu próprio, e o host — que pode depender de tudo — é quem junta os
+dois para imprimir.
+
+## O que não é problema
+
+O host importar todas as fases é o desenho, não um desvio: `cmd/*`, `repl`, `internal/cli` e
+`lsp` existem para montar as peças, e nada depende deles.
+
+## Perguntas em aberto
+
+1. **Nome do pacote.** `ir`, `bytecode`, `instruction`?
+2. **O que mais vai junto?** `Program`, `Expression` e `Label` moram no emitter e atravessam
+   para o host. `ResolveOpCode` e `Format` são apresentação — talvez fiquem no `internal/trace`.
+3. **Vale para a AST?** Mesmo problema, custo muito maior.
+4. **Fica escrito onde?** Se a resposta for a opção 1, a premissa 2 precisa ser reescrita para
+   dizer o que a tabela já diz. Se for a 4, a tabela é que muda: fase depende de auxiliares e
+   de contratos, nunca de outra fase.

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -1,125 +1,139 @@
-# Uma fase importa a anterior; a premissa diz que não deveria
+# Fases não se conhecem: o que isso exige do projeto
 
 **Estado:** proposta · **Data:** 2026-08-17
 
-Veio do review do PR #38: o `builder/evm` importa o `emitter`. Ficou como está naquele PR, e
-o problema está registrado aqui.
+Veio do review do PR #38 — o `builder/evm` importa o `emitter` — e cresceu quando as regras
+foram fixadas. Fica registrado aqui o que elas exigem e o que elas encontram no código de hoje.
 
-Tudo abaixo foi medido no código.
+Tudo abaixo foi medido.
 
 ---
 
-## As duas leituras da mesma regra
+## As regras, como ficaram
 
-O `CLAUDE.md` diz duas coisas que podem ser lidas como diferentes.
+1. **Pacote não tem interdependência com pacote.** O que ligaria um ao outro se resolve por
+   injeção de dependência. **Exceto pacotes auxiliares.**
+2. **Pacote vital é puro:** sem I/O, e sem processamento que não devolva nada.
+3. **Erro se trata na camada de hosting.** Nada de erro resolvido magicamente dentro de um
+   pacote.
+4. **I/O só na camada de hosting, e injeção só em arquivos do pacote `main`.** Nenhum
+   entrelaçamento entre vitais, nem entre hosting e vital, que não seja por injeção.
 
-A **premissa 2**: *um pacote vital ou auxiliar não conhece o resto do projeto — a ponto de
-alguém pegar uma parte e construir outro compilador.*
+E o encadeamento das fases:
 
-A **tabela**, logo abaixo:
+```
+(Lexer) → {cadeia de tokens} → (Parser) → {árvore abstrata} → (Emitter) → {código intermediário} → (Builder)
+```
 
-| kind | who | may depend on |
+---
+
+## O que o desenho já diz
+
+Vale reparar no que esse encadeamento nomeia. Entre parênteses estão as **fases**; entre
+chaves, os **artefatos**. São coisas de naturezas diferentes, e hoje as chaves não existem
+como pacote: a cadeia de tokens mora no `lexer`, a árvore mora no `parser`, o código
+intermediário mora no `emitter`.
+
+É daí que vem o acoplamento. Não é o `builder` querendo conhecer o `emitter` — é o artefato
+que ele lê estar guardado dentro de quem o produziu. Enquanto o IR morar no emitter, quem lê
+IR importa o emitter.
+
+**Injeção sozinha não resolve isso.** Se o Lexer produz uma cadeia de tokens e o Parser a
+consome, os dois precisam nomear esse tipo. Injetar o *comportamento* não elimina o tipo do
+*dado*. Restam dois caminhos:
+
+- **o artefato vira pacote auxiliar** — e a regra 1 já abre essa exceção, porque um auxiliar
+  não conhece nada do projeto;
+- **cada fase declara a interface do que consome**, e o `main` converte — o que, para fatias,
+  é uma cópia a cada fronteira, e para constantes (tags, opcodes) é uma tabela de tradução no
+  `main`, onde um mapa incompleto vira bytecode errado em silêncio em vez de erro de
+  compilação.
+
+O primeiro é o que o encadeamento acima descreve. As chaves viram pacotes.
+
+## O que as regras encontram hoje
+
+| Regra | Estado |
+|---|---|
+| Fase não conhece fase | ✗ `parser→lexer`, `emitter→parser`, `evaluator→emitter`, `builder/evm→emitter` |
+| Injeção só no `main` | ✗ quatro lugares montam fases, e **só um é `main`** |
+| I/O só no hosting | ✗ o evaluator recebe um `io.Writer` e **escreve durante a avaliação** |
+| Erro no hosting | ✓ as fases devolvem erro, não escrevem |
+
+Os quatro lugares que montam fases:
+
+| Onde | Pacote | Monta |
 |---|---|---|
-| phase | `lexer`, `parser`, `emitter`, `evaluator`, `builder/evm` | **earlier phases**, auxiliaries |
+| `cmd/playground/main.go` | `main` ✓ | lexer, parser, emitter, evaluator |
+| `internal/cli/compile.go` | `cli` ✗ | lexer, parser, emitter |
+| `repl/repl.go` | `repl` ✗ | lexer, parser, emitter, evaluator |
+| `lsp/textdoc/validator.go` | `textdoc` ✗ | lexer, parser |
 
-Uma proíbe conhecer o resto do projeto; a outra autoriza conhecer as fases anteriores. Hoje o
-código segue a tabela:
+E o `builder/evm` nomeia **33 constantes de opcode** do emitter. Não é a forma que o prende —
+é o vocabulário.
 
-```
-lexer        → (nada)
-parser       → lexer
-emitter      → lexer, parser
-evaluator    → lexer, parser, emitter
-builder/evm  → lexer, parser, emitter
-```
+## A regra 2 encontra o que ninguém tinha olhado
 
-Isso não é recente nem é de um pacote só: é a forma do projeto desde fevereiro.
+O evaluator guarda um `io.Writer` e os builtins de print escrevem nele **enquanto o programa
+roda**. Foi injetado pelo host, o que atende a regra 4, mas não a 2: é I/O dentro de um pacote
+vital.
 
-## O que está acoplado, exatamente
+É o mesmo problema que tirou os loggers de dentro das fases, e o roadmap já registra a versão
+dele que sobrou — o traço do evaluator só volta se ele **devolver** o traço em vez de escrever.
+Com a regra 2 escrita assim, o print cai no mesmo lugar: um evaluator puro devolveria o que o
+programa disse, e quem escreve seria o host.
 
-Duas coisas bem diferentes, que vale separar antes de decidir:
+Isso tem um custo que precisa ser dito: hoje o print sai **na hora**, no meio da execução. Um
+evaluator que devolve tudo no fim muda o que o usuário vê num programa longo, e num REPL muda
+quando a linha aparece.
 
-| | O que é | Exemplo |
-|---|---|---|
-| **A forma** | a interface do dado que atravessa | `[]emitter.Instruction`, `parser.Node`, `[]lexer.Token` |
-| **O vocabulário** | o significado, em constantes | `emitter.OpAdd`, `lexer.TagSum`, os tipos concretos de nó |
+## Proposta
 
-O `builder/evm` nomeia **33 constantes de opcode** do emitter. Não é a forma que o prende ao
-emitter — é o significado.
+**Primeiro os artefatos, depois a montagem.**
 
-E o IR não tem um consumidor, tem cinco: `builder/evm`, `evaluator`, `internal/cli`,
-`internal/trace` e `repl`. Ele já se comporta como contrato público; só não mora num lugar
-que diga isso.
+**Etapa 1 — o código intermediário vira pacote.** `Instruction` e os opcodes saem do `emitter`
+para um auxiliar (`ir`, ou o nome que se escolher). É o artefato com mais consumidores —
+`builder/evm`, `evaluator`, `internal/cli`, `internal/trace`, `repl` — e o mais barato de
+mover: `opcodes.go` tem 37 linhas e `instruction.go` 41, só declaração, sem comportamento.
+Depois disso, `emitter → ir`, `evaluator → ir`, `builder/evm → ir`, e nenhuma fase importa
+outra fase por causa do IR.
 
-## As opções
+**Etapa 2 — a árvore vira pacote.** Mesmo desenho, custo bem maior: o emitter faz `switch`
+sobre vinte e um tipos concretos de nó. Vale fazer depois da etapa 1, com o desenho já visto
+de pé.
 
-**1. Manter, e escrever que o IR é o contrato.** Custo zero. O compilador continua acusando
-quando um opcode muda de número. Perde-se a premissa como está escrita: ninguém pega o
-`builder/evm` sozinho, porque leva o `emitter` junto.
+**Etapa 3 — a cadeia de tokens vira pacote.** `Token` e as tags saem do `lexer`.
 
-**2. Injetar só a forma.** Cada fase declara a interface que consome; o host converte as
-fatias, já que Go não converte `[]emitter.Instruction` em `[]evm.Instruction`. Parece
-progresso e não é: as 33 constantes continuam vindo do emitter. É a opção que dá trabalho e
-não entrega a premissa.
+**Etapa 4 — a montagem sobe para o `main`.** Cada host declara a interface do que precisa e o
+`main` injeta as fases prontas. É a etapa que muda mais assinatura: `internal/cli` deixa de
+importar `lexer`, `parser` e `emitter`, e passa a receber o que compila.
 
-**3. Injetar forma e significado.** O host passa a tabela que liga o vocabulário do IR às
-operações do backend:
+**Etapa 5 — o evaluator devolve o que o programa disse**, em vez de escrever. Depois de
+decidir o que fazer com a saída na hora certa.
 
-```go
-evm.NewBuilder(insts, evm.Options{
-    Writers: map[byte]evm.WriteFunc{emitter.OpAdd: evm.WriteAdd, ...},
-})
-```
-
-Entrega a premissa: o builder deixa de nomear o emitter. Custa caro — a tabela migra para o
-host, e o `Lowering` também classifica por opcode (`IsOperand`, `IsBinaryValueConsumer`), então
-precisa do mesmo tratamento. E tem um preço que não é de linhas: **hoje um opcode renomeado é
-erro de compilação; com tabela injetada vira mapa incompleto e bytecode errado em silêncio.**
-
-**4. Tirar o contrato de dentro do emitter.** `Instruction` e os opcodes viram um pacote
-auxiliar — `ir`, ou o nome que se escolher — que não conhece nada do projeto. Aí:
-
-```
-emitter      → ir
-evaluator    → ir
-builder/evm  → ir
-```
-
-Nenhuma fase importa outra fase, sem cerimônia de injeção e sem perder a checagem em tempo de
-compilação. É o desenho que a biblioteca padrão do Go usa: `go/token` e `go/ast` existem
-separados de `go/parser` justamente porque são o contrato, não a fase.
-
-O tamanho: `emitter/opcodes.go` tem 37 linhas e `emitter/instruction.go` tem 41 — declarações,
-sem comportamento. Mover é barato; o que custa é atualizar os cinco consumidores e decidir o
-que mais vai junto.
-
-## Recomendação
-
-**Opção 4, começando pelo IR.** É a que torna a premissa verdadeira em vez de negociada, e a
-única que faz isso sem trocar erro de compilação por erro de silêncio.
-
-A AST (`parser.Node` e os tipos de nó que o emitter percorre) tem o mesmo problema e é bem
-maior — o emitter faz `switch` sobre vinte e um tipos concretos. Vale decidir depois, com o IR
-já fora, para ver se o mesmo desenho se sustenta.
+A ordem importa: as etapas 1 a 3 tiram a interdependência sem mexer em assinatura de host. A
+4 é a que atravessa o projeto inteiro, e fica muito mais fácil quando os artefatos já têm casa.
 
 ## O que já foi resolvido
 
-No próprio #38, um acoplamento que não era desse tipo: o `Warnings()` do builder devolvia
-`emitter.Warning`, ou seja, o backend falava de si mesmo no vocabulário da fase anterior. O
-builder passou a ter o seu próprio, e o host — que pode depender de tudo — é quem junta os
-dois para imprimir.
+No próprio #38: o `Warnings()` do builder devolvia `emitter.Warning`, ou seja, o backend
+falava de si mesmo no vocabulário da fase anterior. O builder passou a ter o seu, e o host
+junta os dois para imprimir.
 
 ## O que não é problema
 
-O host importar todas as fases é o desenho, não um desvio: `cmd/*`, `repl`, `internal/cli` e
-`lsp` existem para montar as peças, e nada depende deles.
+O `main` importar tudo é o desenho. E um pacote auxiliar ser importado por qualquer um é a
+exceção da regra 1 — é o que torna os artefatos possíveis.
 
 ## Perguntas em aberto
 
-1. **Nome do pacote.** `ir`, `bytecode`, `instruction`?
-2. **O que mais vai junto?** `Program`, `Expression` e `Label` moram no emitter e atravessam
-   para o host. `ResolveOpCode` e `Format` são apresentação — talvez fiquem no `internal/trace`.
-3. **Vale para a AST?** Mesmo problema, custo muito maior.
-4. **Fica escrito onde?** Se a resposta for a opção 1, a premissa 2 precisa ser reescrita para
-   dizer o que a tabela já diz. Se for a 4, a tabela é que muda: fase depende de auxiliares e
-   de contratos, nunca de outra fase.
+1. **Nome dos pacotes de artefato.** `ir`, `ast`, `token`? Ou um `contract/` com os três
+   dentro?
+2. **O que viaja junto com o IR?** `Program`, `Expression` e `Label` moram no emitter e
+   atravessam para o host. `ResolveOpCode` e `Format` são apresentação — talvez pertençam ao
+   `internal/trace`.
+3. **`internal/cli` continua existindo?** Ele é host mas não é `main`. Ou ele passa a receber
+   tudo injetado, ou o que ele faz sobe para `cmd/aurora`.
+4. **O print sai na hora ou no fim?** A regra 2 pede que o evaluator devolva; o usuário hoje vê
+   sair no meio da execução.
+5. **O LSP e o playground também?** Os dois montam fases; o playground já é `main`, o LSP não.


### PR DESCRIPTION
From your review of #38, grown into the project's architecture. This PR writes the decision down and records the migration; **no code moves yet**.

## Two layers, five kinds of package

```
(lexer) → {tokens} → (parser) → {tree} → (emitter) → {IR} → (builder) │ (evaluator)
```

Between parentheses are the phases; between braces, what crosses. That drawing is the architecture: **parentheses are vital, braces are wire**.

| kind | what it is | imports |
|---|---|---|
| **vital** | a step of the pipeline | wire, util |
| **wire** | what crosses a boundary: tokens, tree, IR, warnings | nothing of the project |
| **util** | reusable behaviour that never touches the world | nothing of the project |
| **hosting** | one interaction: CLI, REPL, LSP | wire, util, shared |
| **shared** | serves the hosting *layer*, not one interaction | wire, util |

**Why five and not three.** Two of them had rules of their own that were being borrowed from a neighbour:

- **wire is not util.** A util is behaviour you may reuse and nobody is obliged to. A wire package is *data crossing a boundary* — two phases sharing exactly that type is the point, and a phase declaring its own version of it is the mistake the kind exists to prevent. It also explains why **injection alone cannot fix the coupling**: if the lexer produces a chain of tokens and the parser consumes it, both must name that type; injecting behaviour does not remove the type of the data.
- **shared is not hosting.** A host serves one interaction and is a leaf. A shared package serves the layer, may be imported by any host, may touch the world, and must not know which interaction is using it — the second half being what keeps it from becoming the drawer where cohesion dies.

## The rules that follow

1. **No package knows another** — except wire and util, which know nothing of the project and may be known by all.
2. **A vital package is pure**: no I/O, nothing done that is not returned.
3. **Errors are resolved in hosting.** A package returns an error; it never writes one, and never ends the process.
4. **I/O in hosting, injection only in `main`.**

**A sub-package has the kind of its parent**, and one that needs I/O takes the port and calls it rather than deciding to write.

## What the rules find today

| Rule | State |
|---|---|
| No package knows another | ✗ every phase imports the one before it |
| Injection only in `main` | ✗ four places assemble phases, **only one is `main`** |
| I/O only in hosting | ✗ the evaluator writes while the program runs; `logger` writes **and calls `os.Exit(2)`** |
| Errors in hosting | ✗ `logger` ends the process on its own |

Both documents say so plainly and point at the RFC. A standard describing a repository that does not exist teaches people to ignore standards.

## The migration, in the RFC

Artefacts first, assembly last — the first steps remove the interdependency **without touching a host signature**, which makes the last one far smaller.

1. the IR becomes `wire` (37 + 41 lines of declarations, five consumers)
2. the tree becomes `wire`
3. the token chain becomes `wire`
4. `logger` becomes a formatting util — and `os.Exit` moves to `cmd/*`
5. `fileutil`, `manifest`, `internal/trace` become `shared`
6. assembly moves to `main`
7. the evaluator returns what the program said

Step 7 carries two decisions that are not details: the output must come back **even when evaluation fails**, and the user stops seeing output *as it happens* — which changes the REPL.

## Two other things this settles

- **The evaluator is vital.** It consumes the IR the way the builder does — one runs it, the other writes bytecode. So purity reaches it.
- **The EVM backend goes back on stand-by** while this lands. What it keeps is the differential harness, so whatever is written next is provable rather than believed.

The RFC also records that `wire` **simplifies the fix from #38**: a warning crosses from a phase to a host, so it is wire — one `wire.Warning`, no conversion.