### PR TITLE
The IR moves to wire/ir

### DIFF
--- a/.claude/agents/aurora-standards.md
+++ b/.claude/agents/aurora-standards.md
@@ -33,14 +33,14 @@ Between parentheses are the phases; between braces, what crosses between them. T
 | kind | what it is | imports | is imported by |
 |---|---|---|---|
 | **vital** | a step of the pipeline: `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
-| **wire** | what crosses a boundary: the token chain, the tree, the IR, a warning | **nothing of the project** | everyone |
+| **wire** | what crosses a boundary: the token chain, the tree, the IR, a warning | util, and nothing else of the project | everyone |
 | **util** | behaviour worth reusing that never touches the world: `byteutil`, `logger` as a formatter | **nothing of the project** | everyone |
 | **hosting** | one kind of interaction: `internal/cli`, `repl`, `lsp` | wire, util, shared | `main` |
 | **shared** | serves the hosting *layer*, not one interaction: `fileutil`, `manifest`, `internal/trace` | wire, util | hosting, `main` |
 
 The two that are easy to confuse:
 
-- **wire against util.** A util is behaviour you may reuse and nobody is obliged to. A wire package is *data crossing a boundary*, and two phases sharing exactly that type is the point — a phase declaring its own version of it is the mistake the kind exists to prevent. Wire holds the shape and the vocabulary (the types, the constructors, the constants) and never an algorithm: what *interprets* the vocabulary — laying an instruction out for a human — is presentation and belongs to `internal/trace`.
+- **wire against util.** A util is behaviour you may reuse and nobody is obliged to. A wire package is *data crossing a boundary*, and two phases sharing exactly that type is the point — a phase declaring its own version of it is the mistake the kind exists to prevent. Wire holds the shape and the vocabulary: the types, the constructors, the constants, and **how they are written down** — spelling the vocabulary out is part of the vocabulary, the way a token knows how to spell itself. What is *not* wire is deciding to show it and choosing where it goes: that is a host's, and `internal/trace` is where it lives. A wire package may lean on a util to do its spelling, and on nothing else of the project.
 - **hosting against shared.** A hosting package serves one interaction and is a leaf: only `main` depends on it. A shared package serves the layer, may be imported by any host, may touch the world, and **must not know which interaction is using it**. That last half is what keeps it from becoming the drawer where cohesion goes to die.
 
 ### The four rules

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ Between parentheses are the phases; between braces, what crosses between them.
 | kind | who | imports | is imported by |
 |---|---|---|---|
 | **vital** | `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
-| **wire** | what crosses: tokens, tree, IR, warnings | **nothing of the project** | everyone |
+| **wire** | what crosses: tokens, tree, IR, warnings | util, and nothing else of the project | everyone |
 | **util** | reusable behaviour that never touches the world: `byteutil`, `logger` | **nothing of the project** | everyone |
 | **hosting** | one interaction: `internal/cli`, `repl`, `lsp` | wire, util, shared | `main` |
 | **shared** | serves the hosting layer, not one interaction: `fileutil`, `manifest`, `internal/trace` | wire, util | hosting, `main` |

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -11,7 +11,7 @@ import (
 	"io"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 const (
@@ -38,12 +38,12 @@ type RuntimeCode struct {
 type Builder struct {
 	tapeSize     int
 	cursor       int
-	insts        []emitter.Instruction
+	insts        []ir.Instruction
 	operands     [][]byte
 	identManager *IdentManager
 }
 
-func (b *Builder) GetInstruction() emitter.Instruction {
+func (b *Builder) GetInstruction() ir.Instruction {
 	return b.insts[b.cursor]
 }
 
@@ -57,7 +57,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 		return nil, cursor, false
 	}
 	inst := b.insts[cursor]
-	if inst.GetOpCode() != emitter.OpDefer {
+	if inst.GetOpCode() != ir.OpDefer {
 		return nil, cursor, false
 	}
 
@@ -81,7 +81,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 		return nil, cursor, false
 	}
 	selectorInst := b.insts[end]
-	if selectorInst.GetOpCode() != emitter.OpIdent {
+	if selectorInst.GetOpCode() != ir.OpIdent {
 		return nil, cursor, false
 	}
 	selector := selectorInst.GetLeft()
@@ -98,7 +98,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 
 func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	dispatchers := make([]Dispatcher, 0)
-	rootinsts := make([]emitter.Instruction, 0)
+	rootinsts := make([]ir.Instruction, 0)
 	offset := 0
 
 	for b.cursor < len(b.insts) {
@@ -163,7 +163,7 @@ type NewBuilderOptions struct {
 	TapeSize int
 }
 
-func NewBuilder(insts []emitter.Instruction, options NewBuilderOptions) *Builder {
+func NewBuilder(insts []ir.Instruction, options NewBuilderOptions) *Builder {
 	return &Builder{
 		tapeSize:     byteutil.TapeSize(options.TapeSize),
 		operands:     make([][]byte, 0),

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 type PickedRuntimeCodeExpectation struct {
@@ -179,7 +180,7 @@ func TestPickRuntimeCode(t *testing.T) {
 func TestPickDeferAtCursor(t *testing.T) {
 	cases := []struct {
 		Name                 string
-		Insts                []emitter.Instruction
+		Insts                []ir.Instruction
 		Cursor               int
 		Offset               int
 		WantOK               bool
@@ -190,11 +191,11 @@ func TestPickDeferAtCursor(t *testing.T) {
 	}{
 		{
 			Name: "valid_defer",
-			Insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpDefer, []byte("ret"), byteutil.FromUint64(2)),
-				emitter.NewInstruction([]byte("1"), emitter.OpBeginScope, nil, nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpReturn, nil, nil),
-				emitter.NewInstruction([]byte("3"), emitter.OpIdent, []byte("f"), []byte("0")),
+			Insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpDefer, []byte("ret"), byteutil.FromUint64(2)),
+				ir.NewInstruction([]byte("1"), ir.OpBeginScope, nil, nil),
+				ir.NewInstruction([]byte("2"), ir.OpReturn, nil, nil),
+				ir.NewInstruction([]byte("3"), ir.OpIdent, []byte("f"), []byte("0")),
 			},
 			Cursor:               0,
 			Offset:               0,
@@ -206,8 +207,8 @@ func TestPickDeferAtCursor(t *testing.T) {
 		},
 		{
 			Name: "not_op_defer",
-			Insts: []emitter.Instruction{
-				emitter.NewInstruction(nil, emitter.OpBeginScope, nil, nil),
+			Insts: []ir.Instruction{
+				ir.NewInstruction(nil, ir.OpBeginScope, nil, nil),
 			},
 			Cursor:         0,
 			Offset:         0,
@@ -216,11 +217,11 @@ func TestPickDeferAtCursor(t *testing.T) {
 		},
 		{
 			Name: "defer_without_op_ident_after",
-			Insts: []emitter.Instruction{
-				emitter.NewInstruction(nil, emitter.OpDefer, nil, byteutil.FromUint64(2)),
-				emitter.NewInstruction(nil, emitter.OpBeginScope, nil, nil),
-				emitter.NewInstruction(nil, emitter.OpReturn, nil, nil),
-				emitter.NewInstruction(nil, emitter.OpAdd, nil, nil),
+			Insts: []ir.Instruction{
+				ir.NewInstruction(nil, ir.OpDefer, nil, byteutil.FromUint64(2)),
+				ir.NewInstruction(nil, ir.OpBeginScope, nil, nil),
+				ir.NewInstruction(nil, ir.OpReturn, nil, nil),
+				ir.NewInstruction(nil, ir.OpAdd, nil, nil),
 			},
 			Cursor:         0,
 			Offset:         0,

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -2,10 +2,10 @@ package evm
 
 import (
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
-func Lowering(insts []emitter.Instruction) []emitter.Instruction {
+func Lowering(insts []ir.Instruction) []ir.Instruction {
 	if len(insts) == 0 {
 		return insts
 	}
@@ -14,7 +14,7 @@ func Lowering(insts []emitter.Instruction) []emitter.Instruction {
 
 func IsOperand(op byte) bool {
 	switch op {
-	case emitter.OpGetFeed, emitter.OpSave, emitter.OpLoad:
+	case ir.OpGetFeed, ir.OpSave, ir.OpLoad:
 		return true
 	default:
 		return false
@@ -23,7 +23,7 @@ func IsOperand(op byte) bool {
 
 func IsAssociativeOperator(op byte) bool {
 	switch op {
-	case emitter.OpSubtract, emitter.OpDivide:
+	case ir.OpSubtract, ir.OpDivide:
 		return true
 	default:
 		return false
@@ -34,7 +34,7 @@ func IsAssociativeOperator(op byte) bool {
 // Used so we only reorder for Add/Sub/Mul/Div; OpReturn, OpBeginScope, etc. are left as-is and not merged.
 func IsBinaryValueConsumer(op byte) bool {
 	switch op {
-	case emitter.OpAdd, emitter.OpSubtract, emitter.OpMultiply, emitter.OpDivide:
+	case ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide:
 		return true
 	default:
 		return false
@@ -51,7 +51,7 @@ func OperandStackDelta(op byte) int {
 	return 0
 }
 
-func GetOperandStackDeltaDepth(insts []emitter.Instruction) []int {
+func GetOperandStackDeltaDepth(insts []ir.Instruction) []int {
 	depth := make([]int, len(insts)+1)
 	depth[0] = 0
 	for at, inst := range insts {
@@ -60,16 +60,16 @@ func GetOperandStackDeltaDepth(insts []emitter.Instruction) []int {
 	return depth
 }
 
-func ResolveOperandsOrder(insts []emitter.Instruction) []emitter.Instruction {
+func ResolveOperandsOrder(insts []ir.Instruction) []ir.Instruction {
 	if len(insts) < 2 {
 		return insts
 	}
-	operands := make(map[string][]emitter.Instruction, 0)
-	out := make([]emitter.Instruction, 0)
+	operands := make(map[string][]ir.Instruction, 0)
+	out := make([]ir.Instruction, 0)
 	for _, inst := range insts {
 		if IsOperand(inst.GetOpCode()) {
 			label := byteutil.ToHex(inst.GetLabel())
-			operands[label] = []emitter.Instruction{inst}
+			operands[label] = []ir.Instruction{inst}
 			continue
 		}
 
@@ -81,7 +81,7 @@ func ResolveOperandsOrder(insts []emitter.Instruction) []emitter.Instruction {
 		or, okr := operands[lr]
 
 		if IsBinaryValueConsumer(inst.GetOpCode()) && okl && okr {
-			curb := make([]emitter.Instruction, 0)
+			curb := make([]ir.Instruction, 0)
 
 			if IsAssociativeOperator(inst.GetOpCode()) {
 				curb = append(curb, or...)
@@ -100,7 +100,7 @@ func ResolveOperandsOrder(insts []emitter.Instruction) []emitter.Instruction {
 		} else {
 			// OpReturn consumes one value (return value); emit it before Return only when not already in out.
 			// (After a binary op we set out = curb, so the result is already last in out; don't duplicate.)
-			if inst.GetOpCode() == emitter.OpReturn && okr {
+			if inst.GetOpCode() == ir.OpReturn && okr {
 				lastIsBinary := len(out) > 0 && IsBinaryValueConsumer(out[len(out)-1].GetOpCode())
 				if !lastIsBinary {
 					out = append(out, or...)

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 func TestOperandStackDelta(t *testing.T) {
@@ -17,15 +18,15 @@ func TestOperandStackDelta(t *testing.T) {
 		op   byte
 		want int
 	}{
-		{name: "OpGetFeed_push", op: emitter.OpGetFeed, want: 1},
-		{name: "OpSave_push", op: emitter.OpSave, want: 1},
-		{name: "OpLoad_push", op: emitter.OpLoad, want: 1},
-		{name: "OpSubtract_pop2_push1", op: emitter.OpSubtract, want: -1},
-		{name: "OpDivide_pop2_push1", op: emitter.OpDivide, want: -1},
-		{name: "OpBeginScope_neutral", op: emitter.OpBeginScope, want: 0},
-		{name: "OpReturn_neutral", op: emitter.OpReturn, want: 0},
-		{name: "OpIdent_neutral", op: emitter.OpIdent, want: 0},
-		{name: "OpDefer_neutral", op: emitter.OpDefer, want: 0},
+		{name: "OpGetFeed_push", op: ir.OpGetFeed, want: 1},
+		{name: "OpSave_push", op: ir.OpSave, want: 1},
+		{name: "OpLoad_push", op: ir.OpLoad, want: 1},
+		{name: "OpSubtract_pop2_push1", op: ir.OpSubtract, want: -1},
+		{name: "OpDivide_pop2_push1", op: ir.OpDivide, want: -1},
+		{name: "OpBeginScope_neutral", op: ir.OpBeginScope, want: 0},
+		{name: "OpReturn_neutral", op: ir.OpReturn, want: 0},
+		{name: "OpIdent_neutral", op: ir.OpIdent, want: 0},
+		{name: "OpDefer_neutral", op: ir.OpDefer, want: 0},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestOperandStackDelta(t *testing.T) {
 func TestGetOperandStackDeltaDepth(t *testing.T) {
 	cases := []struct {
 		name  string
-		insts []emitter.Instruction
+		insts []ir.Instruction
 		want  []int
 	}{
 		{
@@ -50,56 +51,56 @@ func TestGetOperandStackDeltaDepth(t *testing.T) {
 		},
 		{
 			name: "single_GetArg",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
 			},
 			want: []int{0, 1},
 		},
 		{
 			name: "two_GetArg",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
 			},
 			want: []int{0, 1, 2},
 		},
 		{
 			name: "GetArg_GetArg_Add",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpAdd, []byte("0"), []byte("1")),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpAdd, []byte("0"), []byte("1")),
 			},
 			want: []int{0, 1, 2, 2},
 		},
 		{
 			name: "GetArg_GetArg_Sub",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpSubtract, []byte("0"), []byte("1")),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
 			},
 			want: []int{0, 1, 2, 1},
 		},
 		{
 			name: "GetArg_GetArg_GetArg_Sub_Sub",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpGetFeed, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("3"), emitter.OpSubtract, []byte("0"), []byte("1")),
-				emitter.NewInstruction([]byte("4"), emitter.OpSubtract, []byte("2"), []byte("3")),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpGetFeed, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("3"), ir.OpSubtract, []byte("0"), []byte("1")),
+				ir.NewInstruction([]byte("4"), ir.OpSubtract, []byte("2"), []byte("3")),
 			},
 			want: []int{0, 1, 2, 3, 2, 1},
 		},
 		{
 			name: "BeginScope_GetArg_GetArg_Sub_Return",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction(nil, emitter.OpBeginScope, nil, nil),
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpSubtract, []byte("0"), []byte("1")),
-				emitter.NewInstruction(nil, emitter.OpReturn, nil, nil),
+			insts: []ir.Instruction{
+				ir.NewInstruction(nil, ir.OpBeginScope, nil, nil),
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
+				ir.NewInstruction(nil, ir.OpReturn, nil, nil),
 			},
 			want: []int{0, 0, 1, 2, 1, 1},
 		},
@@ -120,12 +121,12 @@ func TestIsAsociativeOperator(t *testing.T) {
 		op   byte
 		want bool
 	}{
-		{name: "Sub", op: emitter.OpSubtract, want: true},
-		{name: "Div", op: emitter.OpDivide, want: true},
-		{name: "Mul", op: emitter.OpMultiply, want: false},
-		{name: "Add", op: emitter.OpAdd, want: false},
-		{name: "GetArg", op: emitter.OpGetFeed, want: false},
-		{name: "Return", op: emitter.OpReturn, want: false},
+		{name: "Sub", op: ir.OpSubtract, want: true},
+		{name: "Div", op: ir.OpDivide, want: true},
+		{name: "Mul", op: ir.OpMultiply, want: false},
+		{name: "Add", op: ir.OpAdd, want: false},
+		{name: "GetArg", op: ir.OpGetFeed, want: false},
+		{name: "Return", op: ir.OpReturn, want: false},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -141,44 +142,44 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 	cases := []struct {
 		name   string
 		source string
-		want   []emitter.Instruction
+		want   []ir.Instruction
 	}{
 		{
 			name:   "single_inst",
 			source: "feed(0);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
 			},
 		},
 		{
 			name:   "add_no_reorder",
 			source: "feed(0) + feed(1);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("01"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpAdd, []byte("00"), []byte("01")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("01"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("02"), ir.OpAdd, []byte("00"), []byte("01")),
 			},
 		},
 		{
 			name:   "sub_reorder",
 			source: "feed(0) - feed(1);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("01"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpSubtract, []byte("00"), []byte("01")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("01"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("02"), ir.OpSubtract, []byte("00"), []byte("01")),
 			},
 		},
 		{
 			name:   "sub_sub_reorder",
 			source: "feed(0) - feed(1) - feed(2) - feed(3);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("05"), emitter.OpGetFeed, byteutil.FromUint64(3), nil),
-				emitter.NewInstruction([]byte("03"), emitter.OpGetFeed, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("01"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpSubtract, []byte("00"), []byte("01")),
-				emitter.NewInstruction([]byte("04"), emitter.OpSubtract, []byte("02"), []byte("03")),
-				emitter.NewInstruction([]byte("06"), emitter.OpSubtract, []byte("04"), []byte("05")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("05"), ir.OpGetFeed, byteutil.FromUint64(3), nil),
+				ir.NewInstruction([]byte("03"), ir.OpGetFeed, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("01"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("02"), ir.OpSubtract, []byte("00"), []byte("01")),
+				ir.NewInstruction([]byte("04"), ir.OpSubtract, []byte("02"), []byte("03")),
+				ir.NewInstruction([]byte("06"), ir.OpSubtract, []byte("04"), []byte("05")),
 			},
 		},
 		{
@@ -188,47 +189,47 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 			// group division to the right, where the question did not arise.
 			name:   "div_div_reorder",
 			source: "feed(0) / feed(1) / feed(2);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("03"), emitter.OpGetFeed, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("01"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpDivide, []byte("00"), []byte("01")),
-				emitter.NewInstruction([]byte("04"), emitter.OpDivide, []byte("02"), []byte("03")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("03"), ir.OpGetFeed, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("01"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("02"), ir.OpDivide, []byte("00"), []byte("01")),
+				ir.NewInstruction([]byte("04"), ir.OpDivide, []byte("02"), []byte("03")),
 			},
 		},
 		{
 			name:   "div_reorder",
 			source: "feed(0) / feed(1);",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("01"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("00"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpDivide, []byte("00"), []byte("01")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("01"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("00"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("02"), ir.OpDivide, []byte("00"), []byte("01")),
 			},
 		},
 		{
 			name:   "div_and_sub_reorder",
 			source: "1 - 2 / 2 - 1;",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("05"), emitter.OpSave, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpSave, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("01"), emitter.OpSave, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("03"), emitter.OpDivide, []byte("01"), []byte("02")),
-				emitter.NewInstruction([]byte("00"), emitter.OpSave, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("04"), emitter.OpSubtract, []byte("00"), []byte("03")),
-				emitter.NewInstruction([]byte("06"), emitter.OpSubtract, []byte("04"), []byte("05")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("05"), ir.OpSave, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("02"), ir.OpSave, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("01"), ir.OpSave, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("03"), ir.OpDivide, []byte("01"), []byte("02")),
+				ir.NewInstruction([]byte("00"), ir.OpSave, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("04"), ir.OpSubtract, []byte("00"), []byte("03")),
+				ir.NewInstruction([]byte("06"), ir.OpSubtract, []byte("04"), []byte("05")),
 			},
 		},
 		{
 			name:   "sub_and_mult_reorder",
 			source: "6 - 2 * 2 - 1;",
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("05"), emitter.OpSave, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("01"), emitter.OpSave, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("02"), emitter.OpSave, byteutil.FromUint64(2), nil),
-				emitter.NewInstruction([]byte("03"), emitter.OpMultiply, []byte("01"), []byte("02")),
-				emitter.NewInstruction([]byte("00"), emitter.OpSave, byteutil.FromUint64(6), nil),
-				emitter.NewInstruction([]byte("04"), emitter.OpSubtract, []byte("00"), []byte("03")),
-				emitter.NewInstruction([]byte("06"), emitter.OpSubtract, []byte("04"), []byte("05")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("05"), ir.OpSave, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("01"), ir.OpSave, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("02"), ir.OpSave, byteutil.FromUint64(2), nil),
+				ir.NewInstruction([]byte("03"), ir.OpMultiply, []byte("01"), []byte("02")),
+				ir.NewInstruction([]byte("00"), ir.OpSave, byteutil.FromUint64(6), nil),
+				ir.NewInstruction([]byte("04"), ir.OpSubtract, []byte("00"), []byte("03")),
+				ir.NewInstruction([]byte("06"), ir.OpSubtract, []byte("04"), []byte("05")),
 			},
 		},
 	}
@@ -254,7 +255,7 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 			}
 			got := ResolveOperandsOrder(insts)
 			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("\ngot =\n%v \nwant =\n%v", emitter.Format(got), emitter.Format(tc.want))
+				t.Errorf("\ngot =\n%v \nwant =\n%v", ir.Format(got), ir.Format(tc.want))
 			}
 		})
 	}
@@ -263,34 +264,34 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 func TestLowering(t *testing.T) {
 	cases := []struct {
 		name  string
-		insts []emitter.Instruction
-		want  []emitter.Instruction
+		insts []ir.Instruction
+		want  []ir.Instruction
 	}{
 		{
 			name: "no_reordering",
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpAdd, []byte("0"), []byte("1")),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpAdd, []byte("0"), []byte("1")),
 			},
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpAdd, []byte("0"), []byte("1")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpAdd, []byte("0"), []byte("1")),
 			},
 		},
 		{
 			name: "reordering",
 			// Single Sub: we reorder the instruction sequence (GetArg(1), GetArg(0), Sub) so stack order is correct; IR ops unchanged.
-			insts: []emitter.Instruction{
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpSubtract, []byte("0"), []byte("1")),
+			insts: []ir.Instruction{
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
 			},
-			want: []emitter.Instruction{
-				emitter.NewInstruction([]byte("1"), emitter.OpGetFeed, byteutil.FromUint64(1), nil),
-				emitter.NewInstruction([]byte("0"), emitter.OpGetFeed, byteutil.FromUint64(0), nil),
-				emitter.NewInstruction([]byte("2"), emitter.OpSubtract, []byte("0"), []byte("1")),
+			want: []ir.Instruction{
+				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
+				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
+				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
 			},
 		},
 	}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // WritePush emits PUSH<size> with the operand as a tape. The push opcodes are contiguous
@@ -188,59 +188,59 @@ func WriteBodyCode(bs io.Writer, ds []Dispatcher, root *bytes.Buffer) (int, erro
 	return 0, nil
 }
 
-func WriteCode(bs io.Writer, im *IdentManager, insts []emitter.Instruction, tapeSize int) (int, error) {
+func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int) (int, error) {
 	for _, inst := range insts {
 		op := inst.GetOpCode()
 
-		if op == emitter.OpAdd {
+		if op == ir.OpAdd {
 			if _, err := WriteAdd(bs); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpMultiply {
+		if op == ir.OpMultiply {
 			if _, err := WriteMultiply(bs); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpSubtract {
+		if op == ir.OpSubtract {
 			if _, err := WriteSubtract(bs); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpDivide {
+		if op == ir.OpDivide {
 			if _, err := WriteDivide(bs); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpReturn {
+		if op == ir.OpReturn {
 			if _, err := WriteReturn(bs); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpSave {
+		if op == ir.OpSave {
 			if _, err := WriteSave(bs, inst.GetLeft(), tapeSize); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpIdent {
+		if op == ir.OpIdent {
 			if _, err := WriteIdent(bs, im, inst.GetLeft()); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpLoad {
+		if op == ir.OpLoad {
 			if _, err := WriteLoad(bs, im, inst.GetLeft()); err != nil {
 				return 0, err
 			}
 		}
 
-		if op == emitter.OpGetFeed {
+		if op == ir.OpGetFeed {
 			if _, err := WriteGetArg(bs, inst.GetLeft()); err != nil {
 				return 0, err
 			}

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 type Emitter interface {
-	Emit(ast parser.AST) ([]Instruction, error)
+	Emit(ast parser.AST) ([]ir.Instruction, error)
 	EmitProgram(ast parser.AST) (Program, error)
 }
 
@@ -27,7 +28,7 @@ type Expression struct {
 // Program is what a source file compiled to: the instruction stream, where each top-level
 // expression sits inside it, and anything worth saying that did not stop the compilation.
 type Program struct {
-	Instructions []Instruction
+	Instructions []ir.Instruction
 	Expressions  []Expression
 	Warnings     []Warning
 }
@@ -46,12 +47,12 @@ type Label []byte
 
 // printOpCodes maps each reading of a value to the instruction that writes it.
 var printOpCodes = map[parser.PrintFormat]byte{
-	parser.PrintBytes:   OpPrintBytes,
-	parser.PrintChars:   OpPrintChars,
-	parser.PrintDecimal: OpPrintDecimal,
+	parser.PrintBytes:   ir.OpPrintBytes,
+	parser.PrintChars:   ir.OpPrintChars,
+	parser.PrintDecimal: ir.OpPrintDecimal,
 }
 
-func EmitInstruction(tc *int, insts *[]Instruction, expr parser.Node, tapeSize int) Label {
+func EmitInstruction(tc *int, insts *[]ir.Instruction, expr parser.Node, tapeSize int) Label {
 	switch n := expr.(type) {
 	case parser.IdentLiteral:
 		return emitIdentLiteral(tc, insts, n, tapeSize)
@@ -110,11 +111,11 @@ func EmitInstruction(tc *int, insts *[]Instruction, expr parser.Node, tapeSize i
 }
 
 // emitIdentLiteral binds a name to a value.
-func emitIdentLiteral(tc *int, insts *[]Instruction, n parser.IdentLiteral, tapeSize int) Label {
+func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n parser.IdentLiteral, tapeSize int) Label {
 	ll := n.Token.GetMatch()
 	lr := EmitInstruction(tc, insts, n.Value, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpIdent, ll, lr))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpIdent, ll, lr))
 	// A binding has a value like every other expression — the neutral one — and the
 	// label has to come back, or a scope ending in a binding returns the fallback of
 	// a node the emitter did not recognise.
@@ -123,17 +124,17 @@ func emitIdentLiteral(tc *int, insts *[]Instruction, n parser.IdentLiteral, tape
 }
 
 // emitBlockExpression opens a scope and returns the value its body ended with.
-func emitBlockExpression(tc *int, insts *[]Instruction, n parser.BlockExpression, tapeSize int) Label {
+func emitBlockExpression(tc *int, insts *[]ir.Instruction, n parser.BlockExpression, tapeSize int) Label {
 	var l []byte
-	body := make([]Instruction, 0)
+	body := make([]ir.Instruction, 0)
 	for _, ins := range n.Body {
 		l = EmitInstruction(tc, &body, ins, tapeSize)
 	}
 
 	lsc := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(lsc, OpBeginScope, nil, nil))
+	*insts = append(*insts, ir.NewInstruction(lsc, ir.OpBeginScope, nil, nil))
 
-	body = append(body, NewInstruction(GenerateLabel(tc), OpReturn, lsc, l))
+	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpReturn, lsc, l))
 	*insts = append(*insts, body...)
 
 	return lsc
@@ -141,19 +142,19 @@ func emitBlockExpression(tc *int, insts *[]Instruction, n parser.BlockExpression
 }
 
 // emitDeferExpression stores a scope to be run later, and skips over its body.
-func emitDeferExpression(tc *int, insts *[]Instruction, n parser.DeferExpression, tapeSize int) Label {
-	body := make([]Instruction, 0)
+func emitDeferExpression(tc *int, insts *[]ir.Instruction, n parser.DeferExpression, tapeSize int) Label {
+	body := make([]ir.Instruction, 0)
 	l := EmitInstruction(tc, &body, n.Block, tapeSize)
 	bodylength := uint64(len(body))
 	lo := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(lo, OpDefer, l, byteutil.FromUint64(bodylength)))
+	*insts = append(*insts, ir.NewInstruction(lo, ir.OpDefer, l, byteutil.FromUint64(bodylength)))
 	*insts = append(*insts, body...)
 	return lo
 
 }
 
 // emitUnaryExpression negates: a tape is unsigned, so this is zero minus the value.
-func emitUnaryExpression(tc *int, insts *[]Instruction, n parser.UnaryExpression, tapeSize int) Label {
+func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n parser.UnaryExpression, tapeSize int) Label {
 	// A tape is unsigned, so negating is taking the value away from zero and letting it
 	// wrap: -5 is the same tape as 0 - 5. Emitting the subtraction says exactly that,
 	// and every stage below — the evaluator, the lowering, the EVM writer — already
@@ -164,65 +165,65 @@ func emitUnaryExpression(tc *int, insts *[]Instruction, n parser.UnaryExpression
 	lo := EmitInstruction(tc, insts, n.Expression, tapeSize)
 
 	lz := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(lz, OpSave, byteutil.FalseTape(tapeSize), nil))
+	*insts = append(*insts, ir.NewInstruction(lz, ir.OpSave, byteutil.FalseTape(tapeSize), nil))
 
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSubtract, lz, lo))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSubtract, lz, lo))
 	return l
 
 }
 
 // emitRelativeExpression compares two values.
-func emitRelativeExpression(tc *int, insts *[]Instruction, n parser.RelativeExpression, tapeSize int) Label {
+func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n parser.RelativeExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
 	switch string(n.Operation.Token.GetMatch()) {
 	case "equals":
-		op = OpEquals
+		op = ir.OpEquals
 	case "different":
-		op = OpDiff
+		op = ir.OpDiff
 	case "bigger":
-		op = OpBigger
+		op = ir.OpBigger
 	case "smaller":
-		op = OpSmaller
+		op = ir.OpSmaller
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, op, ll, lr))
+	*insts = append(*insts, ir.NewInstruction(l, op, ll, lr))
 
 	return l
 
 }
 
 // emitBooleanExpression combines two truth values.
-func emitBooleanExpression(tc *int, insts *[]Instruction, n parser.BooleanExpression, tapeSize int) Label {
+func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n parser.BooleanExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
 	switch string(n.Operation.Token.GetMatch()) {
 	case "or":
-		op = OpOr
+		op = ir.OpOr
 	case "and":
-		op = OpAnd
+		op = ir.OpAnd
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, op, ll, lr))
+	*insts = append(*insts, ir.NewInstruction(l, op, ll, lr))
 	return l
 
 }
 
 // emitTapeBracketExpression builds a tape byte by byte.
-func emitTapeBracketExpression(tc *int, insts *[]Instruction, n parser.TapeBracketExpression, tapeSize int) Label {
+func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n parser.TapeBracketExpression, tapeSize int) Label {
 	// Create the initial tape, all zeros
 	l := GenerateLabel(tc)
 	tape := byteutil.FalseTape(tapeSize)
-	*insts = append(*insts, NewInstruction(l, OpSave, tape, nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, tape, nil))
 
-	// For each item, generate instruction and use OpPull to add bytes directly
+	// For each item, generate instruction and use ir.OpPull to add bytes directly
 	for _, i := range n.Items {
 		la := GenerateLabel(tc)
 		li := EmitInstruction(tc, insts, i, tapeSize)
-		*insts = append(*insts, NewInstruction(la, OpPull, l, li))
+		*insts = append(*insts, ir.NewInstruction(la, ir.OpPull, l, li))
 		l = la
 	}
 	return l
@@ -230,31 +231,31 @@ func emitTapeBracketExpression(tc *int, insts *[]Instruction, n parser.TapeBrack
 }
 
 // emitStructDeclaration answers the neutral value: a directive does no work.
-func emitStructDeclaration(tc *int, insts *[]Instruction, _ parser.StructDeclaration, tapeSize int) Label {
+func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ parser.StructDeclaration, tapeSize int) Label {
 	// A directive emits no work. It still answers with a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSave, byteutil.FalseTape(tapeSize), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.FalseTape(tapeSize), nil))
 	return l
 
 }
 
 // emitStructLiteral lays one tape per field, end to end.
-func emitStructLiteral(tc *int, insts *[]Instruction, n parser.StructLiteral, tapeSize int) Label {
+func emitStructLiteral(tc *int, insts *[]ir.Instruction, n parser.StructLiteral, tapeSize int) Label {
 	// One tape per field, laid end to end — the shape a reel of the same length has.
 	// Instructions carry two operands, so the run is built by chaining, the way a tape
-	// literal chains OpPull.
+	// literal chains ir.OpPull.
 	//
 	// It starts from an empty run rather than from the first field so that every field
 	// crosses the same join, which is what narrows each one to a single tape. Starting
 	// at the first field left that one whole, and a reel there became several tapes.
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSave, make([]byte, 0), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, make([]byte, 0), nil))
 
 	for _, value := range n.Values {
 		lv := EmitInstruction(tc, insts, value, tapeSize)
 		lj := GenerateLabel(tc)
-		*insts = append(*insts, NewInstruction(lj, OpJoin, l, lv))
+		*insts = append(*insts, ir.NewInstruction(lj, ir.OpJoin, l, lv))
 		l = lj
 	}
 	return l
@@ -262,18 +263,18 @@ func emitStructLiteral(tc *int, insts *[]Instruction, n parser.StructLiteral, ta
 }
 
 // emitFieldExpression reads one tape out of a run, by an index resolved while parsing.
-func emitFieldExpression(tc *int, insts *[]Instruction, n parser.FieldExpression, tapeSize int) Label {
+func emitFieldExpression(tc *int, insts *[]ir.Instruction, n parser.FieldExpression, tapeSize int) Label {
 	// The index was resolved while parsing, so it goes in as an immediate — the same
 	// shape head and tail use. Nothing here knows the field had a name.
 	lv := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpField, lv, byteutil.FromUint64(n.Index)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpField, lv, byteutil.FromUint64(n.Index)))
 	return l
 
 }
 
 // emitShapedExpression emits what was shaped: `as` is a claim, not an operation.
-func emitShapedExpression(tc *int, insts *[]Instruction, n parser.ShapedExpression, tapeSize int) Label {
+func emitShapedExpression(tc *int, insts *[]ir.Instruction, n parser.ShapedExpression, tapeSize int) Label {
 	// `as` says how to read a value, which is a question the compiler answers and the
 	// program never asks: what is left is the value itself.
 	return EmitInstruction(tc, insts, n.Expression, tapeSize)
@@ -281,51 +282,51 @@ func emitShapedExpression(tc *int, insts *[]Instruction, n parser.ShapedExpressi
 }
 
 // emitPullExpression shifts a tape left, the value entering at the right.
-func emitPullExpression(tc *int, insts *[]Instruction, n parser.PullExpression, tapeSize int) Label {
+func emitPullExpression(tc *int, insts *[]ir.Instruction, n parser.PullExpression, tapeSize int) Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpPull, lt, li))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpPull, lt, li))
 	return l
 
 }
 
 // emitHeadExpression keeps the first bytes of a tape.
-func emitHeadExpression(tc *int, insts *[]Instruction, n parser.HeadExpression, tapeSize int) Label {
+func emitHeadExpression(tc *int, insts *[]ir.Instruction, n parser.HeadExpression, tapeSize int) Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpHead, e, ln))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpHead, e, ln))
 	return l
 
 }
 
 // emitTailExpression drops the first bytes of a tape.
-func emitTailExpression(tc *int, insts *[]Instruction, n parser.TailExpression, tapeSize int) Label {
+func emitTailExpression(tc *int, insts *[]ir.Instruction, n parser.TailExpression, tapeSize int) Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpTail, e, ln))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpTail, e, ln))
 	return l
 
 }
 
 // emitPushExpression shifts a tape right, the value entering at the left.
-func emitPushExpression(tc *int, insts *[]Instruction, n parser.PushExpression, tapeSize int) Label {
+func emitPushExpression(tc *int, insts *[]ir.Instruction, n parser.PushExpression, tapeSize int) Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpPush, lt, li))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpPush, lt, li))
 	return l
 
 }
 
 // emitIfExpression lays out the test, the body and the else, with the jumps between them.
-func emitIfExpression(tc *int, insts *[]Instruction, n parser.IfExpression, tapeSize int) Label {
+func emitIfExpression(tc *int, insts *[]ir.Instruction, n parser.IfExpression, tapeSize int) Label {
 	var bl, eul []byte
 
 	/*Extract Else body*/
-	euze := make([]Instruction, 0)
+	euze := make([]ir.Instruction, 0)
 	if n.Else != nil {
 		for _, inst := range n.Else.Body {
 			eul = EmitInstruction(tc, &euze, inst, tapeSize)
@@ -334,7 +335,7 @@ func emitIfExpression(tc *int, insts *[]Instruction, n parser.IfExpression, tape
 	euzelen := byteutil.FromUint64(uint64(len(euze)) + 1)
 
 	/*Extract Condition body*/
-	body := make([]Instruction, 0)
+	body := make([]ir.Instruction, 0)
 	for _, inst := range n.Body {
 		bl = EmitInstruction(tc, &body, inst, tapeSize)
 	}
@@ -342,13 +343,13 @@ func emitIfExpression(tc *int, insts *[]Instruction, n parser.IfExpression, tape
 
 	lt := EmitInstruction(tc, insts, n.Test, tapeSize)
 	inl := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(inl, OpIf, lt, bodylen))
+	*insts = append(*insts, ir.NewInstruction(inl, ir.OpIf, lt, bodylen))
 
-	body = append(body, NewInstruction(GenerateLabel(tc), OpReturn, inl, bl))
-	body = append(body, NewInstruction(GenerateLabel(tc), OpJump, euzelen, nil))
+	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpReturn, inl, bl))
+	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpJump, euzelen, nil))
 	*insts = append(*insts, body...)
 
-	euze = append(euze, NewInstruction(GenerateLabel(tc), OpReturn, inl, eul))
+	euze = append(euze, ir.NewInstruction(GenerateLabel(tc), ir.OpReturn, inl, eul))
 	*insts = append(*insts, euze...)
 
 	return inl
@@ -356,105 +357,105 @@ func emitIfExpression(tc *int, insts *[]Instruction, n parser.IfExpression, tape
 }
 
 // emitCalleeLiteral applies values to a scope.
-func emitCalleeLiteral(tc *int, insts *[]Instruction, n parser.CalleeLiteral, tapeSize int) Label {
+func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n parser.CalleeLiteral, tapeSize int) Label {
 	for i, p := range n.Params {
 		ll := EmitInstruction(tc, insts, p.Expression, tapeSize)
 		l := GenerateLabel(tc)
-		*insts = append(*insts, NewInstruction(l, OpPushFeed, byteutil.FromUint64(uint64(i)), ll))
+		*insts = append(*insts, ir.NewInstruction(l, ir.OpPushFeed, byteutil.FromUint64(uint64(i)), ll))
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpCall, n.Id.Token.GetMatch(), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpCall, n.Id.Token.GetMatch(), nil))
 	return l
 
 }
 
 // emitPrintStatement writes a value in one of the three readings.
-func emitPrintStatement(tc *int, insts *[]Instruction, n parser.PrintStatement, tapeSize int) Label {
+func emitPrintStatement(tc *int, insts *[]ir.Instruction, n parser.PrintStatement, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Param, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, printOpCodes[n.Format], ll, nil))
+	*insts = append(*insts, ir.NewInstruction(l, printOpCodes[n.Format], ll, nil))
 	return l
 
 }
 
 // emitAssertStatement checks a condition, carrying its message as bytes.
-func emitAssertStatement(tc *int, insts *[]Instruction, n parser.AssertStatement, tapeSize int) Label {
+func emitAssertStatement(tc *int, insts *[]ir.Instruction, n parser.AssertStatement, tapeSize int) Label {
 	// The message rides in the instruction as the bytes it is, not as a value: it is
 	// written for whoever reads the result, and a value would have to fit in a tape.
 	cond := EmitInstruction(tc, insts, n.Condition, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpAssert, cond, []byte(n.Message)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpAssert, cond, []byte(n.Message)))
 	return l
 
 }
 
 // emitFeedExpression reads the nth value applied to this scope.
-func emitFeedExpression(tc *int, insts *[]Instruction, n parser.FeedExpression, tapeSize int) Label {
+func emitFeedExpression(tc *int, insts *[]ir.Instruction, n parser.FeedExpression, tapeSize int) Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpGetFeed, byteutil.FromUint64(n.Nth.Value), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpGetFeed, byteutil.FromUint64(n.Nth.Value), nil))
 	return l
 
 }
 
 // emitBinaryExpression does arithmetic on two values.
-func emitBinaryExpression(tc *int, insts *[]Instruction, n parser.BinaryExpression, tapeSize int) Label {
+func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n parser.BinaryExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
 	switch string(n.Operation.Token.GetMatch()) {
 	case "*":
-		op = OpMultiply
+		op = ir.OpMultiply
 	case "+":
-		op = OpAdd
+		op = ir.OpAdd
 	case "-":
-		op = OpSubtract
+		op = ir.OpSubtract
 	case "/":
-		op = OpDivide
+		op = ir.OpDivide
 	case "^":
-		op = OpExponential
+		op = ir.OpExponential
 	}
 
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, op, ll, lr))
+	*insts = append(*insts, ir.NewInstruction(l, op, ll, lr))
 
 	return l
 
 }
 
 // emitNumberLiteral saves a number as a tape.
-func emitNumberLiteral(tc *int, insts *[]Instruction, n parser.NumberLiteral, tapeSize int) Label {
+func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n parser.NumberLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSave, byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize), nil))
 	return l
 
 }
 
 // emitTextLiteral saves text as the tape of its bytes.
-func emitTextLiteral(tc *int, insts *[]Instruction, n parser.TextLiteral, tapeSize int) Label {
+func emitTextLiteral(tc *int, insts *[]ir.Instruction, n parser.TextLiteral, tapeSize int) Label {
 	// Text is a tape holding its bytes, so it saves like any other value.
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSave, n.Value, nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
 	return l
 
 }
 
 // emitBooleanLiteral saves true or false, which are tapes like any other.
-func emitBooleanLiteral(tc *int, insts *[]Instruction, n parser.BooleanLiteral, tapeSize int) Label {
+func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n parser.BooleanLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpSave, n.Value, nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
 	return l
 
 }
 
 // emitIdentifierLiteral loads what a name is bound to.
-func emitIdentifierLiteral(tc *int, insts *[]Instruction, n parser.IdentifierLiteral, tapeSize int) Label {
+func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n parser.IdentifierLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, NewInstruction(l, OpLoad, n.Token.GetMatch(), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, n.Token.GetMatch(), nil))
 	return l
 
 }
 
-func (e *emt) Emit(ast parser.AST) ([]Instruction, error) {
+func (e *emt) Emit(ast parser.AST) ([]ir.Instruction, error) {
 	program, err := e.EmitProgram(ast)
 	if err != nil {
 		return nil, err
@@ -466,7 +467,7 @@ func (e *emt) Emit(ast parser.AST) ([]Instruction, error) {
 // can run them one at a time and report each value as it is produced.
 func (e *emt) EmitProgram(ast parser.AST) (Program, error) {
 	tc := 0
-	insts := make([]Instruction, 0)
+	insts := make([]ir.Instruction, 0)
 	exprs := make([]Expression, 0, len(ast.Nodes))
 
 	for _, node := range ast.Nodes {

--- a/emitter/golden_test.go
+++ b/emitter/golden_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // A program touching most of the language, and the instructions it compiles to, written
@@ -42,7 +43,7 @@ func TestEmittedProgramMatchesTheGolden(t *testing.T) {
 		t.Fatalf("emitter: %v", err)
 	}
 
-	if got := Format(insts); got != string(want) {
+	if got := ir.Format(insts); got != string(want) {
 		t.Errorf("the emitted program no longer matches testdata/wide.ir.\n\ngot:\n%s\nwant:\n%s", got, want)
 	}
 }

--- a/emitter/parser.go
+++ b/emitter/parser.go
@@ -2,6 +2,8 @@ package emitter
 
 import (
 	"encoding/binary"
+
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 const (
@@ -12,7 +14,7 @@ const (
 	RIGHT_SIZE_COUNTER = 4
 )
 
-func parseLine(ln []byte) (Instruction, error) {
+func parseLine(ln []byte) (ir.Instruction, error) {
 	// Extract label
 	lblen := binary.BigEndian.Uint32((ln[0:LABEL_SIZE_COUNTER]))
 	label := ln[LABEL_SIZE_COUNTER : lblen+LABEL_SIZE_COUNTER]
@@ -31,11 +33,11 @@ func parseLine(ln []byte) (Instruction, error) {
 	rglen := binary.BigEndian.Uint32((ln[0:RIGHT_SIZE_COUNTER]))
 	right := ln[RIGHT_SIZE_COUNTER : rglen+RIGHT_SIZE_COUNTER]
 
-	return NewInstruction(label, op[0], left, right), nil
+	return ir.NewInstruction(label, op[0], left, right), nil
 }
 
-func Parse(bs []byte) ([]Instruction, error) {
-	insts := make([]Instruction, 0)
+func Parse(bs []byte) ([]ir.Instruction, error) {
+	insts := make([]ir.Instruction, 0)
 
 	for len(bs) > 0 {
 		lnlen := binary.BigEndian.Uint32((bs[0:LINE_SIZE_COUNTER]))

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 func compileWith(t *testing.T, source string, tapeSize int) Program {
@@ -79,7 +80,7 @@ func TestEmitMatchesEmitProgram(t *testing.T) {
 	}
 }
 
-// The label of a scope is where its OpReturn writes, which is what makes the value of a
+// The label of a scope is where its ir.OpReturn writes, which is what makes the value of a
 // block or an if readable at all.
 func TestEmitProgramLabelsScopes(t *testing.T) {
 	cases := []struct {
@@ -100,8 +101,8 @@ func TestEmitProgramLabelsScopes(t *testing.T) {
 			expr := program.Expressions[0]
 
 			last := program.Instructions[expr.To-1]
-			if last.GetOpCode() != OpReturn {
-				t.Fatalf("a scope should end in OpReturn, got %s", ResolveOpCode(last.GetOpCode()))
+			if last.GetOpCode() != ir.OpReturn {
+				t.Fatalf("a scope should end in OpReturn, got %s", ir.ResolveOpCode(last.GetOpCode()))
 			}
 			if !bytes.Equal(last.GetLeft(), expr.Label) {
 				t.Errorf("the value lands under %q but the expression reports %q", last.GetLeft(), expr.Label)

--- a/evaluator/dispatch_test.go
+++ b/evaluator/dispatch_test.go
@@ -5,8 +5,8 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/evaluator/environ"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // ExecuteInstruction is the only place that says which opcode runs which operation, and
@@ -42,23 +42,23 @@ func operands(x, y uint64) func(e *Evaluator) {
 
 var dispatchCases = []dispatchCase{
 	{
-		name: "add", opcode: emitter.OpAdd, setup: operands(6, 3),
+		name: "add", opcode: ir.OpAdd, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FromUint64(9), cursor: 1,
 	},
 	{
-		name: "subtract", opcode: emitter.OpSubtract, setup: operands(6, 3),
+		name: "subtract", opcode: ir.OpSubtract, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FromUint64(3), cursor: 1,
 	},
 	{
-		name: "multiply", opcode: emitter.OpMultiply, setup: operands(6, 3),
+		name: "multiply", opcode: ir.OpMultiply, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FromUint64(18), cursor: 1,
 	},
 	{
-		name: "divide", opcode: emitter.OpDivide, setup: operands(6, 3),
+		name: "divide", opcode: ir.OpDivide, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FromUint64(2), cursor: 1,
 	},
 	{
-		name: "exponential", opcode: emitter.OpExponential, setup: operands(6, 3),
+		name: "exponential", opcode: ir.OpExponential, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FromUint64(216), cursor: 1,
 	},
 
@@ -66,55 +66,55 @@ var dispatchCases = []dispatchCase{
 	// (false, false), (true, false) and (false, true) — four different pairs, so a swap
 	// between any two of them shows.
 	{
-		name: "diff, the bigger first", opcode: emitter.OpDiff, setup: operands(6, 3),
+		name: "diff, the bigger first", opcode: ir.OpDiff, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.TrueTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "diff, the smaller first", opcode: emitter.OpDiff, setup: operands(3, 6),
+		name: "diff, the smaller first", opcode: ir.OpDiff, setup: operands(3, 6),
 		left: []byte("00"), right: []byte("01"), want: byteutil.TrueTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "equals, the bigger first", opcode: emitter.OpEquals, setup: operands(6, 3),
+		name: "equals, the bigger first", opcode: ir.OpEquals, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FalseTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "equals, the smaller first", opcode: emitter.OpEquals, setup: operands(3, 6),
+		name: "equals, the smaller first", opcode: ir.OpEquals, setup: operands(3, 6),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FalseTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "bigger, the bigger first", opcode: emitter.OpBigger, setup: operands(6, 3),
+		name: "bigger, the bigger first", opcode: ir.OpBigger, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.TrueTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "bigger, the smaller first", opcode: emitter.OpBigger, setup: operands(3, 6),
+		name: "bigger, the smaller first", opcode: ir.OpBigger, setup: operands(3, 6),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FalseTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "smaller, the bigger first", opcode: emitter.OpSmaller, setup: operands(6, 3),
+		name: "smaller, the bigger first", opcode: ir.OpSmaller, setup: operands(6, 3),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FalseTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "smaller, the smaller first", opcode: emitter.OpSmaller, setup: operands(3, 6),
+		name: "smaller, the smaller first", opcode: ir.OpSmaller, setup: operands(3, 6),
 		left: []byte("00"), right: []byte("01"), want: byteutil.TrueTape(tapeSize), cursor: 1,
 	},
 
 	// and and or only differ where the operands do.
 	{
-		name: "and, one true one false", opcode: emitter.OpAnd, setup: operands(1, 0),
+		name: "and, one true one false", opcode: ir.OpAnd, setup: operands(1, 0),
 		left: []byte("00"), right: []byte("01"), want: byteutil.FalseTape(tapeSize), cursor: 1,
 	},
 	{
-		name: "or, one true one false", opcode: emitter.OpOr, setup: operands(1, 0),
+		name: "or, one true one false", opcode: ir.OpOr, setup: operands(1, 0),
 		left: []byte("00"), right: []byte("01"), want: byteutil.TrueTape(tapeSize), cursor: 1,
 	},
 
 	{
-		name: "save", opcode: emitter.OpSave,
+		name: "save", opcode: ir.OpSave,
 		left: byteutil.FromUint64(7), want: byteutil.FromUint64(7), cursor: 1,
 	},
 	{
 		name:   "load",
-		opcode: emitter.OpLoad,
+		opcode: ir.OpLoad,
 		setup: func(e *Evaluator) {
 			e.environ.SetIdent(byteutil.ToHex([]byte("id")), byteutil.FromUint64(11))
 		},
@@ -122,7 +122,7 @@ var dispatchCases = []dispatchCase{
 	},
 	{
 		name:   "ident",
-		opcode: emitter.OpIdent,
+		opcode: ir.OpIdent,
 		setup: func(e *Evaluator) {
 			e.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(5))
 		},
@@ -138,7 +138,7 @@ var dispatchCases = []dispatchCase{
 	// if and jump both move the cursor and write nothing, so the landing is the whole answer.
 	{
 		name:   "if, the test holds",
-		opcode: emitter.OpIf,
+		opcode: ir.OpIf,
 		setup: func(e *Evaluator) {
 			e.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.TrueTape(tapeSize))
 		},
@@ -146,20 +146,20 @@ var dispatchCases = []dispatchCase{
 	},
 	{
 		name:   "if, the test does not hold",
-		opcode: emitter.OpIf,
+		opcode: ir.OpIf,
 		setup: func(e *Evaluator) {
 			e.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FalseTape(tapeSize))
 		},
 		left: []byte("00"), right: byteutil.FromUint64(4), cursor: 5,
 	},
 	{
-		name: "jump", opcode: emitter.OpJump,
+		name: "jump", opcode: ir.OpJump,
 		left: byteutil.FromUint64(3), cursor: 4,
 	},
 
 	{
 		name:   "get feed",
-		opcode: emitter.OpGetFeed,
+		opcode: ir.OpGetFeed,
 		setup: func(e *Evaluator) {
 			e.environ.SetArgument(0, byteutil.FromUint64(99))
 		},
@@ -167,7 +167,7 @@ var dispatchCases = []dispatchCase{
 	},
 	{
 		// A defer answers with its index as a tape and steps over the body it just stored.
-		name: "defer", opcode: emitter.OpDefer,
+		name: "defer", opcode: ir.OpDefer,
 		left: []byte("ret"), right: byteutil.FromUint64(2),
 		want: byteutil.FalseTape(tapeSize), cursor: 3,
 	},
@@ -175,35 +175,35 @@ var dispatchCases = []dispatchCase{
 	// The tape operations move the same two values in four different directions.
 	{
 		name:   "pull",
-		opcode: emitter.OpPull,
+		opcode: ir.OpPull,
 		setup:  operands(1, 2),
 		left:   []byte("00"), right: []byte("01"),
 		want: byteutil.FromUint64(0x0102), cursor: 1,
 	},
 	{
 		name:   "push",
-		opcode: emitter.OpPush,
+		opcode: ir.OpPush,
 		setup:  operands(1, 2),
 		left:   []byte("00"), right: []byte("01"),
 		want: []byte{2, 0, 0, 0, 0, 0, 0, 0}, cursor: 1,
 	},
 	{
 		name:   "head",
-		opcode: emitter.OpHead,
+		opcode: ir.OpHead,
 		setup:  operands(0x0102, 1),
 		left:   []byte("00"), right: byteutil.FromUint64(1),
 		want: byteutil.FromUint64(1), cursor: 1,
 	},
 	{
 		name:   "tail",
-		opcode: emitter.OpTail,
+		opcode: ir.OpTail,
 		setup:  operands(0x0102, 1),
 		left:   []byte("00"), right: byteutil.FromUint64(1),
 		want: byteutil.FromUint64(2), cursor: 1,
 	},
 	{
 		name:   "join",
-		opcode: emitter.OpJoin,
+		opcode: ir.OpJoin,
 		setup:  operands(1, 2),
 		left:   []byte("00"), right: []byte("01"),
 		want:   append(byteutil.FromUint64(1), byteutil.FromUint64(2)...),
@@ -211,7 +211,7 @@ var dispatchCases = []dispatchCase{
 	},
 	{
 		name:   "field",
-		opcode: emitter.OpField,
+		opcode: ir.OpField,
 		setup: func(e *Evaluator) {
 			run := append(byteutil.FromUint64(1), byteutil.FromUint64(2)...)
 			e.environ.SetTemp(byteutil.ToHex([]byte("00")), run)
@@ -222,7 +222,7 @@ var dispatchCases = []dispatchCase{
 
 	{
 		name:   "push feed",
-		opcode: emitter.OpPushFeed,
+		opcode: ir.OpPushFeed,
 		setup: func(e *Evaluator) {
 			e.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(42))
 		},
@@ -234,7 +234,7 @@ var dispatchCases = []dispatchCase{
 		},
 	},
 	{
-		name: "begin scope", opcode: emitter.OpBeginScope, cursor: 1,
+		name: "begin scope", opcode: ir.OpBeginScope, cursor: 1,
 		check: func(t *testing.T, e *Evaluator) {
 			if e.environ.GetPrevious() == nil {
 				t.Error("no scope was opened")
@@ -243,7 +243,7 @@ var dispatchCases = []dispatchCase{
 	},
 	{
 		name:   "return",
-		opcode: emitter.OpReturn,
+		opcode: ir.OpReturn,
 		setup: func(e *Evaluator) {
 			e.environ = e.environ.Ahead(environ.NewEnviron(environ.NewEnvironOptions{}))
 			e.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(13))
@@ -265,9 +265,9 @@ func TestExecuteInstructionDispatchesToTheRightOperation(t *testing.T) {
 				tc.setup(e)
 			}
 
-			inst := emitter.NewInstruction([]byte("02"), tc.opcode, tc.left, tc.right)
+			inst := ir.NewInstruction([]byte("02"), tc.opcode, tc.left, tc.right)
 			if err := e.ExecuteInstruction(inst); err != nil {
-				t.Fatalf("executing %s: %v", emitter.ResolveOpCode(tc.opcode), err)
+				t.Fatalf("executing %s: %v", ir.ResolveOpCode(tc.opcode), err)
 			}
 
 			if tc.want != nil {
@@ -294,9 +294,9 @@ func TestExecuteInstructionDispatchesThePrints(t *testing.T) {
 		opcode byte
 		want   string
 	}{
-		{name: "bytes", opcode: emitter.OpPrintBytes, want: "[0 0 0 0 0 0 0 65]\n"},
-		{name: "chars", opcode: emitter.OpPrintChars, want: "A\n"},
-		{name: "decimal", opcode: emitter.OpPrintDecimal, want: "65\n"},
+		{name: "bytes", opcode: ir.OpPrintBytes, want: "[0 0 0 0 0 0 0 65]\n"},
+		{name: "chars", opcode: ir.OpPrintChars, want: "A\n"},
+		{name: "decimal", opcode: ir.OpPrintDecimal, want: "65\n"},
 	}
 
 	for _, tc := range cases {
@@ -305,7 +305,7 @@ func TestExecuteInstructionDispatchesThePrints(t *testing.T) {
 			e := New(NewEvaluatorOptions{Output: out})
 			e.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(65))
 
-			inst := emitter.NewInstruction([]byte("02"), tc.opcode, []byte("00"), nil)
+			inst := ir.NewInstruction([]byte("02"), tc.opcode, []byte("00"), nil)
 			if err := e.ExecuteInstruction(inst); err != nil {
 				t.Fatalf("executing: %v", err)
 			}
@@ -323,7 +323,7 @@ func TestExecuteInstructionDispatchesAnAssert(t *testing.T) {
 	e := New(NewEvaluatorOptions{Asserts: true})
 	e.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FalseTape(tapeSize))
 
-	inst := emitter.NewInstruction([]byte("02"), emitter.OpAssert, []byte("00"), []byte("one is one"))
+	inst := ir.NewInstruction([]byte("02"), ir.OpAssert, []byte("00"), []byte("one is one"))
 	if err := e.ExecuteInstruction(inst); err != nil {
 		t.Fatalf("executing: %v", err)
 	}
@@ -343,22 +343,22 @@ func TestExecuteInstructionDispatchesAnAssert(t *testing.T) {
 func TestExecuteInstructionCarriesAnErrorBack(t *testing.T) {
 	cases := []struct {
 		name string
-		inst emitter.Instruction
+		inst ir.Instruction
 		want string
 	}{
 		{
 			name: "load of an identifier that was never set",
-			inst: emitter.NewInstruction([]byte("02"), emitter.OpLoad, []byte("nope"), nil),
+			inst: ir.NewInstruction([]byte("02"), ir.OpLoad, []byte("nope"), nil),
 			want: "identifier nope not found",
 		},
 		{
 			name: "call of an identifier that was never set",
-			inst: emitter.NewInstruction([]byte("02"), emitter.OpCall, []byte("nope"), nil),
+			inst: ir.NewInstruction([]byte("02"), ir.OpCall, []byte("nope"), nil),
 			want: "call: nope identifier not found",
 		},
 		{
 			name: "divide by zero",
-			inst: emitter.NewInstruction([]byte("02"), emitter.OpDivide, []byte("00"), []byte("01")),
+			inst: ir.NewInstruction([]byte("02"), ir.OpDivide, []byte("00"), []byte("01")),
 			want: "integer divide by zero",
 		},
 	}
@@ -385,7 +385,7 @@ func TestExecuteInstructionCarriesAnErrorBack(t *testing.T) {
 func TestExecuteInstructionStepsOverAnOpcodeItDoesNotKnow(t *testing.T) {
 	e := New(NewEvaluatorOptions{})
 
-	inst := emitter.NewInstruction([]byte("02"), emitter.OpPreCall, []byte("00"), []byte("01"))
+	inst := ir.NewInstruction([]byte("02"), ir.OpPreCall, []byte("00"), []byte("01"))
 	if err := e.ExecuteInstruction(inst); err != nil {
 		t.Fatalf("executing: %v", err)
 	}
@@ -400,13 +400,13 @@ func TestExecuteInstructionStepsOverAnOpcodeItDoesNotKnow(t *testing.T) {
 
 // Opcodes proven by a test of their own rather than by the table.
 var coveredElsewhere = map[byte]bool{
-	emitter.OpPrintBytes:   true,
-	emitter.OpPrintChars:   true,
-	emitter.OpPrintDecimal: true,
-	emitter.OpAssert:       true,
-	emitter.OpCall:         true,
+	ir.OpPrintBytes:   true,
+	ir.OpPrintChars:   true,
+	ir.OpPrintDecimal: true,
+	ir.OpAssert:       true,
+	ir.OpCall:         true,
 	// Declared and never emitted; the step-over test is what covers it.
-	emitter.OpPreCall: true,
+	ir.OpPreCall: true,
 }
 
 // A new opcode is added to the emitter and wired into the evaluator in two separate places,
@@ -417,10 +417,10 @@ func TestEveryOpcodeIsDispatchedByACase(t *testing.T) {
 		tested[tc.opcode] = true
 	}
 
-	for op := emitter.OpMultiply; op <= emitter.OpField; op++ {
+	for op := ir.OpMultiply; op <= ir.OpField; op++ {
 		if tested[op] || coveredElsewhere[op] {
 			continue
 		}
-		t.Errorf("%s reaches no test through ExecuteInstruction", emitter.ResolveOpCode(op))
+		t.Errorf("%s reaches no test through ExecuteInstruction", ir.ResolveOpCode(op))
 	}
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -9,9 +9,9 @@ import (
 	"github.com/holiman/uint256"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/evaluator/builtin"
 	"github.com/guiferpa/aurora/evaluator/environ"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // deferMark opens every defer blob. The value handed to a program is an ordinary tape
@@ -63,7 +63,7 @@ type Evaluator struct {
 	player        *Player
 	cursor        uint64
 	end           uint64
-	insts         []emitter.Instruction
+	insts         []ir.Instruction
 	assertResults []AssertResult // what each assertion did, in the order they ran
 	asserts       bool           // whether assertions are evaluated at all
 	output        io.Writer
@@ -504,11 +504,11 @@ func (e *Evaluator) CanReadInstructions() bool {
 	return e.cursor < e.end
 }
 
-func (e *Evaluator) GetInstruction() emitter.Instruction {
+func (e *Evaluator) GetInstruction() ir.Instruction {
 	return e.insts[e.cursor]
 }
 
-func (e *Evaluator) SetInstructions(insts []emitter.Instruction) {
+func (e *Evaluator) SetInstructions(insts []ir.Instruction) {
 	e.insts = insts
 }
 
@@ -548,63 +548,63 @@ var operations map[byte]operation
 func init() {
 	operations = map[byte]operation{
 		// Arithmetic
-		emitter.OpAdd:         (*Evaluator).EvaluateAdd,
-		emitter.OpSubtract:    (*Evaluator).EvaluateSubtract,
-		emitter.OpMultiply:    (*Evaluator).EvaluateMultiply,
-		emitter.OpDivide:      (*Evaluator).EvaluateDivide,
-		emitter.OpExponential: (*Evaluator).EvaluateExponential,
+		ir.OpAdd:         (*Evaluator).EvaluateAdd,
+		ir.OpSubtract:    (*Evaluator).EvaluateSubtract,
+		ir.OpMultiply:    (*Evaluator).EvaluateMultiply,
+		ir.OpDivide:      (*Evaluator).EvaluateDivide,
+		ir.OpExponential: (*Evaluator).EvaluateExponential,
 
 		// Comparison
-		emitter.OpDiff:    (*Evaluator).EvaluateDiff,
-		emitter.OpEquals:  (*Evaluator).EvaluateEquals,
-		emitter.OpBigger:  (*Evaluator).EvaluateBigger,
-		emitter.OpSmaller: (*Evaluator).EvaluateSmaller,
+		ir.OpDiff:    (*Evaluator).EvaluateDiff,
+		ir.OpEquals:  (*Evaluator).EvaluateEquals,
+		ir.OpBigger:  (*Evaluator).EvaluateBigger,
+		ir.OpSmaller: (*Evaluator).EvaluateSmaller,
 
 		// Logic
-		emitter.OpAnd: (*Evaluator).EvaluateAnd,
-		emitter.OpOr:  (*Evaluator).EvaluateOr,
+		ir.OpAnd: (*Evaluator).EvaluateAnd,
+		ir.OpOr:  (*Evaluator).EvaluateOr,
 
 		// Builtins. A print reads one operand, and the opcode is the whole difference between
 		// the three readings of it.
-		emitter.OpPrintBytes: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintBytes: func(e *Evaluator, label, left, _ []byte) error {
 			return e.EvaluatePrintBytes(label, left)
 		},
-		emitter.OpPrintChars: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintChars: func(e *Evaluator, label, left, _ []byte) error {
 			return e.EvaluatePrintChars(label, left)
 		},
-		emitter.OpPrintDecimal: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintDecimal: func(e *Evaluator, label, left, _ []byte) error {
 			return e.EvaluatePrintDecimal(label, left)
 		},
 
 		// Memory
-		emitter.OpSave:  (*Evaluator).EvaluateSave,
-		emitter.OpLoad:  (*Evaluator).EvaluateLoad,
-		emitter.OpIdent: (*Evaluator).EvaluateIdent,
+		ir.OpSave:  (*Evaluator).EvaluateSave,
+		ir.OpLoad:  (*Evaluator).EvaluateLoad,
+		ir.OpIdent: (*Evaluator).EvaluateIdent,
 
 		// Control flow
-		emitter.OpIf:         (*Evaluator).EvaluateIf,
-		emitter.OpJump:       (*Evaluator).EvaluateJump,
-		emitter.OpBeginScope: (*Evaluator).EvaluateBeginScope,
-		emitter.OpReturn:     (*Evaluator).EvaluateReturn,
+		ir.OpIf:         (*Evaluator).EvaluateIf,
+		ir.OpJump:       (*Evaluator).EvaluateJump,
+		ir.OpBeginScope: (*Evaluator).EvaluateBeginScope,
+		ir.OpReturn:     (*Evaluator).EvaluateReturn,
 
 		// Arguments
-		emitter.OpPushFeed: (*Evaluator).EvaluatePushArg,
-		emitter.OpGetFeed:  (*Evaluator).EvaluateGetArg,
+		ir.OpPushFeed: (*Evaluator).EvaluatePushArg,
+		ir.OpGetFeed:  (*Evaluator).EvaluateGetArg,
 
 		// Defer and call
-		emitter.OpDefer: (*Evaluator).EvaluateDefer,
-		emitter.OpCall:  (*Evaluator).EvaluateCall,
+		ir.OpDefer: (*Evaluator).EvaluateDefer,
+		ir.OpCall:  (*Evaluator).EvaluateCall,
 
 		// Tape operations
-		emitter.OpPull:  (*Evaluator).EvaluatePull,
-		emitter.OpPush:  (*Evaluator).EvaluatePush,
-		emitter.OpJoin:  (*Evaluator).EvaluateJoin,
-		emitter.OpField: (*Evaluator).EvaluateField,
-		emitter.OpHead:  (*Evaluator).EvaluateHead,
-		emitter.OpTail:  (*Evaluator).EvaluateTail,
+		ir.OpPull:  (*Evaluator).EvaluatePull,
+		ir.OpPush:  (*Evaluator).EvaluatePush,
+		ir.OpJoin:  (*Evaluator).EvaluateJoin,
+		ir.OpField: (*Evaluator).EvaluateField,
+		ir.OpHead:  (*Evaluator).EvaluateHead,
+		ir.OpTail:  (*Evaluator).EvaluateTail,
 
 		// Assertions
-		emitter.OpAssert: (*Evaluator).EvaluateAssert,
+		ir.OpAssert: (*Evaluator).EvaluateAssert,
 	}
 }
 
@@ -614,7 +614,7 @@ func init() {
 // An opcode with no operation behind it is stepped over rather than refused. OpPreCall is
 // declared and never emitted, and an instruction the evaluator does not know is exactly what
 // a half-wired new opcode looks like — a running program does not stop for it.
-func (e *Evaluator) ExecuteInstruction(inst emitter.Instruction) error {
+func (e *Evaluator) ExecuteInstruction(inst ir.Instruction) error {
 	op, ok := operations[inst.GetOpCode()]
 	if !ok {
 		e.IncrementCursor()
@@ -636,7 +636,7 @@ func (e *Evaluator) ExecuteInstructions(from, to uint64) (ReturnsPerLabel, error
 	return e.environ.GetTemps(), nil
 }
 
-func (e *Evaluator) Evaluate(insts []emitter.Instruction) (ReturnsPerLabel, error) {
+func (e *Evaluator) Evaluate(insts []ir.Instruction) (ReturnsPerLabel, error) {
 	e.SetInstructions(insts)
 	returns, err := e.ExecuteInstructions(0, uint64(len(e.insts)))
 	return returns, err
@@ -645,7 +645,7 @@ func (e *Evaluator) Evaluate(insts []emitter.Instruction) (ReturnsPerLabel, erro
 // EvaluateRange sets the full instruction slice and runs only the range [from, to).
 // Used by the REPL: buffer accumulates all instructions; each line we append and run only the new slice,
 // so defer from/to indices stay valid in the same buffer.
-func (e *Evaluator) EvaluateRange(insts []emitter.Instruction, from, to uint64) (ReturnsPerLabel, error) {
+func (e *Evaluator) EvaluateRange(insts []ir.Instruction, from, to uint64) (ReturnsPerLabel, error) {
 	e.SetInstructions(insts)
 	e.environ.ClearTemps()
 	returns, err := e.ExecuteInstructions(from, to)
@@ -672,7 +672,7 @@ func New(options NewEvaluatorOptions) *Evaluator {
 		player:        options.Player,
 		cursor:        0,
 		end:           0,
-		insts:         make([]emitter.Instruction, 0),
+		insts:         make([]ir.Instruction, 0),
 		assertResults: make([]AssertResult, 0),
 		asserts:       options.Asserts,
 		output:        output,

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/guiferpa/aurora/evaluator/environ"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 func containsReturn(returns ReturnsPerLabel, index int, want []byte) (bool, []byte) {
@@ -382,9 +383,9 @@ func TestEvaluatePrintBuiltins(t *testing.T) {
 
 func TestCanReadInstructions(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
-	ev.SetInstructions([]emitter.Instruction{
-		emitter.NewInstruction([]byte("00"), emitter.OpSave, nil, nil),
-		emitter.NewInstruction([]byte("01"), emitter.OpAdd, nil, nil),
+	ev.SetInstructions([]ir.Instruction{
+		ir.NewInstruction([]byte("00"), ir.OpSave, nil, nil),
+		ir.NewInstruction([]byte("01"), ir.OpAdd, nil, nil),
 	})
 	ev.SetInstructionsOffset(0, 2)
 
@@ -403,42 +404,42 @@ func TestCanReadInstructions(t *testing.T) {
 
 func TestGetInstruction(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
-	inst0 := emitter.NewInstruction([]byte("00"), emitter.OpSave, []byte{1}, nil)
-	inst1 := emitter.NewInstruction([]byte("01"), emitter.OpAdd, []byte("00"), []byte("01"))
-	ev.SetInstructions([]emitter.Instruction{inst0, inst1})
+	inst0 := ir.NewInstruction([]byte("00"), ir.OpSave, []byte{1}, nil)
+	inst1 := ir.NewInstruction([]byte("01"), ir.OpAdd, []byte("00"), []byte("01"))
+	ev.SetInstructions([]ir.Instruction{inst0, inst1})
 	ev.SetInstructionsOffset(0, 2)
 
 	got := ev.GetInstruction()
-	if got.GetOpCode() != emitter.OpSave || !bytes.Equal(got.GetLabel(), []byte("00")) {
+	if got.GetOpCode() != ir.OpSave || !bytes.Equal(got.GetLabel(), []byte("00")) {
 		t.Errorf("expected first instruction (OpSave 00), got op=%d label=%s", got.GetOpCode(), got.GetLabel())
 	}
 	ev.IncrementCursor()
 	got = ev.GetInstruction()
-	if got.GetOpCode() != emitter.OpAdd || !bytes.Equal(got.GetLabel(), []byte("01")) {
+	if got.GetOpCode() != ir.OpAdd || !bytes.Equal(got.GetLabel(), []byte("01")) {
 		t.Errorf("expected second instruction (OpAdd 01), got op=%d label=%s", got.GetOpCode(), got.GetLabel())
 	}
 }
 
 func TestSetInstructions(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
-	insts := []emitter.Instruction{
-		emitter.NewInstruction([]byte("00"), emitter.OpSave, nil, nil),
+	insts := []ir.Instruction{
+		ir.NewInstruction([]byte("00"), ir.OpSave, nil, nil),
 	}
 	ev.SetInstructions(insts)
 	ev.SetInstructionsOffset(0, uint64(len(insts)))
 
 	got := ev.GetInstruction()
-	if got.GetOpCode() != emitter.OpSave {
+	if got.GetOpCode() != ir.OpSave {
 		t.Errorf("expected OpSave after SetInstructions, got op=%d", got.GetOpCode())
 	}
 }
 
 func TestSetInstructionsOffset(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
-	ev.SetInstructions([]emitter.Instruction{
-		emitter.NewInstruction([]byte("00"), emitter.OpSave, nil, nil),
-		emitter.NewInstruction([]byte("01"), emitter.OpSave, nil, nil),
-		emitter.NewInstruction([]byte("02"), emitter.OpAdd, nil, nil),
+	ev.SetInstructions([]ir.Instruction{
+		ir.NewInstruction([]byte("00"), ir.OpSave, nil, nil),
+		ir.NewInstruction([]byte("01"), ir.OpSave, nil, nil),
+		ir.NewInstruction([]byte("02"), ir.OpAdd, nil, nil),
 	})
 	ev.SetInstructionsOffset(1, 3)
 

--- a/internal/cli/test.go
+++ b/internal/cli/test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/evaluator"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // TestExtension marks a test file. A test belongs to the source file of the same name:
@@ -206,7 +206,7 @@ func runTestFile(path string, tapeSize int, loggers []string) FileReport {
 	// instructions — a call would then run whatever happened to be there. The REPL keeps
 	// one buffer across lines for the same reason. Each range clears the temps first,
 	// since the two were emitted separately and both number their labels from zero.
-	instructions := make([]emitter.Instruction, 0, len(sourceProgram.Instructions)+len(testProgram.Instructions))
+	instructions := make([]ir.Instruction, 0, len(sourceProgram.Instructions)+len(testProgram.Instructions))
 	instructions = append(instructions, sourceProgram.Instructions...)
 	boundary := len(instructions)
 	instructions = append(instructions, testProgram.Instructions...)

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -20,9 +20,9 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // Tokens writes what the lexer read, one token per line: the tag, then the bytes it
@@ -49,8 +49,8 @@ func AST(w io.Writer, ast parser.AST) error {
 }
 
 // Instructions writes the IR the emitter produced, one instruction per line.
-func Instructions(w io.Writer, insts []emitter.Instruction) error {
-	_, err := fmt.Fprintln(w, emitter.Format(insts))
+func Instructions(w io.Writer, insts []ir.Instruction) error {
+	_, err := fmt.Fprintln(w, ir.Format(insts))
 	return err
 }
 

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -18,6 +18,7 @@ import (
 	"github.com/guiferpa/aurora/internal/trace"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // render prints the value of the line that was typed — the temp left by its last
@@ -109,7 +110,7 @@ type session struct {
 	directives *parser.Directives
 	// Every line's instructions go into the same buffer, which is what keeps the range a
 	// defer recorded valid when it is called on a later line.
-	insts []emitter.Instruction
+	insts []ir.Instruction
 
 	hist       *History
 	histWarned bool

--- a/wire/ir/format.go
+++ b/wire/ir/format.go
@@ -1,4 +1,4 @@
-package emitter
+package ir
 
 import (
 	"bytes"
@@ -9,9 +9,12 @@ import (
 
 // Format renders instructions one per line, which is how the IR is read by a person.
 //
-// It returns the text rather than printing it: showing something is the host's decision,
-// and a phase that writes takes that decision away — it also gets in the way of a test,
-// which wants the string to compare.
+// It lives with the IR rather than with whoever shows it: writing the vocabulary down is part
+// of the vocabulary, the way a token knows how to spell itself. What belongs to a host is the
+// decision to show it and the writer it goes to.
+//
+// It returns the text rather than printing it: a package that writes takes that decision away
+// — and it also gets in the way of a test, which wants the string to compare.
 func Format(insts []Instruction) string {
 	bs := bytes.NewBuffer(make([]byte, 0))
 	for _, inst := range insts {

--- a/wire/ir/instruction.go
+++ b/wire/ir/instruction.go
@@ -1,4 +1,4 @@
-package emitter
+package ir
 
 type Instruction interface {
 	GetLabel() []byte

--- a/wire/ir/ir_test.go
+++ b/wire/ir/ir_test.go
@@ -1,0 +1,124 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+)
+
+// The IR is what the phases agree on, and until it moved here it had no tests of its own: the
+// emitter and the builder each tested what they made of it, and nobody tested the thing
+// itself. What follows is the contract — that an instruction never holds nothing where it
+// promised bytes, that every opcode answers to a name, and that a program written down reads
+// the same way every time.
+
+// An instruction is handed to a builder and to an evaluator, and both index into its
+// operands. Answering with nil where they expect bytes is how a move becomes a panic.
+func TestNewInstructionNeverHoldsNil(t *testing.T) {
+	cases := []struct {
+		name  string
+		left  []byte
+		right []byte
+	}{
+		{name: "both given", left: []byte{1}, right: []byte{2}},
+		{name: "no left", right: []byte{2}},
+		{name: "no right", left: []byte{1}},
+		{name: "neither"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			inst := NewInstruction([]byte("00"), OpAdd, tc.left, tc.right)
+
+			if inst.GetLeft() == nil {
+				t.Error("the left operand came back as nothing")
+			}
+			if inst.GetRight() == nil {
+				t.Error("the right operand came back as nothing")
+			}
+		})
+	}
+}
+
+// What was put in is what comes out: the label, the opcode and the operands, unchanged.
+func TestAnInstructionAnswersWithWhatItWasGiven(t *testing.T) {
+	inst := NewInstruction([]byte("07"), OpMultiply, []byte{1, 2}, []byte{3})
+
+	if got := string(inst.GetLabel()); got != "07" {
+		t.Errorf("label is %q, want 07", got)
+	}
+	if got := inst.GetOpCode(); got != OpMultiply {
+		t.Errorf("opcode is %d, want %d", got, OpMultiply)
+	}
+	if got := inst.GetLeft(); len(got) != 2 || got[0] != 1 || got[1] != 2 {
+		t.Errorf("left is %v, want [1 2]", got)
+	}
+	if got := inst.GetRight(); len(got) != 1 || got[0] != 3 {
+		t.Errorf("right is %v, want [3]", got)
+	}
+}
+
+// A name is how the vocabulary is read — by a trace, by a test that failed, by whoever is
+// looking for why an instruction is where it is. An opcode added without one shows up as
+// "Unknown" in all three, which reads like a bug in the program rather than a gap here.
+func TestEveryOpcodeAnswersToAName(t *testing.T) {
+	for op := OpMultiply; op <= OpField; op++ {
+		name := ResolveOpCode(op)
+
+		if name == "Unknown" {
+			t.Errorf("opcode %d has no name", op)
+		}
+		if !strings.HasPrefix(name, "Op") {
+			t.Errorf("opcode %d is called %q, want a name starting with Op", op, name)
+		}
+	}
+}
+
+// Two opcodes answering to the same name would make a trace lie about which one ran.
+func TestNoTwoOpcodesShareAName(t *testing.T) {
+	seen := make(map[string]byte)
+
+	for op := OpMultiply; op <= OpField; op++ {
+		name := ResolveOpCode(op)
+		if first, taken := seen[name]; taken {
+			t.Errorf("%s names both %d and %d", name, first, op)
+			continue
+		}
+		seen[name] = op
+	}
+}
+
+// A byte that is not an opcode still has to answer something: a trace of a program being
+// debugged is the worst place to panic.
+func TestAByteThatIsNotAnOpcode(t *testing.T) {
+	if got := ResolveOpCode(0xff); got != "Unknown" {
+		t.Errorf("answered %q, want Unknown", got)
+	}
+}
+
+// The written form is one instruction per line, in the order they run.
+func TestFormat(t *testing.T) {
+	insts := []Instruction{
+		NewInstruction([]byte("00"), OpSave, []byte{1}, nil),
+		NewInstruction([]byte("01"), OpAdd, []byte("00"), []byte("00")),
+	}
+
+	lines := strings.Split(strings.TrimRight(Format(insts), "\n"), "\n")
+
+	if len(lines) != 2 {
+		t.Fatalf("wrote %d lines for two instructions: %q", len(lines), lines)
+	}
+	if !strings.Contains(lines[0], "OpSave") {
+		t.Errorf("the first line is %q, want it to name the opcode", lines[0])
+	}
+	if !strings.Contains(lines[1], "OpAdd") {
+		t.Errorf("the second line is %q, want it to name the opcode", lines[1])
+	}
+}
+
+// Nothing to write is nothing written, rather than a blank line: a caller that shows the
+// trace of an empty program should show nothing at all.
+func TestFormatOfNoInstructions(t *testing.T) {
+	if got := Format(nil); got != "" {
+		t.Errorf("wrote %q for no instructions", got)
+	}
+}

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -1,4 +1,4 @@
-package emitter
+package ir
 
 const (
 	OpMultiply     byte = iota + 0b1 // Multiply two numbers with max of 64 bits (uint64)

--- a/wire/ir/resolver.go
+++ b/wire/ir/resolver.go
@@ -1,4 +1,4 @@
-package emitter
+package ir
 
 func ResolveOpCode(op byte) string {
 	switch op {


### PR DESCRIPTION
Step 1 of [rfcs/phase_coupling.md](https://github.com/guiferpa/aurora/blob/main/rfcs/phase_coupling.md). No behaviour changes; two dependencies between phases disappear.

## What was wrong

The intermediate code was kept **inside the phase that produces it**, so everything that reads IR imported the emitter: the evaluator, the builder, the trace, the CLI, the REPL. It was never the emitter they wanted — it was the contract stored in its house.

## What it costs to fix

`Instruction`, the opcodes, `ResolveOpCode` and `Format` move to `wire/ir`. Nothing else changes: not a line of behaviour, not a test's expectation.

```
evaluator     byteutil lexer parser emitter  →  byteutil wire/ir
builder/evm   byteutil lexer parser emitter  →  byteutil wire/ir
emitter       byteutil lexer parser          →  byteutil lexer parser wire/ir
wire/ir                                      →  byteutil
```

**Two of the four dependencies between phases are gone.** The emitter still depends on the parser — that is the tree, and step 2.

## Two corrections the work made to the standard

Applying a rule is how you find out it was wrong. Both are in the second commit:

- **Wire was written as importing nothing of the project**, and the IR needs `byteutil` to spell an instruction out. A util knows nothing of the project either, so leaning on one cannot tie wire to anything — the sentence was stricter than its own reason.
- **The standard sent `Format` to `internal/trace` as presentation.** It is not: writing the vocabulary down is part of the vocabulary, the way a token knows how to spell itself. What belongs to a host is *deciding to show it* and choosing where it goes — which is what `internal/trace` actually does.

That second one is why `emitter/golden_test.go` and `builder/evm/lowering_test.go` can keep formatting instructions without a vital package's test reaching for `internal/`.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- `make complexity`: unchanged.
- Every test that existed still passes, unedited except for the package name in front of the moved identifiers — which is the point of a move that is only a move.
- Both commits verified in their own `git worktree` with `make check`.

Next: the tree becomes wire, which is the larger one — the emitter switches over 21 concrete node types.