### PR TITLE
The tree moves to wire/ast

### DIFF
--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -19,11 +19,11 @@ func build(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(ast)
+	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -48,14 +48,14 @@ false;
 			t.Errorf("%v: %v", c.Name, err)
 			return
 		}
-		ast, err := parser.New(parser.NewParserOptions{
+		tree, err := parser.New(parser.NewParserOptions{
 			Tokens: tokens,
 		}).Parse()
 		if err != nil {
 			t.Errorf("%v: %v", c.Name, err)
 			return
 		}
-		insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+		insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 		if err != nil {
 			t.Errorf("%v: %v", c.Name, err)
 			return
@@ -151,14 +151,14 @@ func TestPickRuntimeCode(t *testing.T) {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			ast, err := parser.New(parser.NewParserOptions{
+			tree, err := parser.New(parser.NewParserOptions{
 				Tokens: tokens,
 			}).Parse()
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -241,14 +241,14 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
-			ast, err := parser.New(parser.NewParserOptions{
+			tree, err := parser.New(parser.NewParserOptions{
 				Tokens: tokens,
 			}).Parse()
 			if err != nil {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
-			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 			if err != nil {
 				t.Errorf("%v: %v", tc.name, err)
 				return

--- a/byteutil/length.go
+++ b/byteutil/length.go
@@ -1,6 +1,6 @@
 package byteutil
 
-const MAX_BYTES_VARIANTS = 1<<8
+const MAX_BYTES_VARIANTS = 1 << 8
 const MAX_BYTES = MAX_BYTES_VARIANTS - 1
 
 func NonZeroFilledLength(v []byte) int {

--- a/byteutil/significant.go
+++ b/byteutil/significant.go
@@ -20,4 +20,3 @@ func ExtractSignificantBytes(bs []byte) []byte {
 	// Return bytes from first non-zero to end
 	return bs[start:]
 }
-

--- a/byteutil/significant_test.go
+++ b/byteutil/significant_test.go
@@ -77,4 +77,3 @@ func TestExtractSignificantBytes(t *testing.T) {
 		})
 	}
 }
-

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -66,7 +66,7 @@ func init() {
 					return nil
 				}
 			}
-			ast, err := parser.New(parser.NewParserOptions{
+			tree, err := parser.New(parser.NewParserOptions{
 				Tokens:   tokens,
 				TapeSize: size,
 			}).Parse()
@@ -77,14 +77,14 @@ func init() {
 			// The phases return what they made; the page decides to show it. In wasm this
 			// lands in the browser console, which is where the debug checkbox points.
 			if debug {
-				if err := trace.AST(os.Stdout, ast); err != nil {
+				if err := trace.AST(os.Stdout, tree); err != nil {
 					errorWriter.Write([]byte(err.Error()))
 					return nil
 				}
 			}
 			program, err := emitter.New(emitter.NewEmitterOptions{
 				TapeSize: size,
-			}).EmitProgram(ast)
+			}).EmitProgram(tree)
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))
 				return nil

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -4,13 +4,13 @@ import (
 	"fmt"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
 type Emitter interface {
-	Emit(ast parser.AST) ([]ir.Instruction, error)
-	EmitProgram(ast parser.AST) (Program, error)
+	Emit(tree ast.AST) ([]ir.Instruction, error)
+	EmitProgram(tree ast.AST) (Program, error)
 }
 
 // Expression is one top-level expression of a program: the range of instructions it
@@ -46,63 +46,63 @@ func GenerateLabel(tc *int) []byte {
 type Label []byte
 
 // printOpCodes maps each reading of a value to the instruction that writes it.
-var printOpCodes = map[parser.PrintFormat]byte{
-	parser.PrintBytes:   ir.OpPrintBytes,
-	parser.PrintChars:   ir.OpPrintChars,
-	parser.PrintDecimal: ir.OpPrintDecimal,
+var printOpCodes = map[ast.PrintFormat]byte{
+	ast.PrintBytes:   ir.OpPrintBytes,
+	ast.PrintChars:   ir.OpPrintChars,
+	ast.PrintDecimal: ir.OpPrintDecimal,
 }
 
-func EmitInstruction(tc *int, insts *[]ir.Instruction, expr parser.Node, tapeSize int) Label {
+func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize int) Label {
 	switch n := expr.(type) {
-	case parser.IdentLiteral:
+	case ast.IdentLiteral:
 		return emitIdentLiteral(tc, insts, n, tapeSize)
-	case parser.BlockExpression:
+	case ast.BlockExpression:
 		return emitBlockExpression(tc, insts, n, tapeSize)
-	case parser.DeferExpression:
+	case ast.DeferExpression:
 		return emitDeferExpression(tc, insts, n, tapeSize)
-	case parser.UnaryExpression:
+	case ast.UnaryExpression:
 		return emitUnaryExpression(tc, insts, n, tapeSize)
-	case parser.RelativeExpression:
+	case ast.RelativeExpression:
 		return emitRelativeExpression(tc, insts, n, tapeSize)
-	case parser.BooleanExpression:
+	case ast.BooleanExpression:
 		return emitBooleanExpression(tc, insts, n, tapeSize)
-	case parser.TapeBracketExpression:
+	case ast.TapeBracketExpression:
 		return emitTapeBracketExpression(tc, insts, n, tapeSize)
-	case parser.StructDeclaration:
+	case ast.StructDeclaration:
 		return emitStructDeclaration(tc, insts, n, tapeSize)
-	case parser.StructLiteral:
+	case ast.StructLiteral:
 		return emitStructLiteral(tc, insts, n, tapeSize)
-	case parser.FieldExpression:
+	case ast.FieldExpression:
 		return emitFieldExpression(tc, insts, n, tapeSize)
-	case parser.ShapedExpression:
+	case ast.ShapedExpression:
 		return emitShapedExpression(tc, insts, n, tapeSize)
-	case parser.PullExpression:
+	case ast.PullExpression:
 		return emitPullExpression(tc, insts, n, tapeSize)
-	case parser.HeadExpression:
+	case ast.HeadExpression:
 		return emitHeadExpression(tc, insts, n, tapeSize)
-	case parser.TailExpression:
+	case ast.TailExpression:
 		return emitTailExpression(tc, insts, n, tapeSize)
-	case parser.PushExpression:
+	case ast.PushExpression:
 		return emitPushExpression(tc, insts, n, tapeSize)
-	case parser.IfExpression:
+	case ast.IfExpression:
 		return emitIfExpression(tc, insts, n, tapeSize)
-	case parser.CalleeLiteral:
+	case ast.CalleeLiteral:
 		return emitCalleeLiteral(tc, insts, n, tapeSize)
-	case parser.PrintStatement:
+	case ast.PrintStatement:
 		return emitPrintStatement(tc, insts, n, tapeSize)
-	case parser.AssertStatement:
+	case ast.AssertStatement:
 		return emitAssertStatement(tc, insts, n, tapeSize)
-	case parser.FeedExpression:
+	case ast.FeedExpression:
 		return emitFeedExpression(tc, insts, n, tapeSize)
-	case parser.BinaryExpression:
+	case ast.BinaryExpression:
 		return emitBinaryExpression(tc, insts, n, tapeSize)
-	case parser.NumberLiteral:
+	case ast.NumberLiteral:
 		return emitNumberLiteral(tc, insts, n, tapeSize)
-	case parser.TextLiteral:
+	case ast.TextLiteral:
 		return emitTextLiteral(tc, insts, n, tapeSize)
-	case parser.BooleanLiteral:
+	case ast.BooleanLiteral:
 		return emitBooleanLiteral(tc, insts, n, tapeSize)
-	case parser.IdentifierLiteral:
+	case ast.IdentifierLiteral:
 		return emitIdentifierLiteral(tc, insts, n, tapeSize)
 	}
 
@@ -111,7 +111,7 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr parser.Node, tapeSiz
 }
 
 // emitIdentLiteral binds a name to a value.
-func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n parser.IdentLiteral, tapeSize int) Label {
+func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tapeSize int) Label {
 	ll := n.Token.GetMatch()
 	lr := EmitInstruction(tc, insts, n.Value, tapeSize)
 	l := GenerateLabel(tc)
@@ -124,7 +124,7 @@ func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n parser.IdentLiteral, t
 }
 
 // emitBlockExpression opens a scope and returns the value its body ended with.
-func emitBlockExpression(tc *int, insts *[]ir.Instruction, n parser.BlockExpression, tapeSize int) Label {
+func emitBlockExpression(tc *int, insts *[]ir.Instruction, n ast.BlockExpression, tapeSize int) Label {
 	var l []byte
 	body := make([]ir.Instruction, 0)
 	for _, ins := range n.Body {
@@ -142,7 +142,7 @@ func emitBlockExpression(tc *int, insts *[]ir.Instruction, n parser.BlockExpress
 }
 
 // emitDeferExpression stores a scope to be run later, and skips over its body.
-func emitDeferExpression(tc *int, insts *[]ir.Instruction, n parser.DeferExpression, tapeSize int) Label {
+func emitDeferExpression(tc *int, insts *[]ir.Instruction, n ast.DeferExpression, tapeSize int) Label {
 	body := make([]ir.Instruction, 0)
 	l := EmitInstruction(tc, &body, n.Block, tapeSize)
 	bodylength := uint64(len(body))
@@ -154,7 +154,7 @@ func emitDeferExpression(tc *int, insts *[]ir.Instruction, n parser.DeferExpress
 }
 
 // emitUnaryExpression negates: a tape is unsigned, so this is zero minus the value.
-func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n parser.UnaryExpression, tapeSize int) Label {
+func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n ast.UnaryExpression, tapeSize int) Label {
 	// A tape is unsigned, so negating is taking the value away from zero and letting it
 	// wrap: -5 is the same tape as 0 - 5. Emitting the subtraction says exactly that,
 	// and every stage below — the evaluator, the lowering, the EVM writer — already
@@ -174,7 +174,7 @@ func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n parser.UnaryExpress
 }
 
 // emitRelativeExpression compares two values.
-func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n parser.RelativeExpression, tapeSize int) Label {
+func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n ast.RelativeExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -196,7 +196,7 @@ func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n parser.RelativeE
 }
 
 // emitBooleanExpression combines two truth values.
-func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n parser.BooleanExpression, tapeSize int) Label {
+func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n ast.BooleanExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -213,7 +213,7 @@ func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n parser.BooleanExp
 }
 
 // emitTapeBracketExpression builds a tape byte by byte.
-func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n parser.TapeBracketExpression, tapeSize int) Label {
+func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBracketExpression, tapeSize int) Label {
 	// Create the initial tape, all zeros
 	l := GenerateLabel(tc)
 	tape := byteutil.FalseTape(tapeSize)
@@ -231,7 +231,7 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n parser.TapeBr
 }
 
 // emitStructDeclaration answers the neutral value: a directive does no work.
-func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ parser.StructDeclaration, tapeSize int) Label {
+func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclaration, tapeSize int) Label {
 	// A directive emits no work. It still answers with a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
 	l := GenerateLabel(tc)
@@ -241,7 +241,7 @@ func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ parser.StructDecl
 }
 
 // emitStructLiteral lays one tape per field, end to end.
-func emitStructLiteral(tc *int, insts *[]ir.Instruction, n parser.StructLiteral, tapeSize int) Label {
+func emitStructLiteral(tc *int, insts *[]ir.Instruction, n ast.StructLiteral, tapeSize int) Label {
 	// One tape per field, laid end to end — the shape a reel of the same length has.
 	// Instructions carry two operands, so the run is built by chaining, the way a tape
 	// literal chains ir.OpPull.
@@ -263,7 +263,7 @@ func emitStructLiteral(tc *int, insts *[]ir.Instruction, n parser.StructLiteral,
 }
 
 // emitFieldExpression reads one tape out of a run, by an index resolved while parsing.
-func emitFieldExpression(tc *int, insts *[]ir.Instruction, n parser.FieldExpression, tapeSize int) Label {
+func emitFieldExpression(tc *int, insts *[]ir.Instruction, n ast.FieldExpression, tapeSize int) Label {
 	// The index was resolved while parsing, so it goes in as an immediate — the same
 	// shape head and tail use. Nothing here knows the field had a name.
 	lv := EmitInstruction(tc, insts, n.Expression, tapeSize)
@@ -274,7 +274,7 @@ func emitFieldExpression(tc *int, insts *[]ir.Instruction, n parser.FieldExpress
 }
 
 // emitShapedExpression emits what was shaped: `as` is a claim, not an operation.
-func emitShapedExpression(tc *int, insts *[]ir.Instruction, n parser.ShapedExpression, tapeSize int) Label {
+func emitShapedExpression(tc *int, insts *[]ir.Instruction, n ast.ShapedExpression, tapeSize int) Label {
 	// `as` says how to read a value, which is a question the compiler answers and the
 	// program never asks: what is left is the value itself.
 	return EmitInstruction(tc, insts, n.Expression, tapeSize)
@@ -282,7 +282,7 @@ func emitShapedExpression(tc *int, insts *[]ir.Instruction, n parser.ShapedExpre
 }
 
 // emitPullExpression shifts a tape left, the value entering at the right.
-func emitPullExpression(tc *int, insts *[]ir.Instruction, n parser.PullExpression, tapeSize int) Label {
+func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, tapeSize int) Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
@@ -292,7 +292,7 @@ func emitPullExpression(tc *int, insts *[]ir.Instruction, n parser.PullExpressio
 }
 
 // emitHeadExpression keeps the first bytes of a tape.
-func emitHeadExpression(tc *int, insts *[]ir.Instruction, n parser.HeadExpression, tapeSize int) Label {
+func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, tapeSize int) Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
@@ -302,7 +302,7 @@ func emitHeadExpression(tc *int, insts *[]ir.Instruction, n parser.HeadExpressio
 }
 
 // emitTailExpression drops the first bytes of a tape.
-func emitTailExpression(tc *int, insts *[]ir.Instruction, n parser.TailExpression, tapeSize int) Label {
+func emitTailExpression(tc *int, insts *[]ir.Instruction, n ast.TailExpression, tapeSize int) Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
@@ -312,7 +312,7 @@ func emitTailExpression(tc *int, insts *[]ir.Instruction, n parser.TailExpressio
 }
 
 // emitPushExpression shifts a tape right, the value entering at the left.
-func emitPushExpression(tc *int, insts *[]ir.Instruction, n parser.PushExpression, tapeSize int) Label {
+func emitPushExpression(tc *int, insts *[]ir.Instruction, n ast.PushExpression, tapeSize int) Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
@@ -322,7 +322,7 @@ func emitPushExpression(tc *int, insts *[]ir.Instruction, n parser.PushExpressio
 }
 
 // emitIfExpression lays out the test, the body and the else, with the jumps between them.
-func emitIfExpression(tc *int, insts *[]ir.Instruction, n parser.IfExpression, tapeSize int) Label {
+func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tapeSize int) Label {
 	var bl, eul []byte
 
 	/*Extract Else body*/
@@ -357,7 +357,7 @@ func emitIfExpression(tc *int, insts *[]ir.Instruction, n parser.IfExpression, t
 }
 
 // emitCalleeLiteral applies values to a scope.
-func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n parser.CalleeLiteral, tapeSize int) Label {
+func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, tapeSize int) Label {
 	for i, p := range n.Params {
 		ll := EmitInstruction(tc, insts, p.Expression, tapeSize)
 		l := GenerateLabel(tc)
@@ -370,7 +370,7 @@ func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n parser.CalleeLiteral,
 }
 
 // emitPrintStatement writes a value in one of the three readings.
-func emitPrintStatement(tc *int, insts *[]ir.Instruction, n parser.PrintStatement, tapeSize int) Label {
+func emitPrintStatement(tc *int, insts *[]ir.Instruction, n ast.PrintStatement, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Param, tapeSize)
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, printOpCodes[n.Format], ll, nil))
@@ -379,7 +379,7 @@ func emitPrintStatement(tc *int, insts *[]ir.Instruction, n parser.PrintStatemen
 }
 
 // emitAssertStatement checks a condition, carrying its message as bytes.
-func emitAssertStatement(tc *int, insts *[]ir.Instruction, n parser.AssertStatement, tapeSize int) Label {
+func emitAssertStatement(tc *int, insts *[]ir.Instruction, n ast.AssertStatement, tapeSize int) Label {
 	// The message rides in the instruction as the bytes it is, not as a value: it is
 	// written for whoever reads the result, and a value would have to fit in a tape.
 	cond := EmitInstruction(tc, insts, n.Condition, tapeSize)
@@ -390,7 +390,7 @@ func emitAssertStatement(tc *int, insts *[]ir.Instruction, n parser.AssertStatem
 }
 
 // emitFeedExpression reads the nth value applied to this scope.
-func emitFeedExpression(tc *int, insts *[]ir.Instruction, n parser.FeedExpression, tapeSize int) Label {
+func emitFeedExpression(tc *int, insts *[]ir.Instruction, n ast.FeedExpression, tapeSize int) Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpGetFeed, byteutil.FromUint64(n.Nth.Value), nil))
 	return l
@@ -398,7 +398,7 @@ func emitFeedExpression(tc *int, insts *[]ir.Instruction, n parser.FeedExpressio
 }
 
 // emitBinaryExpression does arithmetic on two values.
-func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n parser.BinaryExpression, tapeSize int) Label {
+func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpression, tapeSize int) Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -423,7 +423,7 @@ func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n parser.BinaryExpre
 }
 
 // emitNumberLiteral saves a number as a tape.
-func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n parser.NumberLiteral, tapeSize int) Label {
+func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize), nil))
 	return l
@@ -431,7 +431,7 @@ func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n parser.NumberLiteral,
 }
 
 // emitTextLiteral saves text as the tape of its bytes.
-func emitTextLiteral(tc *int, insts *[]ir.Instruction, n parser.TextLiteral, tapeSize int) Label {
+func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSize int) Label {
 	// Text is a tape holding its bytes, so it saves like any other value.
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
@@ -440,7 +440,7 @@ func emitTextLiteral(tc *int, insts *[]ir.Instruction, n parser.TextLiteral, tap
 }
 
 // emitBooleanLiteral saves true or false, which are tapes like any other.
-func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n parser.BooleanLiteral, tapeSize int) Label {
+func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
 	return l
@@ -448,15 +448,15 @@ func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n parser.BooleanLitera
 }
 
 // emitIdentifierLiteral loads what a name is bound to.
-func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n parser.IdentifierLiteral, tapeSize int) Label {
+func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLiteral, tapeSize int) Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, n.Token.GetMatch(), nil))
 	return l
 
 }
 
-func (e *emt) Emit(ast parser.AST) ([]ir.Instruction, error) {
-	program, err := e.EmitProgram(ast)
+func (e *emt) Emit(tree ast.AST) ([]ir.Instruction, error) {
+	program, err := e.EmitProgram(tree)
 	if err != nil {
 		return nil, err
 	}
@@ -465,12 +465,12 @@ func (e *emt) Emit(ast parser.AST) ([]ir.Instruction, error) {
 
 // EmitProgram compiles ast and records where each top-level expression landed, so a caller
 // can run them one at a time and report each value as it is produced.
-func (e *emt) EmitProgram(ast parser.AST) (Program, error) {
+func (e *emt) EmitProgram(tree ast.AST) (Program, error) {
 	tc := 0
 	insts := make([]ir.Instruction, 0)
-	exprs := make([]Expression, 0, len(ast.Nodes))
+	exprs := make([]Expression, 0, len(tree.Nodes))
 
-	for _, node := range ast.Nodes {
+	for _, node := range tree.Nodes {
 		from := len(insts)
 		label := EmitInstruction(&tc, &insts, node, e.tapeSize)
 		exprs = append(exprs, Expression{From: from, To: len(insts), Label: label})
@@ -479,7 +479,7 @@ func (e *emt) EmitProgram(ast parser.AST) (Program, error) {
 	return Program{
 		Instructions: insts,
 		Expressions:  exprs,
-		Warnings:     append(checkDeferCapacity(ast.Nodes, e.tapeSize), checkAsserts(ast.Nodes)...),
+		Warnings:     append(checkDeferCapacity(tree.Nodes, e.tapeSize), checkAsserts(tree.Nodes)...),
 	}, nil
 }
 

--- a/emitter/golden_test.go
+++ b/emitter/golden_test.go
@@ -34,11 +34,11 @@ func TestEmittedProgramMatchesTheGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "wide.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "wide.ar", Tokens: tokens}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	insts, err := New(NewEmitterOptions{}).Emit(ast)
+	insts, err := New(NewEmitterOptions{}).Emit(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -15,11 +15,11 @@ func compileWith(t *testing.T, source string, tapeSize int) Program {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	program, err := New(NewEmitterOptions{TapeSize: tapeSize}).EmitProgram(ast)
+	program, err := New(NewEmitterOptions{TapeSize: tapeSize}).EmitProgram(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}
@@ -64,8 +64,8 @@ func TestEmitMatchesEmitProgram(t *testing.T) {
 	program := compile(t, source)
 
 	tokens, _ := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
-	ast, _ := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
-	insts, err := New(NewEmitterOptions{}).Emit(ast)
+	tree, _ := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	insts, err := New(NewEmitterOptions{}).Emit(tree)
 	if err != nil {
 		t.Fatalf("Emit: %v", err)
 	}

--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 )
 
 // A Warning is something worth saying about a program that is not a reason to refuse it.
@@ -37,7 +37,7 @@ func (w Warning) Positioned() bool {
 // This is a warning rather than an error because the count is static: it cannot know how
 // often a scope actually runs. And it is never checked at runtime — a program that is
 // already running should not be stopped by a limit its shape implied.
-func checkDeferCapacity(nodes []parser.Node, tapeSize int) []Warning {
+func checkDeferCapacity(nodes []ast.Node, tapeSize int) []Warning {
 	tapeSize = byteutil.TapeSize(tapeSize)
 	if tapeSize >= 8 {
 		// A scope would need more than 2^64 defers to wrap; nothing to say.
@@ -46,8 +46,8 @@ func checkDeferCapacity(nodes []parser.Node, tapeSize int) []Warning {
 	capacity := uint64(1) << (8 * tapeSize)
 
 	warnings := make([]Warning, 0)
-	var walk func(scope []parser.Node)
-	walk = func(scope []parser.Node) {
+	var walk func(scope []ast.Node)
+	walk = func(scope []ast.Node) {
 		defers := 0
 		for _, node := range scope {
 			if countDefers(node, &defers, walk) {
@@ -69,13 +69,13 @@ func checkDeferCapacity(nodes []parser.Node, tapeSize int) []Warning {
 // An assertion belongs to "aurora test"; a plain run consumes it and moves on, so the
 // point of the warning is to say that out loud rather than let someone believe a check
 // ran. Each one is named by position, so an editor can jump to it.
-func checkAsserts(nodes []parser.Node) []Warning {
+func checkAsserts(nodes []ast.Node) []Warning {
 	warnings := make([]Warning, 0)
 
-	var walk func(scope []parser.Node)
-	walk = func(scope []parser.Node) {
+	var walk func(scope []ast.Node)
+	walk = func(scope []ast.Node) {
 		for _, node := range scope {
-			if assertion, ok := node.(parser.AssertStatement); ok {
+			if assertion, ok := node.(ast.AssertStatement); ok {
 				warning := Warning{Message: "assert only runs under 'aurora test'; ignored here"}
 				if assertion.Token != nil {
 					warning.Line = assertion.Token.GetLine()
@@ -93,31 +93,31 @@ func checkAsserts(nodes []parser.Node) []Warning {
 }
 
 // childScopesOf returns the expressions a node holds, so a walk reaches what is nested.
-func childScopesOf(node parser.Node) []parser.Node {
+func childScopesOf(node ast.Node) []ast.Node {
 	switch n := node.(type) {
-	case parser.IdentLiteral:
-		return []parser.Node{n.Value}
-	case parser.BlockExpression:
+	case ast.IdentLiteral:
+		return []ast.Node{n.Value}
+	case ast.BlockExpression:
 		return n.Body
-	case parser.DeferExpression:
+	case ast.DeferExpression:
 		return n.Block.Body
-	case parser.IfExpression:
-		body := make([]parser.Node, 0, len(n.Body)+1)
+	case ast.IfExpression:
+		body := make([]ast.Node, 0, len(n.Body)+1)
 		body = append(body, n.Body...)
 		if n.Else != nil {
 			body = append(body, n.Else.Body...)
 		}
 		return body
-	case parser.PrintStatement:
-		return []parser.Node{n.Param}
-	case parser.StructLiteral:
+	case ast.PrintStatement:
+		return []ast.Node{n.Param}
+	case ast.StructLiteral:
 		// A field can hold a deferred scope, so the values of a struct are walked like any
 		// other place a scope can hide.
 		return n.Values
-	case parser.FieldExpression:
-		return []parser.Node{n.Expression}
-	case parser.ShapedExpression:
-		return []parser.Node{n.Expression}
+	case ast.FieldExpression:
+		return []ast.Node{n.Expression}
+	case ast.ShapedExpression:
+		return []ast.Node{n.Expression}
 	default:
 		return nil
 	}
@@ -125,31 +125,31 @@ func childScopesOf(node parser.Node) []parser.Node {
 
 // countDefers adds node's own defers to count and walks the scopes it opens, since each of
 // those keeps its own tally.
-func countDefers(node parser.Node, count *int, walk func([]parser.Node)) bool {
+func countDefers(node ast.Node, count *int, walk func([]ast.Node)) bool {
 	switch n := node.(type) {
-	case parser.DeferExpression:
+	case ast.DeferExpression:
 		*count++
 		walk(n.Block.Body)
-	case parser.IdentLiteral:
+	case ast.IdentLiteral:
 		return countDefers(n.Value, count, walk)
-	case parser.BlockExpression:
+	case ast.BlockExpression:
 		walk(n.Body)
-	case parser.IfExpression:
+	case ast.IfExpression:
 		walk(n.Body)
 		if n.Else != nil {
 			walk(n.Else.Body)
 		}
-	case parser.PrintStatement:
+	case ast.PrintStatement:
 		return countDefers(n.Param, count, walk)
-	case parser.StructLiteral:
+	case ast.StructLiteral:
 		for _, value := range n.Values {
 			if !countDefers(value, count, walk) {
 				return false
 			}
 		}
-	case parser.FieldExpression:
+	case ast.FieldExpression:
 		return countDefers(n.Expression, count, walk)
-	case parser.ShapedExpression:
+	case ast.ShapedExpression:
 		return countDefers(n.Expression, count, walk)
 	}
 	return true

--- a/evaluator/assert_test.go
+++ b/evaluator/assert_test.go
@@ -18,11 +18,11 @@ func evaluateAsserts(t *testing.T, source string, asserts bool) *Evaluator {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "checks.test.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "checks.test.ar", Tokens: tokens}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+	insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -516,7 +516,7 @@ func runEvaluateCase(t *testing.T, cases []EvaluateCase, options RunEvaluateCase
 				return
 			}
 
-			ast, err := parser.New(parser.NewParserOptions{
+			tree, err := parser.New(parser.NewParserOptions{
 				Filename: options.Filename,
 				Tokens:   tokens,
 			}).Parse()
@@ -525,7 +525,7 @@ func runEvaluateCase(t *testing.T, cases []EvaluateCase, options RunEvaluateCase
 				return
 			}
 
-			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
@@ -1209,7 +1209,7 @@ func runAssertCase(t *testing.T, cases []AssertCase) {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			ast, err := parser.New(parser.NewParserOptions{
+			tree, err := parser.New(parser.NewParserOptions{
 				// assert is only accepted in a test file
 				Filename: "assert.test.ar",
 				Tokens:   tokens,
@@ -1218,7 +1218,7 @@ func runAssertCase(t *testing.T, cases []AssertCase) {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(ast)
+			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return

--- a/evaluator/output_order_test.go
+++ b/evaluator/output_order_test.go
@@ -32,11 +32,11 @@ func runInOrder(t *testing.T, source string) []string {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	program, err := emitter.New(emitter.NewEmitterOptions{}).EmitProgram(ast)
+	program, err := emitter.New(emitter.NewEmitterOptions{}).EmitProgram(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}

--- a/evaluator/tape_size_test.go
+++ b/evaluator/tape_size_test.go
@@ -22,14 +22,14 @@ func runWithTapeSize(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{
 		Filename: "main.ar", Tokens: tokens,
 		TapeSize: tapeSize,
 	}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(ast)
+	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}
@@ -59,7 +59,7 @@ func runAndError(t *testing.T, source string, tapeSize int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	ast, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{
 		Filename: "main.ar",
 		Tokens:   tokens,
 		TapeSize: tapeSize,
@@ -67,7 +67,7 @@ func runAndError(t *testing.T, source string, tapeSize int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(ast)
+	insts, err := emitter.New(emitter.NewEmitterOptions{TapeSize: tapeSize}).Emit(tree)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/compile.go
+++ b/internal/cli/compile.go
@@ -42,7 +42,7 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (e
 		}
 	}
 
-	ast, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{
 		Filename: source,
 		Tokens:   tokens,
 		TapeSize: tapeSize,
@@ -53,14 +53,14 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (e
 	// A phase returns what it made and does not show it; showing is decided here, once the
 	// phase has finished, which is why the output is no longer on-time.
 	if slices.Contains(loggers, "parser") {
-		if err := trace.AST(traces, ast); err != nil {
+		if err := trace.AST(traces, tree); err != nil {
 			return emitter.Program{}, err
 		}
 	}
 
 	program, err := emitter.New(emitter.NewEmitterOptions{
 		TapeSize: tapeSize,
-	}).EmitProgram(ast)
+	}).EmitProgram(tree)
 	if err != nil {
 		return emitter.Program{}, err
 	}

--- a/internal/trace/trace.go
+++ b/internal/trace/trace.go
@@ -20,7 +20,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/ir"
 	"github.com/guiferpa/aurora/wire/token"
 )
@@ -39,7 +39,7 @@ func Tokens(w io.Writer, tokens []token.Token) error {
 }
 
 // AST writes the tree the parser produced, as JSON.
-func AST(w io.Writer, ast parser.AST) error {
+func AST(w io.Writer, ast ast.AST) error {
 	bs, err := json.MarshalIndent(wrapNode(ast), "", "  ")
 	if err != nil {
 		return err
@@ -63,7 +63,7 @@ type node struct {
 	Data any    `json:"data"`
 }
 
-var nodeType = reflect.TypeOf((*parser.Node)(nil)).Elem()
+var nodeType = reflect.TypeOf((*ast.Node)(nil)).Elem()
 
 // wrapNode walks a node and labels every node inside it with its type.
 //
@@ -101,10 +101,10 @@ func wrapNode(n any) any {
 		value := v.Field(i).Interface()
 
 		switch value := value.(type) {
-		case parser.Node:
+		case ast.Node:
 			fields[field.Tag.Get("json")] = wrapNode(value)
 
-		case []parser.Node:
+		case []ast.Node:
 			wrapped := make([]any, 0, len(value))
 			for _, n := range value {
 				wrapped = append(wrapped, wrapNode(n))

--- a/internal/trace/trace_test.go
+++ b/internal/trace/trace_test.go
@@ -9,35 +9,36 @@ import (
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 )
 
 // compile runs the front end over source, which is what a host hands to trace.
-func compile(t *testing.T, source string) (parser.AST, emitter.Program) {
+func compile(t *testing.T, source string) (ast.AST, emitter.Program) {
 	t.Helper()
 
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	ast, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
-	program, err := emitter.New(emitter.NewEmitterOptions{}).EmitProgram(ast)
+	program, err := emitter.New(emitter.NewEmitterOptions{}).EmitProgram(tree)
 	if err != nil {
 		t.Fatalf("emitter: %v", err)
 	}
-	return ast, program
+	return tree, program
 }
 
 // The tree is shown with every node labelled by its type, which is the first thing anyone
 // reading a tree looks for. Positions are left out: a token carries its whole location, and
 // printing that drowns the tree it belongs to.
 func TestASTNamesEveryNode(t *testing.T) {
-	ast, _ := compile(t, "ident a = 1 + 2;\n")
+	tree, _ := compile(t, "ident a = 1 + 2;\n")
 
 	out := bytes.NewBuffer(nil)
-	if err := AST(out, ast); err != nil {
+	if err := AST(out, tree); err != nil {
 		t.Fatalf("AST: %v", err)
 	}
 
@@ -52,10 +53,10 @@ func TestASTNamesEveryNode(t *testing.T) {
 // An empty program is still a tree, and showing it must not fail: a host asks for the tree
 // before knowing whether there is anything in it.
 func TestASTOfAnEmptyProgram(t *testing.T) {
-	ast, _ := compile(t, "")
+	tree, _ := compile(t, "")
 
 	out := bytes.NewBuffer(nil)
-	if err := AST(out, ast); err != nil {
+	if err := AST(out, tree); err != nil {
 		t.Errorf("AST of an empty program: %v", err)
 	}
 	if out.Len() == 0 {
@@ -94,9 +95,9 @@ func (failing) Write([]byte) (int, error) { return 0, errors.New("broken pipe") 
 // something that has gone away has to hear about it — that is the whole reason this lives
 // on the host side rather than printing from inside a phase.
 func TestWriterErrorsAreReturned(t *testing.T) {
-	ast, program := compile(t, "1 + 2;\n")
+	tree, program := compile(t, "1 + 2;\n")
 
-	if err := AST(failing{}, ast); err == nil {
+	if err := AST(failing{}, tree); err == nil {
 		t.Error("AST swallowed the writer error")
 	}
 	if err := Instructions(failing{}, program.Instructions); err == nil {

--- a/lsp/textdoc/validator.go
+++ b/lsp/textdoc/validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/lsp"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -30,7 +31,7 @@ type Analysis struct {
 	Source string
 	Mapper *lsp.Mapper
 	Tokens []token.Token
-	AST    *parser.AST
+	AST    *ast.AST
 	Err    error
 }
 
@@ -61,7 +62,7 @@ func Analyze(doc Document) *Analysis {
 		return analysis
 	}
 
-	ast, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{
 		Filename: doc.Filename,
 		Tokens:   tokens,
 		// How wide a value is decides what fits in one, so the document is read in the
@@ -72,7 +73,7 @@ func Analyze(doc Document) *Analysis {
 		analysis.Err = err
 		return analysis
 	}
-	analysis.AST = &ast
+	analysis.AST = &tree
 
 	return analysis
 }
@@ -231,13 +232,13 @@ func CompletionItemsFor(doc Document, pos lsp.Position, snippets bool) []Complet
 
 // FindIdent looks for the declaration of name, walking into the expression forms that
 // carry a body.
-func FindIdent(nodes []parser.Node, name string) *parser.IdentLiteral {
+func FindIdent(nodes []ast.Node, name string) *ast.IdentLiteral {
 	for _, node := range nodes {
-		if ident, ok := node.(parser.IdentLiteral); ok {
+		if ident, ok := node.(ast.IdentLiteral); ok {
 			if ident.Id == name {
 				return &ident
 			}
-			if found := FindIdent([]parser.Node{ident.Value}, name); found != nil {
+			if found := FindIdent([]ast.Node{ident.Value}, name); found != nil {
 				return found
 			}
 		}
@@ -249,12 +250,12 @@ func FindIdent(nodes []parser.Node, name string) *parser.IdentLiteral {
 }
 
 // CollectIdents lists every identifier declared in the document, outermost first.
-func CollectIdents(nodes []parser.Node) []parser.IdentLiteral {
-	idents := make([]parser.IdentLiteral, 0)
+func CollectIdents(nodes []ast.Node) []ast.IdentLiteral {
+	idents := make([]ast.IdentLiteral, 0)
 	for _, node := range nodes {
-		if ident, ok := node.(parser.IdentLiteral); ok {
+		if ident, ok := node.(ast.IdentLiteral); ok {
 			idents = append(idents, ident)
-			idents = append(idents, CollectIdents([]parser.Node{ident.Value})...)
+			idents = append(idents, CollectIdents([]ast.Node{ident.Value})...)
 			continue
 		}
 		idents = append(idents, CollectIdents(childrenOf(node))...)
@@ -262,14 +263,14 @@ func CollectIdents(nodes []parser.Node) []parser.IdentLiteral {
 	return idents
 }
 
-func childrenOf(node parser.Node) []parser.Node {
+func childrenOf(node ast.Node) []ast.Node {
 	switch n := node.(type) {
-	case parser.BlockExpression:
+	case ast.BlockExpression:
 		return n.Body
-	case parser.DeferExpression:
+	case ast.DeferExpression:
 		return n.Block.Body
-	case parser.IfExpression:
-		body := make([]parser.Node, 0, len(n.Body)+1)
+	case ast.IfExpression:
+		body := make([]ast.Node, 0, len(n.Body)+1)
 		body = append(body, n.Body...)
 		if n.Else != nil {
 			body = append(body, n.Else.Body...)
@@ -280,31 +281,31 @@ func childrenOf(node parser.Node) []parser.Node {
 	}
 }
 
-func describeNode(node parser.Node) string {
+func describeNode(node ast.Node) string {
 	switch node.(type) {
-	case parser.NumberLiteral:
+	case ast.NumberLiteral:
 		return "number"
-	case parser.BooleanLiteral:
+	case ast.BooleanLiteral:
 		return "boolean"
-	case parser.TextLiteral:
+	case ast.TextLiteral:
 		return "text"
-	case parser.IdentifierLiteral:
+	case ast.IdentifierLiteral:
 		return "identifier"
-	case parser.TapeBracketExpression:
+	case ast.TapeBracketExpression:
 		return "tape"
-	case parser.PullExpression, parser.PushExpression, parser.HeadExpression, parser.TailExpression:
+	case ast.PullExpression, ast.PushExpression, ast.HeadExpression, ast.TailExpression:
 		return "tape operation"
-	case parser.BinaryExpression:
+	case ast.BinaryExpression:
 		return "arithmetic expression"
-	case parser.RelativeExpression, parser.BooleanExpression:
+	case ast.RelativeExpression, ast.BooleanExpression:
 		return "boolean expression"
-	case parser.IfExpression:
+	case ast.IfExpression:
 		return "if expression"
-	case parser.BlockExpression:
+	case ast.BlockExpression:
 		return "scope"
-	case parser.DeferExpression:
+	case ast.DeferExpression:
 		return "deferred scope"
-	case parser.CalleeLiteral:
+	case ast.CalleeLiteral:
 		return "call"
 	default:
 		return "expression"

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -7,13 +7,14 @@ import (
 	"strings"
 
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
 type Parser interface {
 	GetLookahead() token.Token
 	EatToken(tokenId string) (token.Token, error)
-	Parse() (AST, error)
+	Parse() (ast.AST, error)
 }
 
 type pr struct {
@@ -29,27 +30,27 @@ type pr struct {
 }
 
 // Helper functions to validate node types for tape operations
-func isValidTapeTarget(node Node) bool {
+func isValidTapeTarget(node ast.Node) bool {
 	switch node.(type) {
-	case TapeBracketExpression, NumberLiteral, IdentifierLiteral,
-		PullExpression, PushExpression, HeadExpression, TailExpression:
+	case ast.TapeBracketExpression, ast.NumberLiteral, ast.IdentifierLiteral,
+		ast.PullExpression, ast.PushExpression, ast.HeadExpression, ast.TailExpression:
 		return true
 	default:
 		return false
 	}
 }
 
-func isValidTapeItem(node Node) bool {
+func isValidTapeItem(node ast.Node) bool {
 	switch node.(type) {
-	case TapeBracketExpression, NumberLiteral, IdentifierLiteral:
+	case ast.TapeBracketExpression, ast.NumberLiteral, ast.IdentifierLiteral:
 		return true
 	default:
 		return false
 	}
 }
 
-func (p *pr) ParseCallee(id IdentifierLiteral) (Node, error) {
-	params := make([]ParameterLiteral, 0)
+func (p *pr) ParseCallee(id ast.IdentifierLiteral) (ast.Node, error) {
+	params := make([]ast.ParameterLiteral, 0)
 	if p.GetLookahead().GetTag().Id != token.O_PAREN {
 		return id, nil
 	}
@@ -61,7 +62,7 @@ func (p *pr) ParseCallee(id IdentifierLiteral) (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		params = append(params, ParameterLiteral{expr})
+		params = append(params, ast.ParameterLiteral{Expression: expr})
 		if p.GetLookahead().GetTag().Id == token.C_PAREN {
 			break
 		}
@@ -72,38 +73,38 @@ func (p *pr) ParseCallee(id IdentifierLiteral) (Node, error) {
 	if _, err := p.EatToken(token.C_PAREN); err != nil {
 		return nil, err
 	}
-	return CalleeLiteral{id, params}, nil
+	return ast.CalleeLiteral{Id: id, Params: params}, nil
 }
 
 // ParseIdentifier reads a plain name.
-func (p *pr) ParseIdentifier() (IdentifierLiteral, error) {
+func (p *pr) ParseIdentifier() (ast.IdentifierLiteral, error) {
 	tok, err := p.EatToken(token.ID)
 	if err != nil {
-		return IdentifierLiteral{}, err
+		return ast.IdentifierLiteral{}, err
 	}
-	return IdentifierLiteral{Value: string(tok.GetMatch()), Token: tok}, nil
+	return ast.IdentifierLiteral{Value: string(tok.GetMatch()), Token: tok}, nil
 }
 
-func (p *pr) ParseBooleanTrue() (BooleanLiteral, error) {
+func (p *pr) ParseBooleanTrue() (ast.BooleanLiteral, error) {
 	tok, err := p.EatToken(token.TRUE)
 	if err != nil {
-		return BooleanLiteral{}, err
+		return ast.BooleanLiteral{}, err
 	}
-	return BooleanLiteral{byteutil.TrueTape(p.tapeSize), tok}, nil
+	return ast.BooleanLiteral{Value: byteutil.TrueTape(p.tapeSize), Token: tok}, nil
 }
 
-func (p *pr) ParseBooleanFalse() (BooleanLiteral, error) {
+func (p *pr) ParseBooleanFalse() (ast.BooleanLiteral, error) {
 	tok, err := p.EatToken(token.FALSE)
 	if err != nil {
-		return BooleanLiteral{}, err
+		return ast.BooleanLiteral{}, err
 	}
-	return BooleanLiteral{byteutil.FalseTape(p.tapeSize), tok}, nil
+	return ast.BooleanLiteral{Value: byteutil.FalseTape(p.tapeSize), Token: tok}, nil
 }
 
-func (p *pr) ParseNumber() (NumberLiteral, error) {
+func (p *pr) ParseNumber() (ast.NumberLiteral, error) {
 	tok, err := p.EatToken(token.NUMBER)
 	if err != nil {
-		return NumberLiteral{}, err
+		return ast.NumberLiteral{}, err
 	}
 
 	raw := strings.ReplaceAll(string(tok.GetMatch()), "_", "")
@@ -113,23 +114,23 @@ func (p *pr) ParseNumber() (NumberLiteral, error) {
 		if n, err := strconv.ParseUint(raw[2:], 16, 64); err == nil {
 			return p.fitInTape(n, tok)
 		}
-		return NumberLiteral{}, err
+		return ast.NumberLiteral{}, err
 	}
 
 	// Parse as decimal
 	if n, err := strconv.ParseUint(raw, 10, 64); err == nil {
 		return p.fitInTape(n, tok)
 	}
-	return NumberLiteral{}, err
+	return ast.NumberLiteral{}, err
 }
 
 // fitInTape rejects a literal that the configured tape cannot hold, instead of letting it
 // be truncated silently at emission.
-func (p *pr) fitInTape(v uint64, tok token.Token) (NumberLiteral, error) {
+func (p *pr) fitInTape(v uint64, tok token.Token) (ast.NumberLiteral, error) {
 	if !byteutil.FitsInTape(v, p.tapeSize) {
-		return NumberLiteral{}, token.NewError(tok, "value %d does not fit in a %d-byte tape (max %d)", v, p.tapeSize, byteutil.MaxTapeValue(p.tapeSize))
+		return ast.NumberLiteral{}, token.NewError(tok, "value %d does not fit in a %d-byte tape (max %d)", v, p.tapeSize, byteutil.MaxTapeValue(p.tapeSize))
 	}
-	return NumberLiteral{v, tok}, nil
+	return ast.NumberLiteral{Value: v, Token: tok}, nil
 }
 
 // ParseText reads `"text"` into one tape holding its bytes.
@@ -137,29 +138,29 @@ func (p *pr) fitInTape(v uint64, tok token.Token) (NumberLiteral, error) {
 // The bytes are the text as written, in UTF-8, right aligned like every other value — so
 // "a" is the tape holding 97, which is the tape the number 97 is, and "café" is its five
 // UTF-8 bytes rather than four characters spread over four tapes.
-func (p *pr) ParseText() (TextLiteral, error) {
+func (p *pr) ParseText() (ast.TextLiteral, error) {
 	tok, err := p.EatToken(token.STRING)
 	if err != nil {
-		return TextLiteral{}, err
+		return ast.TextLiteral{}, err
 	}
 	match := tok.GetMatch()
 	if len(match) < 2 {
-		return TextLiteral{}, token.NewError(tok, "invalid string literal at line %d, column %d", tok.GetLine(), tok.GetColumn())
+		return ast.TextLiteral{}, token.NewError(tok, "invalid string literal at line %d, column %d", tok.GetLine(), tok.GetColumn())
 	}
 	content := match[1 : len(match)-1]
 
 	// A value is a tape, and a tape is tape_size bytes: text that does not fit is rejected
 	// where it was written, the same way a number that does not fit is.
 	if len(content) > p.tapeSize {
-		return TextLiteral{}, token.NewError(tok, "text is %d bytes but a tape holds %d at line %d and column %d",
+		return ast.TextLiteral{}, token.NewError(tok, "text is %d bytes but a tape holds %d at line %d and column %d",
 			len(content), p.tapeSize, tok.GetLine(), tok.GetColumn())
 	}
 
-	return TextLiteral{byteutil.PaddingTape(content, p.tapeSize), tok}, nil
+	return ast.TextLiteral{Value: byteutil.PaddingTape(content, p.tapeSize), Token: tok}, nil
 }
 
 // ParsePriExpr reads a primary and then whatever binds to it tightest: a field, a shape.
-func (p *pr) ParsePriExpr() (Node, error) {
+func (p *pr) ParsePriExpr() (ast.Node, error) {
 	expr, err := p.parsePrimaryExpr()
 	if err != nil {
 		return nil, err
@@ -167,7 +168,7 @@ func (p *pr) ParsePriExpr() (Node, error) {
 	return p.parsePostfix(expr)
 }
 
-func (p *pr) parsePrimaryExpr() (Node, error) {
+func (p *pr) parsePrimaryExpr() (ast.Node, error) {
 	lookahead := p.GetLookahead()
 	if lookahead.GetTag().Id == token.FEED {
 		return p.ParseFeed()
@@ -232,11 +233,11 @@ func (p *pr) parsePrimaryExpr() (Node, error) {
 	return id, nil
 }
 
-func (p *pr) ParseTapeBrk() (Node, error) {
+func (p *pr) ParseTapeBrk() (ast.Node, error) {
 	if _, err := p.EatToken(token.O_BRK); err != nil {
 		return nil, err
 	}
-	items := make([]Node, 0)
+	items := make([]ast.Node, 0)
 	for p.GetLookahead().GetTag().Id != token.C_BRK {
 		expr, err := p.ParseExpr()
 		if err != nil {
@@ -245,7 +246,7 @@ func (p *pr) ParseTapeBrk() (Node, error) {
 
 		// Validate: if item is a number literal, it must be between 0 and 255
 		// (since tapes store values as direct bytes)
-		if numNode, ok := expr.(NumberLiteral); ok {
+		if numNode, ok := expr.(ast.NumberLiteral); ok {
 			if numNode.Value > byteutil.MAX_BYTES {
 				return nil, fmt.Errorf("tape values must be between 0 and %d, got %d", byteutil.MAX_BYTES, numNode.Value)
 			}
@@ -266,10 +267,10 @@ func (p *pr) ParseTapeBrk() (Node, error) {
 	if len(items) > p.tapeSize {
 		return nil, token.NewError(closing, "tape literal has %d values but a tape holds %d bytes", len(items), p.tapeSize)
 	}
-	return TapeBracketExpression{Items: items}, nil
+	return ast.TapeBracketExpression{Items: items}, nil
 }
 
-func (p *pr) ParsePull() (Node, error) {
+func (p *pr) ParsePull() (ast.Node, error) {
 	if _, err := p.EatToken(token.PULL); err != nil {
 		return nil, err
 	}
@@ -289,10 +290,10 @@ func (p *pr) ParsePull() (Node, error) {
 	if !isValidTapeItem(expr) {
 		return nil, errors.New("it is not a valid append item")
 	}
-	return PullExpression{Target: target, Item: expr}, nil
+	return ast.PullExpression{Target: target, Item: expr}, nil
 }
 
-func (p *pr) ParseHead() (Node, error) {
+func (p *pr) ParseHead() (ast.Node, error) {
 	if _, err := p.EatToken(token.HEAD); err != nil {
 		return nil, err
 	}
@@ -308,10 +309,10 @@ func (p *pr) ParseHead() (Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return HeadExpression{Expression: expr, Length: length.Value}, nil
+	return ast.HeadExpression{Expression: expr, Length: length.Value}, nil
 }
 
-func (p *pr) ParseTail() (Node, error) {
+func (p *pr) ParseTail() (ast.Node, error) {
 	if _, err := p.EatToken(token.TAIL); err != nil {
 		return nil, err
 	}
@@ -327,10 +328,10 @@ func (p *pr) ParseTail() (Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return TailExpression{Expression: expr, Length: length.Value}, nil
+	return ast.TailExpression{Expression: expr, Length: length.Value}, nil
 }
 
-func (p *pr) ParsePush() (Node, error) {
+func (p *pr) ParsePush() (ast.Node, error) {
 	if _, err := p.EatToken(token.PUSH); err != nil {
 		return nil, err
 	}
@@ -350,10 +351,10 @@ func (p *pr) ParsePush() (Node, error) {
 	if !isValidTapeItem(expr) {
 		return nil, errors.New("it is not a valid push item")
 	}
-	return PushExpression{Target: target, Item: expr}, nil
+	return ast.PushExpression{Target: target, Item: expr}, nil
 }
 
-func (p *pr) ParseUnaExpr() (Node, error) {
+func (p *pr) ParseUnaExpr() (ast.Node, error) {
 	lookahead := p.GetLookahead()
 	if lookahead.GetTag().Id == token.SUB {
 		op, err := p.EatToken(token.SUB)
@@ -364,12 +365,12 @@ func (p *pr) ParseUnaExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return UnaryExpression{expr, OperationLiteral{string(op.GetMatch()), op}}, nil
+		return ast.UnaryExpression{Expression: expr, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 	return p.ParsePriExpr()
 }
 
-func (p *pr) ParseExpoExpr() (Node, error) {
+func (p *pr) ParseExpoExpr() (ast.Node, error) {
 	left, err := p.ParseUnaExpr()
 	if err != nil {
 		return nil, err
@@ -385,7 +386,7 @@ func (p *pr) ParseExpoExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return BinaryExpression{left, right, OperationLiteral{string(op.GetMatch()), op}}, nil
+		return ast.BinaryExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 
 	return left, nil
@@ -398,7 +399,7 @@ func (p *pr) ParseExpoExpr() (Node, error) {
 // as 20 / (5 / 2) and answered 10 instead of 2, and `4 / 2 * 6` read as 4 / (2 * 6) and
 // answered 0 instead of 12. Multiplication hid it — it is associative, so only a chain mixing
 // it with division gives a different answer.
-func (p *pr) ParseMultExpr() (Node, error) {
+func (p *pr) ParseMultExpr() (ast.Node, error) {
 	left, err := p.ParseExpoExpr()
 	if err != nil {
 		return nil, err
@@ -414,7 +415,7 @@ func (p *pr) ParseMultExpr() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			left = BinaryExpression{left, right, OperationLiteral{string(op.GetMatch()), op}}
+			left = ast.BinaryExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 			continue
 		}
 		if lookahead.GetTag().Id == token.DIV {
@@ -426,7 +427,7 @@ func (p *pr) ParseMultExpr() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			left = BinaryExpression{left, right, OperationLiteral{string(op.GetMatch()), op}}
+			left = ast.BinaryExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 			continue
 		}
 		break
@@ -435,7 +436,7 @@ func (p *pr) ParseMultExpr() (Node, error) {
 }
 
 // ParseAddExpr parses additive expressions left-associatively: a - b - c => (a - b) - c, a + b + c => (a + b) + c.
-func (p *pr) ParseAddExpr() (Node, error) {
+func (p *pr) ParseAddExpr() (ast.Node, error) {
 	left, err := p.ParseMultExpr()
 	if err != nil {
 		return nil, err
@@ -451,7 +452,7 @@ func (p *pr) ParseAddExpr() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			left = BinaryExpression{left, right, OperationLiteral{string(op.GetMatch()), op}}
+			left = ast.BinaryExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 			continue
 		}
 		if lookahead.GetTag().Id == token.SUB {
@@ -463,7 +464,7 @@ func (p *pr) ParseAddExpr() (Node, error) {
 			if err != nil {
 				return nil, err
 			}
-			left = BinaryExpression{left, right, OperationLiteral{string(op.GetMatch()), op}}
+			left = ast.BinaryExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 			continue
 		}
 		break
@@ -471,7 +472,7 @@ func (p *pr) ParseAddExpr() (Node, error) {
 	return left, nil
 }
 
-func (p *pr) ParseRelExpr() (Node, error) {
+func (p *pr) ParseRelExpr() (ast.Node, error) {
 	left, err := p.ParseAddExpr()
 	if err != nil {
 		return nil, err
@@ -486,7 +487,7 @@ func (p *pr) ParseRelExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return RelativeExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
+		return ast.RelativeExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 	if lookahead.GetTag().Id == token.DIFFERENT {
 		op, err := p.EatToken(token.DIFFERENT)
@@ -497,7 +498,7 @@ func (p *pr) ParseRelExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return RelativeExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
+		return ast.RelativeExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 	if lookahead.GetTag().Id == token.BIGGER {
 		op, err := p.EatToken(token.BIGGER)
@@ -508,7 +509,7 @@ func (p *pr) ParseRelExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return RelativeExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
+		return ast.RelativeExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 	if lookahead.GetTag().Id == token.SMALLER {
 		op, err := p.EatToken(token.SMALLER)
@@ -519,7 +520,7 @@ func (p *pr) ParseRelExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		return RelativeExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
+		return ast.RelativeExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}, nil
 	}
 	return left, nil
 }
@@ -530,7 +531,7 @@ func (p *pr) ParseRelExpr() (Node, error) {
 // read as `a and (b or c)`: `false and true or true` answered false where every language
 // that gives `and` the tighter binding answers true. Splitting them into two levels is what
 // makes `and` bind tighter, and the loop is what groups a chain to the left.
-func (p *pr) ParseBoolExpr() (Node, error) {
+func (p *pr) ParseBoolExpr() (ast.Node, error) {
 	left, err := p.ParseAndExpr()
 	if err != nil {
 		return nil, err
@@ -544,13 +545,13 @@ func (p *pr) ParseBoolExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		left = BooleanExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}
+		left = ast.BooleanExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 	}
 	return left, nil
 }
 
 // ParseAndExpr parses `and`, which binds tighter than `or` and looser than a comparison.
-func (p *pr) ParseAndExpr() (Node, error) {
+func (p *pr) ParseAndExpr() (ast.Node, error) {
 	left, err := p.ParseRelExpr()
 	if err != nil {
 		return nil, err
@@ -564,12 +565,12 @@ func (p *pr) ParseAndExpr() (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		left = BooleanExpression{left, right, OperationLiteral{Value: string(op.GetMatch()), Token: op}}
+		left = ast.BooleanExpression{Left: left, Right: right, Operation: ast.OperationLiteral{Value: string(op.GetMatch()), Token: op}}
 	}
 	return left, nil
 }
 
-func (p *pr) ParseBranchItem() (Node, error) {
+func (p *pr) ParseBranchItem() (ast.Node, error) {
 	expr, err := p.ParseExpr()
 	if err != nil {
 		return nil, err
@@ -582,10 +583,10 @@ func (p *pr) ParseBranchItem() (Node, error) {
 		return expr, nil
 	}
 
-	_, isBoolean := expr.(BooleanExpression)
-	_, isRel := expr.(RelativeExpression)
-	_, isLiteralBool := expr.(BooleanLiteral)
-	_, isId := expr.(IdentifierLiteral)
+	_, isBoolean := expr.(ast.BooleanExpression)
+	_, isRel := expr.(ast.RelativeExpression)
+	_, isLiteralBool := expr.(ast.BooleanLiteral)
+	_, isId := expr.(ast.IdentifierLiteral)
 	if !isBoolean && !isRel && !isLiteralBool && !isId {
 		return nil, errors.New("branch must have boolean expression as test")
 	}
@@ -608,14 +609,14 @@ func (p *pr) ParseBranchItem() (Node, error) {
 		return nil, err
 	}
 
-	return IfExpression{
+	return ast.IfExpression{
 		Test: expr,
-		Body: []Node{body},
-		Else: &ElseExpression{Body: []Node{euzeb}},
+		Body: []ast.Node{body},
+		Else: &ast.ElseExpression{Body: []ast.Node{euzeb}},
 	}, nil
 }
 
-func (p *pr) ParseBranch() (Node, error) {
+func (p *pr) ParseBranch() (ast.Node, error) {
 	if _, err := p.EatToken(token.BRANCH); err != nil {
 		return nil, err
 	}
@@ -636,7 +637,7 @@ func (p *pr) ParseBranch() (Node, error) {
 	return item, nil
 }
 
-func (p *pr) ParseBlockExpr() (Node, error) {
+func (p *pr) ParseBlockExpr() (ast.Node, error) {
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
 		return nil, err
 	}
@@ -647,10 +648,10 @@ func (p *pr) ParseBlockExpr() (Node, error) {
 	if _, err := p.EatToken(token.C_CUR_BRK); err != nil {
 		return nil, err
 	}
-	return BlockExpression{Body: exprs}, nil
+	return ast.BlockExpression{Body: exprs}, nil
 }
 
-func (p *pr) ParseDefer() (Node, error) {
+func (p *pr) ParseDefer() (ast.Node, error) {
 	if _, err := p.EatToken(token.DEFER); err != nil {
 		return nil, err
 	}
@@ -664,11 +665,11 @@ func (p *pr) ParseDefer() (Node, error) {
 	if _, err := p.EatToken(token.C_CUR_BRK); err != nil {
 		return nil, err
 	}
-	block := BlockExpression{Body: exprs}
-	return DeferExpression{Block: block}, nil
+	block := ast.BlockExpression{Body: exprs}
+	return ast.DeferExpression{Block: block}, nil
 }
 
-func (p *pr) ParseIf() (Node, error) {
+func (p *pr) ParseIf() (ast.Node, error) {
 	if _, err := p.EatToken(token.IF); err != nil {
 		return nil, err
 	}
@@ -688,12 +689,12 @@ func (p *pr) ParseIf() (Node, error) {
 	}
 	if p.GetLookahead().GetTag().Id == token.ELSE {
 		euze, err := p.ParseElse()
-		return IfExpression{test, body, euze}, err
+		return ast.IfExpression{Test: test, Body: body, Else: euze}, err
 	}
-	return IfExpression{test, body, nil}, nil
+	return ast.IfExpression{Test: test, Body: body, Else: nil}, nil
 }
 
-func (p *pr) ParseElse() (*ElseExpression, error) {
+func (p *pr) ParseElse() (*ast.ElseExpression, error) {
 	if _, err := p.EatToken(token.ELSE); err != nil {
 		return nil, err
 	}
@@ -707,10 +708,10 @@ func (p *pr) ParseElse() (*ElseExpression, error) {
 	if _, err := p.EatToken(token.C_CUR_BRK); err != nil {
 		return nil, err
 	}
-	return &ElseExpression{body}, nil
+	return &ast.ElseExpression{Body: body}, nil
 }
 
-func (p *pr) ParseIdent() (Node, error) {
+func (p *pr) ParseIdent() (ast.Node, error) {
 	if _, err := p.EatToken(token.IDENT); err != nil {
 		return nil, err
 	}
@@ -733,10 +734,10 @@ func (p *pr) ParseIdent() (Node, error) {
 	if shape := p.shapeOf(expr); shape != "" {
 		p.directives.Shapes[string(id.GetMatch())] = shape
 	}
-	return IdentLiteral{string(id.GetMatch()), id, expr}, nil
+	return ast.IdentLiteral{Id: string(id.GetMatch()), Token: id, Value: expr}, nil
 }
 
-func (p *pr) ParseExpr() (Node, error) {
+func (p *pr) ParseExpr() (ast.Node, error) {
 	lookahead := p.GetLookahead()
 	if lookahead == nil {
 		return nil, fmt.Errorf("unexpected end of input")
@@ -781,13 +782,13 @@ func (p *pr) ParseExpr() (Node, error) {
 }
 
 // printFormats maps each print builtin to the reading it asks for.
-var printFormats = map[string]PrintFormat{
-	token.PRINTB: PrintBytes,
-	token.PRINTC: PrintChars,
-	token.PRINTD: PrintDecimal,
+var printFormats = map[string]ast.PrintFormat{
+	token.PRINTB: ast.PrintBytes,
+	token.PRINTC: ast.PrintChars,
+	token.PRINTD: ast.PrintDecimal,
 }
 
-func (p *pr) ParsePrint(token string, format PrintFormat) (Node, error) {
+func (p *pr) ParsePrint(token string, format ast.PrintFormat) (ast.Node, error) {
 	if _, err := p.EatToken(token); err != nil {
 		return nil, err
 	}
@@ -795,10 +796,10 @@ func (p *pr) ParsePrint(token string, format PrintFormat) (Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return PrintStatement{Format: format, Param: expr}, nil
+	return ast.PrintStatement{Format: format, Param: expr}, nil
 }
 
-func (p *pr) ParseAssert() (Node, error) {
+func (p *pr) ParseAssert() (ast.Node, error) {
 	// Validate that assert can only be used in .test.ar files
 	if !strings.HasSuffix(p.filename, ".test.ar") {
 		lookahead := p.GetLookahead()
@@ -835,7 +836,7 @@ func (p *pr) ParseAssert() (Node, error) {
 		return nil, err
 	}
 
-	return AssertStatement{
+	return ast.AssertStatement{
 		Condition: condition,
 		Message:   string(quoted[1 : len(quoted)-1]),
 		Token:     t,
@@ -843,7 +844,7 @@ func (p *pr) ParseAssert() (Node, error) {
 }
 
 // ParseFeed parses the builtin "feed": feed(index), or feed index without parentheses.
-func (p *pr) ParseFeed() (Node, error) {
+func (p *pr) ParseFeed() (ast.Node, error) {
 	if _, err := p.EatToken(token.FEED); err != nil {
 		return nil, err
 	}
@@ -858,17 +859,17 @@ func (p *pr) ParseFeed() (Node, error) {
 		if _, err := p.EatToken(token.C_PAREN); err != nil {
 			return nil, err
 		}
-		return FeedExpression{nth}, nil
+		return ast.FeedExpression{Nth: nth}, nil
 	}
 	nth, err := p.ParseNumber()
 	if err != nil {
 		return nil, err
 	}
-	return FeedExpression{nth}, nil
+	return ast.FeedExpression{Nth: nth}, nil
 }
 
-func (p *pr) ParseExprs(t token.Tag) ([]Node, error) {
-	exprs := make([]Node, 0)
+func (p *pr) ParseExprs(t token.Tag) ([]ast.Node, error) {
+	exprs := make([]ast.Node, 0)
 	for {
 		lookahead := p.GetLookahead()
 		if lookahead == nil || lookahead.GetTag().Id == t.Id {
@@ -909,13 +910,13 @@ func (p *pr) EatToken(tokenId string) (token.Token, error) {
 	return currtok, nil
 }
 
-func (p *pr) Parse() (AST, error) {
+func (p *pr) Parse() (ast.AST, error) {
 	nodes, err := p.ParseExprs(token.TagEOF)
 	if err != nil {
-		return AST{}, err
+		return ast.AST{}, err
 	}
 
-	return AST{Filename: p.filename, Nodes: nodes}, nil
+	return ast.AST{Filename: p.filename, Nodes: nodes}, nil
 }
 
 type NewParserOptions struct {

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -120,24 +121,24 @@ func TestParse(t *testing.T) {
 		tok{[]byte("tok17"), token.TagSemicolon},
 		tok{[]byte("tok18"), token.TagEOF},
 	}
-	expected := AST{
+	expected := ast.AST{
 		Filename: "testing.ar",
-		Nodes: []Node{
-			IdentLiteral{
+		Nodes: []ast.Node{
+			ast.IdentLiteral{
 				Id:    "a",
 				Token: tokens[1],
-				Value: IfExpression{
-					Test: RelativeExpression{
-						Left:      NumberLiteral{Value: 10, Token: tokens[4]},
-						Right:     NumberLiteral{Value: 11, Token: tokens[6]},
-						Operation: OperationLiteral{Value: "tok6", Token: tokens[5]},
+				Value: ast.IfExpression{
+					Test: ast.RelativeExpression{
+						Left:      ast.NumberLiteral{Value: 10, Token: tokens[4]},
+						Right:     ast.NumberLiteral{Value: 11, Token: tokens[6]},
+						Operation: ast.OperationLiteral{Value: "tok6", Token: tokens[5]},
 					},
-					Body: []Node{
-						NumberLiteral{Value: 0, Token: tokens[8]},
+					Body: []ast.Node{
+						ast.NumberLiteral{Value: 0, Token: tokens[8]},
 					},
-					Else: &ElseExpression{
-						Body: []Node{
-							NumberLiteral{Value: 1, Token: tokens[13]},
+					Else: &ast.ElseExpression{
+						Body: []ast.Node{
+							ast.NumberLiteral{Value: 1, Token: tokens[13]},
 						},
 					},
 				},
@@ -145,11 +146,11 @@ func TestParse(t *testing.T) {
 		},
 	}
 	p := &pr{filename: "testing.ar", cursor: 0, tokens: tokens}
-	ast, err := p.Parse()
+	tree, err := p.Parse()
 	if err != nil {
 		t.Errorf("param: %v, %v", tokens, err)
 	}
-	if !ASTEqual(ast, expected) {
-		t.Errorf("\nexpected: %+v,\ngot: %+v", expected, ast)
+	if !ast.Equal(tree, expected) {
+		t.Errorf("\nexpected: %+v,\ngot: %+v", expected, tree)
 	}
 }

--- a/parser/shapes_test.go
+++ b/parser/shapes_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -14,26 +15,26 @@ import (
 // as long as the answer comes out right.
 
 // parse compiles source and returns the top-level nodes.
-func parse(t *testing.T, source string) []Node {
+func parse(t *testing.T, source string) []ast.Node {
 	t.Helper()
-	ast, err := parseSource(t, source, "main.ar")
+	tree, err := parseSource(t, source, "main.ar")
 	if err != nil {
 		t.Fatalf("parsing %q: %v", source, err)
 	}
-	return ast.Nodes
+	return tree.Nodes
 }
 
-func parseSource(t *testing.T, source, filename string) (AST, error) {
+func parseSource(t *testing.T, source, filename string) (ast.AST, error) {
 	t.Helper()
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
 	if err != nil {
-		return AST{}, err
+		return ast.AST{}, err
 	}
 	return New(NewParserOptions{Filename: filename, Tokens: tokens}).Parse()
 }
 
 // first returns the single top-level node, asserting the type.
-func first[T Node](t *testing.T, source string) T {
+func first[T ast.Node](t *testing.T, source string) T {
 	t.Helper()
 	nodes := parse(t, source)
 	if len(nodes) != 1 {
@@ -48,12 +49,12 @@ func first[T Node](t *testing.T, source string) T {
 }
 
 func TestParseIdentShape(t *testing.T) {
-	ident := first[IdentLiteral](t, "ident total = 42;")
+	ident := first[ast.IdentLiteral](t, "ident total = 42;")
 
 	if ident.Id != "total" {
 		t.Errorf("id = %q, want total", ident.Id)
 	}
-	number, ok := ident.Value.(NumberLiteral)
+	number, ok := ident.Value.(ast.NumberLiteral)
 	if !ok {
 		t.Fatalf("value is %T, want NumberLiteral", ident.Value)
 	}
@@ -75,7 +76,7 @@ func TestParseNumberShape(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.source, func(t *testing.T) {
-			if got := first[NumberLiteral](t, tc.source); got.Value != tc.want {
+			if got := first[ast.NumberLiteral](t, tc.source); got.Value != tc.want {
 				t.Errorf("value = %d, want %d", got.Value, tc.want)
 			}
 		})
@@ -83,12 +84,12 @@ func TestParseNumberShape(t *testing.T) {
 }
 
 func TestParseBooleanShape(t *testing.T) {
-	truth := first[BooleanLiteral](t, "true;")
+	truth := first[ast.BooleanLiteral](t, "true;")
 	if want := byteutil.TrueTape(byteutil.DefaultTapeSize); string(truth.Value) != string(want) {
 		t.Errorf("true = %v, want %v", truth.Value, want)
 	}
 
-	lie := first[BooleanLiteral](t, "false;")
+	lie := first[ast.BooleanLiteral](t, "false;")
 	if want := byteutil.FalseTape(byteutil.DefaultTapeSize); string(lie.Value) != string(want) {
 		t.Errorf("false = %v, want %v", lie.Value, want)
 	}
@@ -96,7 +97,7 @@ func TestParseBooleanShape(t *testing.T) {
 
 // Text is one more way of writing a tape: its bytes, right aligned, like every other value.
 func TestParseTextShape(t *testing.T) {
-	text := first[TextLiteral](t, `"hi";`)
+	text := first[ast.TextLiteral](t, `"hi";`)
 
 	want := byteutil.PaddingTape([]byte("hi"), byteutil.DefaultTapeSize)
 	if string(text.Value) != string(want) {
@@ -104,13 +105,13 @@ func TestParseTextShape(t *testing.T) {
 	}
 
 	// Which makes a text of one character the same tape as its number.
-	one := first[TextLiteral](t, `"a";`)
+	one := first[ast.TextLiteral](t, `"a";`)
 	if string(one.Value) != string(byteutil.PaddingTape([]byte{97}, byteutil.DefaultTapeSize)) {
 		t.Errorf(`"a" = %v, want the tape holding 97`, one.Value)
 	}
 
 	// An empty text is no bytes, which is the neutral value.
-	empty := first[TextLiteral](t, `"";`)
+	empty := first[ast.TextLiteral](t, `"";`)
 	if string(empty.Value) != string(byteutil.FalseTape(byteutil.DefaultTapeSize)) {
 		t.Errorf(`"" = %v, want a tape of zeros`, empty.Value)
 	}
@@ -129,68 +130,68 @@ func TestTextLongerThanATapeIsRejected(t *testing.T) {
 }
 
 func TestParseTapeLiteralShape(t *testing.T) {
-	tape := first[TapeBracketExpression](t, "[1, 2, 3];")
+	tape := first[ast.TapeBracketExpression](t, "[1, 2, 3];")
 	if len(tape.Items) != 3 {
 		t.Fatalf("got %d items, want 3", len(tape.Items))
 	}
 
-	empty := first[TapeBracketExpression](t, "[];")
+	empty := first[ast.TapeBracketExpression](t, "[];")
 	if len(empty.Items) != 0 {
 		t.Errorf("got %d items, want none", len(empty.Items))
 	}
 }
 
 func TestParseTapeOperationShapes(t *testing.T) {
-	pull := first[PullExpression](t, "pull [1] 2;")
-	if _, ok := pull.Target.(TapeBracketExpression); !ok {
+	pull := first[ast.PullExpression](t, "pull [1] 2;")
+	if _, ok := pull.Target.(ast.TapeBracketExpression); !ok {
 		t.Errorf("pull target is %T, want a tape", pull.Target)
 	}
-	if _, ok := pull.Item.(NumberLiteral); !ok {
+	if _, ok := pull.Item.(ast.NumberLiteral); !ok {
 		t.Errorf("pull item is %T, want a number", pull.Item)
 	}
 
-	push := first[PushExpression](t, "push [1] 2;")
-	if _, ok := push.Target.(TapeBracketExpression); !ok {
+	push := first[ast.PushExpression](t, "push [1] 2;")
+	if _, ok := push.Target.(ast.TapeBracketExpression); !ok {
 		t.Errorf("push target is %T, want a tape", push.Target)
 	}
 
-	head := first[HeadExpression](t, "head [1, 2, 3] 2;")
+	head := first[ast.HeadExpression](t, "head [1, 2, 3] 2;")
 	if head.Length != 2 {
 		t.Errorf("head length = %d, want 2", head.Length)
 	}
 
-	tail := first[TailExpression](t, "tail [1, 2, 3] 2;")
+	tail := first[ast.TailExpression](t, "tail [1, 2, 3] 2;")
 	if tail.Length != 2 {
 		t.Errorf("tail length = %d, want 2", tail.Length)
 	}
 }
 
 func TestParseDeferShape(t *testing.T) {
-	deferred := first[DeferExpression](t, "defer { 1; 2; };")
+	deferred := first[ast.DeferExpression](t, "defer { 1; 2; };")
 	if len(deferred.Block.Body) != 2 {
 		t.Errorf("body holds %d expressions, want 2", len(deferred.Block.Body))
 	}
 
-	empty := first[DeferExpression](t, "defer {};")
+	empty := first[ast.DeferExpression](t, "defer {};")
 	if len(empty.Block.Body) != 0 {
 		t.Errorf("an empty defer holds %d expressions, want none", len(empty.Block.Body))
 	}
 }
 
 func TestParseBlockShape(t *testing.T) {
-	block := first[BlockExpression](t, "{ 1; 2; 3; };")
+	block := first[ast.BlockExpression](t, "{ 1; 2; 3; };")
 	if len(block.Body) != 3 {
 		t.Errorf("body holds %d expressions, want 3", len(block.Body))
 	}
 
-	empty := first[BlockExpression](t, "{};")
+	empty := first[ast.BlockExpression](t, "{};")
 	if len(empty.Body) != 0 {
 		t.Errorf("an empty block holds %d expressions, want none", len(empty.Body))
 	}
 }
 
 func TestParseCalleeShape(t *testing.T) {
-	call := first[CalleeLiteral](t, "sum(1, 2);")
+	call := first[ast.CalleeLiteral](t, "sum(1, 2);")
 
 	if call.Id.Value != "sum" {
 		t.Errorf("callee = %q, want sum", call.Id.Value)
@@ -199,57 +200,57 @@ func TestParseCalleeShape(t *testing.T) {
 		t.Fatalf("got %d parameters, want 2", len(call.Params))
 	}
 
-	none := first[CalleeLiteral](t, "go();")
+	none := first[ast.CalleeLiteral](t, "go();")
 	if len(none.Params) != 0 {
 		t.Errorf("got %d parameters, want none", len(none.Params))
 	}
 
 	// Without parentheses it is a plain identifier, not a call.
-	if _, ok := parse(t, "sum;")[0].(IdentifierLiteral); !ok {
+	if _, ok := parse(t, "sum;")[0].(ast.IdentifierLiteral); !ok {
 		t.Error("a bare name should parse as an identifier")
 	}
 }
 
 func TestParseFeedShape(t *testing.T) {
-	withParens := first[FeedExpression](t, "feed(2);")
+	withParens := first[ast.FeedExpression](t, "feed(2);")
 	if withParens.Nth.Value != 2 {
 		t.Errorf("index = %d, want 2", withParens.Nth.Value)
 	}
 
 	// The form without parentheses is also accepted.
-	bare := first[FeedExpression](t, "feed 3;")
+	bare := first[ast.FeedExpression](t, "feed 3;")
 	if bare.Nth.Value != 3 {
 		t.Errorf("index = %d, want 3", bare.Nth.Value)
 	}
 }
 
 func TestParseIfShape(t *testing.T) {
-	withoutElse := first[IfExpression](t, "if true { 1; };")
+	withoutElse := first[ast.IfExpression](t, "if true { 1; };")
 	if withoutElse.Else != nil {
 		t.Error("there is no else here")
 	}
 	if len(withoutElse.Body) != 1 {
 		t.Errorf("body holds %d expressions, want 1", len(withoutElse.Body))
 	}
-	if _, ok := withoutElse.Test.(BooleanLiteral); !ok {
+	if _, ok := withoutElse.Test.(ast.BooleanLiteral); !ok {
 		t.Errorf("test is %T, want a boolean", withoutElse.Test)
 	}
 
-	withElse := first[IfExpression](t, "if 1 bigger 2 { 1; } else { 2; };")
+	withElse := first[ast.IfExpression](t, "if 1 bigger 2 { 1; } else { 2; };")
 	if withElse.Else == nil {
 		t.Fatal("the else is missing")
 	}
 	if len(withElse.Else.Body) != 1 {
 		t.Errorf("else holds %d expressions, want 1", len(withElse.Else.Body))
 	}
-	if _, ok := withElse.Test.(RelativeExpression); !ok {
+	if _, ok := withElse.Test.(ast.RelativeExpression); !ok {
 		t.Errorf("test is %T, want a comparison", withElse.Test)
 	}
 }
 
 // branch is sugar: it desugars into nested ifs, with the fallback as the innermost else.
 func TestParseBranchDesugarsIntoNestedIfs(t *testing.T) {
-	outer := first[IfExpression](t, `branch {
+	outer := first[ast.IfExpression](t, `branch {
   1 equals 1: 10,
   2 equals 2: 20,
   30;
@@ -258,14 +259,14 @@ func TestParseBranchDesugarsIntoNestedIfs(t *testing.T) {
 	if outer.Else == nil {
 		t.Fatal("the first branch item needs an else holding the rest")
 	}
-	inner, ok := outer.Else.Body[0].(IfExpression)
+	inner, ok := outer.Else.Body[0].(ast.IfExpression)
 	if !ok {
 		t.Fatalf("the else holds %T, want the next branch item", outer.Else.Body[0])
 	}
 	if inner.Else == nil {
 		t.Fatal("the second item needs an else holding the fallback")
 	}
-	if _, ok := inner.Else.Body[0].(NumberLiteral); !ok {
+	if _, ok := inner.Else.Body[0].(ast.NumberLiteral); !ok {
 		t.Errorf("the fallback is %T, want the number", inner.Else.Body[0])
 	}
 }
@@ -275,16 +276,16 @@ func TestParseBranchDesugarsIntoNestedIfs(t *testing.T) {
 func TestParsePrintShapes(t *testing.T) {
 	cases := []struct {
 		source string
-		want   PrintFormat
+		want   ast.PrintFormat
 	}{
-		{source: "printb 1;", want: PrintBytes},
-		{source: `printc "hi";`, want: PrintChars},
-		{source: "printd 1;", want: PrintDecimal},
+		{source: "printb 1;", want: ast.PrintBytes},
+		{source: `printc "hi";`, want: ast.PrintChars},
+		{source: "printd 1;", want: ast.PrintDecimal},
 	}
 
 	for _, tc := range cases {
 		t.Run(tc.source, func(t *testing.T) {
-			printed := first[PrintStatement](t, tc.source)
+			printed := first[ast.PrintStatement](t, tc.source)
 			if printed.Format != tc.want {
 				t.Errorf("format = %q, want %q", printed.Format, tc.want)
 			}
@@ -296,15 +297,15 @@ func TestParsePrintShapes(t *testing.T) {
 }
 
 func TestParseAssertShape(t *testing.T) {
-	ast, err := parseSource(t, `assert(1 equals 1, "ok");`, "checks.test.ar")
+	tree, err := parseSource(t, `assert(1 equals 1, "ok");`, "checks.test.ar")
 	if err != nil {
 		t.Fatalf("assert in a test file: %v", err)
 	}
-	assertion, ok := ast.Nodes[0].(AssertStatement)
+	assertion, ok := tree.Nodes[0].(ast.AssertStatement)
 	if !ok {
-		t.Fatalf("got %T, want AssertStatement", ast.Nodes[0])
+		t.Fatalf("got %T, want AssertStatement", tree.Nodes[0])
 	}
-	if _, ok := assertion.Condition.(RelativeExpression); !ok {
+	if _, ok := assertion.Condition.(ast.RelativeExpression); !ok {
 		t.Errorf("condition is %T, want a comparison", assertion.Condition)
 	}
 	if assertion.Message == "" {
@@ -313,11 +314,11 @@ func TestParseAssertShape(t *testing.T) {
 }
 
 func TestParseUnaryShape(t *testing.T) {
-	unary := first[UnaryExpression](t, "-5;")
+	unary := first[ast.UnaryExpression](t, "-5;")
 	if unary.Operation.Value != "-" {
 		t.Errorf("operation = %q, want -", unary.Operation.Value)
 	}
-	if _, ok := unary.Expression.(NumberLiteral); !ok {
+	if _, ok := unary.Expression.(ast.NumberLiteral); !ok {
 		t.Errorf("operand is %T, want a number", unary.Expression)
 	}
 }
@@ -326,7 +327,7 @@ func TestParseOperatorShapes(t *testing.T) {
 	arithmetic := []string{"+", "-", "*", "/", "^"}
 	for _, op := range arithmetic {
 		t.Run(op, func(t *testing.T) {
-			expr := first[BinaryExpression](t, "1 "+op+" 2;")
+			expr := first[ast.BinaryExpression](t, "1 "+op+" 2;")
 			if expr.Operation.Value != op {
 				t.Errorf("operation = %q, want %q", expr.Operation.Value, op)
 			}
@@ -336,7 +337,7 @@ func TestParseOperatorShapes(t *testing.T) {
 	comparisons := []string{"equals", "different", "bigger", "smaller"}
 	for _, op := range comparisons {
 		t.Run(op, func(t *testing.T) {
-			expr := first[RelativeExpression](t, "1 "+op+" 2;")
+			expr := first[ast.RelativeExpression](t, "1 "+op+" 2;")
 			if expr.Operation.Value != op {
 				t.Errorf("operation = %q, want %q", expr.Operation.Value, op)
 			}
@@ -345,7 +346,7 @@ func TestParseOperatorShapes(t *testing.T) {
 
 	for _, op := range []string{"and", "or"} {
 		t.Run(op, func(t *testing.T) {
-			expr := first[BooleanExpression](t, "true "+op+" false;")
+			expr := first[ast.BooleanExpression](t, "true "+op+" false;")
 			if expr.Operation.Value != op {
 				t.Errorf("operation = %q, want %q", expr.Operation.Value, op)
 			}
@@ -357,27 +358,27 @@ func TestParseOperatorShapes(t *testing.T) {
 // they can be checked directly.
 func TestPrecedence(t *testing.T) {
 	// 2 + 3 * 4 groups as 2 + (3 * 4)
-	sum := first[BinaryExpression](t, "2 + 3 * 4;")
+	sum := first[ast.BinaryExpression](t, "2 + 3 * 4;")
 	if sum.Operation.Value != "+" {
 		t.Fatalf("the outer operation is %q, want +", sum.Operation.Value)
 	}
-	product, ok := sum.Right.(BinaryExpression)
+	product, ok := sum.Right.(ast.BinaryExpression)
 	if !ok || product.Operation.Value != "*" {
 		t.Errorf("the right side is %T, want the multiplication", sum.Right)
 	}
 
 	// Parentheses override it: (2 + 3) * 4
-	product = first[BinaryExpression](t, "(2 + 3) * 4;")
+	product = first[ast.BinaryExpression](t, "(2 + 3) * 4;")
 	if product.Operation.Value != "*" {
 		t.Fatalf("the outer operation is %q, want *", product.Operation.Value)
 	}
-	if inner, ok := product.Left.(BinaryExpression); !ok || inner.Operation.Value != "+" {
+	if inner, ok := product.Left.(ast.BinaryExpression); !ok || inner.Operation.Value != "+" {
 		t.Errorf("the left side is %T, want the sum", product.Left)
 	}
 
 	// Comparison binds looser than arithmetic: (1 + 1) equals 2
-	comparison := first[RelativeExpression](t, "1 + 1 equals 2;")
-	if _, ok := comparison.Left.(BinaryExpression); !ok {
+	comparison := first[ast.RelativeExpression](t, "1 + 1 equals 2;")
+	if _, ok := comparison.Left.(ast.BinaryExpression); !ok {
 		t.Errorf("the left side is %T, want the sum", comparison.Left)
 	}
 }
@@ -385,16 +386,16 @@ func TestPrecedence(t *testing.T) {
 // Additive expressions are left-associative, which is why the EVM lowering has to reorder
 // them: 10 - 3 - 2 is (10 - 3) - 2, not 10 - (3 - 2).
 func TestAdditiveIsLeftAssociative(t *testing.T) {
-	expr := first[BinaryExpression](t, "10 - 3 - 2;")
+	expr := first[ast.BinaryExpression](t, "10 - 3 - 2;")
 
-	left, ok := expr.Left.(BinaryExpression)
+	left, ok := expr.Left.(ast.BinaryExpression)
 	if !ok {
 		t.Fatalf("the left side is %T, want the inner subtraction", expr.Left)
 	}
-	if first, ok := left.Left.(NumberLiteral); !ok || first.Value != 10 {
+	if first, ok := left.Left.(ast.NumberLiteral); !ok || first.Value != 10 {
 		t.Errorf("the innermost operand is %v, want 10", left.Left)
 	}
-	if last, ok := expr.Right.(NumberLiteral); !ok || last.Value != 2 {
+	if last, ok := expr.Right.(ast.NumberLiteral); !ok || last.Value != 2 {
 		t.Errorf("the outer right operand is %v, want 2", expr.Right)
 	}
 }
@@ -403,12 +404,12 @@ func TestAdditiveIsLeftAssociative(t *testing.T) {
 // 20 / (5 / 2). They used to group to the right, which answered 10 for that.
 func TestMultiplicativeIsLeftAssociative(t *testing.T) {
 	for _, source := range []string{"20 / 5 / 2;", "4 / 2 * 6;", "2 * 3 / 6;"} {
-		expr := first[BinaryExpression](t, source)
+		expr := first[ast.BinaryExpression](t, source)
 
-		if _, ok := expr.Left.(BinaryExpression); !ok {
+		if _, ok := expr.Left.(ast.BinaryExpression); !ok {
 			t.Errorf("%s: the left side is %T, want the inner operation", source, expr.Left)
 		}
-		if _, ok := expr.Right.(NumberLiteral); !ok {
+		if _, ok := expr.Right.(ast.NumberLiteral); !ok {
 			t.Errorf("%s: the right side is %T, want the last operand alone", source, expr.Right)
 		}
 	}
@@ -417,37 +418,37 @@ func TestMultiplicativeIsLeftAssociative(t *testing.T) {
 // `and` binds tighter than `or`: a and b or c is (a and b) or c. They used to share one
 // precedence level and recurse to the right, which grouped it as a and (b or c).
 func TestAndBindsTighterThanOr(t *testing.T) {
-	expr := first[BooleanExpression](t, "a and b or c;")
+	expr := first[ast.BooleanExpression](t, "a and b or c;")
 	if expr.Operation.Value != "or" {
 		t.Fatalf("the outer operation is %q, want or", expr.Operation.Value)
 	}
-	inner, ok := expr.Left.(BooleanExpression)
+	inner, ok := expr.Left.(ast.BooleanExpression)
 	if !ok {
 		t.Fatalf("the left side is %T, want the inner conjunction", expr.Left)
 	}
 	if inner.Operation.Value != "and" {
 		t.Errorf("the inner operation is %q, want and", inner.Operation.Value)
 	}
-	if _, ok := expr.Right.(IdentifierLiteral); !ok {
+	if _, ok := expr.Right.(ast.IdentifierLiteral); !ok {
 		t.Errorf("the right side is %T, want the last operand alone", expr.Right)
 	}
 }
 
 // A comparison binds tighter than both, so a range reads as one test.
 func TestComparisonBindsTighterThanAnd(t *testing.T) {
-	expr := first[BooleanExpression](t, "n bigger 18 and n smaller 65;")
-	if _, ok := expr.Left.(RelativeExpression); !ok {
+	expr := first[ast.BooleanExpression](t, "n bigger 18 and n smaller 65;")
+	if _, ok := expr.Left.(ast.RelativeExpression); !ok {
 		t.Errorf("the left side is %T, want the comparison", expr.Left)
 	}
-	if _, ok := expr.Right.(RelativeExpression); !ok {
+	if _, ok := expr.Right.(ast.RelativeExpression); !ok {
 		t.Errorf("the right side is %T, want the comparison", expr.Right)
 	}
 }
 
 // Exponentiation recurses to the right: 2 ^ 3 ^ 2 is 2 ^ (3 ^ 2).
 func TestExponentiationIsRightAssociative(t *testing.T) {
-	expr := first[BinaryExpression](t, "2 ^ 3 ^ 2;")
-	if _, ok := expr.Right.(BinaryExpression); !ok {
+	expr := first[ast.BinaryExpression](t, "2 ^ 3 ^ 2;")
+	if _, ok := expr.Right.(ast.BinaryExpression); !ok {
 		t.Errorf("the right side is %T, want the inner exponentiation", expr.Right)
 	}
 }
@@ -457,13 +458,13 @@ func TestParseSeveralTopLevelExpressions(t *testing.T) {
 	if len(nodes) != 3 {
 		t.Fatalf("got %d nodes, want 3", len(nodes))
 	}
-	if _, ok := nodes[0].(IdentLiteral); !ok {
+	if _, ok := nodes[0].(ast.IdentLiteral); !ok {
 		t.Errorf("first node is %T", nodes[0])
 	}
-	if _, ok := nodes[1].(PrintStatement); !ok {
+	if _, ok := nodes[1].(ast.PrintStatement); !ok {
 		t.Errorf("second node is %T", nodes[1])
 	}
-	if _, ok := nodes[2].(BinaryExpression); !ok {
+	if _, ok := nodes[2].(ast.BinaryExpression); !ok {
 		t.Errorf("third node is %T", nodes[2])
 	}
 }
@@ -541,32 +542,32 @@ ident t = pull [1, 2] 3;
 		t.Fatalf("lexer: %v", err)
 	}
 
-	ast, err := New(NewParserOptions{
+	tree, err := New(NewParserOptions{
 		Filename: "main.ar",
 		Tokens:   tokens,
 	}).Parse()
 	if err != nil {
 		t.Fatalf("parsing with logging on: %v", err)
 	}
-	if len(ast.Nodes) != 4 {
-		t.Errorf("got %d nodes, want 4", len(ast.Nodes))
+	if len(tree.Nodes) != 4 {
+		t.Errorf("got %d nodes, want 4", len(tree.Nodes))
 	}
 }
 
 // ASTEqual is what other packages use to compare trees, so it has to notice a difference
 // wherever it sits.
-func TestASTEqual(t *testing.T) {
-	build := func(source string) AST {
+func TestEqualAcrossSources(t *testing.T) {
+	build := func(source string) ast.AST {
 		t.Helper()
-		ast, err := parseSource(t, source, "main.ar")
+		tree, err := parseSource(t, source, "main.ar")
 		if err != nil {
 			t.Fatalf("parsing %q: %v", source, err)
 		}
-		return ast
+		return tree
 	}
 
 	same := "ident a = defer { 1; };"
-	if !ASTEqual(build(same), build(same)) {
+	if !ast.Equal(build(same), build(same)) {
 		t.Error("the same source produced trees that do not compare equal")
 	}
 
@@ -583,7 +584,7 @@ func TestASTEqual(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if ASTEqual(build(tc.a), build(tc.b)) {
+			if ast.Equal(build(tc.a), build(tc.b)) {
 				t.Errorf("%q and %q should not compare equal", tc.a, tc.b)
 			}
 		})

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -4,6 +4,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -34,7 +35,7 @@ func NewDirectives() *Directives {
 }
 
 // ParseStruct reads `struct Point { x, y };`.
-func (p *pr) ParseStruct() (Node, error) {
+func (p *pr) ParseStruct() (ast.Node, error) {
 	tok, err := p.EatToken(token.STRUCT)
 	if err != nil {
 		return nil, err
@@ -85,7 +86,7 @@ func (p *pr) ParseStruct() (Node, error) {
 	}
 
 	p.directives.Structs[structName] = fields
-	return StructDeclaration{Name: structName, Fields: fields, Token: tok}, nil
+	return ast.StructDeclaration{Name: structName, Fields: fields, Token: tok}, nil
 }
 
 // ParseStructLiteral reads `Point{10, 20}`: one value per field, in the declared order.
@@ -95,13 +96,13 @@ func (p *pr) ParseStruct() (Node, error) {
 // only a construction when the name was declared, because `if flag { … }` also puts a brace
 // after a name; declaring a struct called `flag` and testing on it is the one ambiguity left,
 // and it is the same one Go has.
-func (p *pr) ParseStructLiteral(id IdentifierLiteral) (Node, error) {
+func (p *pr) ParseStructLiteral(id ast.IdentifierLiteral) (ast.Node, error) {
 	fields := p.directives.Structs[id.Value]
 
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
 		return nil, err
 	}
-	values := make([]Node, 0, len(fields))
+	values := make([]ast.Node, 0, len(fields))
 	for p.GetLookahead() != nil && p.GetLookahead().GetTag().Id != token.C_CUR_BRK {
 		expr, err := p.ParseExpr()
 		if err != nil {
@@ -128,13 +129,13 @@ func (p *pr) ParseStructLiteral(id IdentifierLiteral) (Node, error) {
 			id.Value, len(fields), strings.Join(fields, ", "), len(values), closing.GetLine(), closing.GetColumn())
 	}
 
-	return StructLiteral{Name: id.Value, Values: values, Token: id.Token}, nil
+	return ast.StructLiteral{Name: id.Value, Values: values, Token: id.Token}, nil
 }
 
 // parsePostfix applies what binds tightest of all: reading a field, and naming the shape a
 // value is read with. Both are left to right, so `feed(0) as Point.x` reads the field of
 // the shaped value.
-func (p *pr) parsePostfix(expr Node) (Node, error) {
+func (p *pr) parsePostfix(expr ast.Node) (ast.Node, error) {
 	for {
 		lookahead := p.GetLookahead()
 		if lookahead == nil {
@@ -158,7 +159,7 @@ func (p *pr) parsePostfix(expr Node) (Node, error) {
 
 // parseField resolves `.x` to the index x was declared at. The name does not survive into
 // the tree as anything the emitter reads.
-func (p *pr) parseField(expr Node) (Node, error) {
+func (p *pr) parseField(expr ast.Node) (ast.Node, error) {
 	if _, err := p.EatToken(token.DOT); err != nil {
 		return nil, err
 	}
@@ -181,12 +182,12 @@ func (p *pr) parseField(expr Node) (Node, error) {
 			shape, field, name.GetLine(), name.GetColumn(), strings.Join(fields, ", "))
 	}
 
-	return FieldExpression{Expression: expr, Index: uint64(index), Field: field, Token: name}, nil
+	return ast.FieldExpression{Expression: expr, Index: uint64(index), Field: field, Token: name}, nil
 }
 
 // parseShape reads `as Point`. It claims a shape rather than checking one: a value is a run
 // of bytes and there is nothing in it to check against.
-func (p *pr) parseShape(expr Node) (Node, error) {
+func (p *pr) parseShape(expr ast.Node) (ast.Node, error) {
 	tok, err := p.EatToken(token.AS)
 	if err != nil {
 		return nil, err
@@ -201,18 +202,18 @@ func (p *pr) parseShape(expr Node) (Node, error) {
 			structName, name.GetLine(), name.GetColumn())
 	}
 
-	return ShapedExpression{Expression: expr, Struct: structName, Token: tok}, nil
+	return ast.ShapedExpression{Expression: expr, Struct: structName, Token: tok}, nil
 }
 
 // shapeOf answers which struct a value is read as, or empty when nothing said. A field is
 // one tape wide, so reading a field of a field is never known.
-func (p *pr) shapeOf(node Node) string {
+func (p *pr) shapeOf(node ast.Node) string {
 	switch n := node.(type) {
-	case StructLiteral:
+	case ast.StructLiteral:
 		return n.Name
-	case ShapedExpression:
+	case ast.ShapedExpression:
 		return n.Struct
-	case IdentifierLiteral:
+	case ast.IdentifierLiteral:
 		return p.directives.Shapes[n.Value]
 	}
 	return ""

--- a/parser/structs_test.go
+++ b/parser/structs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -27,7 +28,7 @@ func TestFieldResolvesToItsIndex(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.source, func(t *testing.T) {
 			nodes := parse(t, tc.source)
-			field, ok := nodes[len(nodes)-1].(FieldExpression)
+			field, ok := nodes[len(nodes)-1].(ast.FieldExpression)
 			if !ok {
 				t.Fatalf("last node is %T, want a FieldExpression", nodes[len(nodes)-1])
 			}
@@ -139,7 +140,7 @@ func TestStructNameIsOnlyADirective(t *testing.T) {
 // are the same shape, so telling them apart needed the directive; `Point{1, 2}` does not.
 func TestConstructionUsesBraces(t *testing.T) {
 	nodes := parse(t, "struct Point { x, y };\nPoint{1, 2};")
-	if _, ok := nodes[1].(StructLiteral); !ok {
+	if _, ok := nodes[1].(ast.StructLiteral); !ok {
 		t.Errorf("Point{1, 2} parsed as %T, want a StructLiteral", nodes[1])
 	}
 
@@ -151,7 +152,7 @@ func TestConstructionUsesBraces(t *testing.T) {
 
 	// Parentheses still apply values to a scope.
 	nodes = parse(t, "ident greet = defer { 1; };\ngreet();")
-	if _, ok := nodes[1].(CalleeLiteral); !ok {
+	if _, ok := nodes[1].(ast.CalleeLiteral); !ok {
 		t.Errorf("greet() parsed as %T, want a CalleeLiteral", nodes[1])
 	}
 }

--- a/parser/tape_size_test.go
+++ b/parser/tape_size_test.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
-func parseWithTapeSize(t *testing.T, source string, tapeSize int) (AST, error) {
+func parseWithTapeSize(t *testing.T, source string, tapeSize int) (ast.AST, error) {
 	t.Helper()
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
 	if err != nil {
@@ -96,7 +97,7 @@ func TestBooleanLiteralWidth(t *testing.T) {
 		if err != nil {
 			t.Fatalf("parse: %v", err)
 		}
-		literal, ok := ns.Nodes[0].(BooleanLiteral)
+		literal, ok := ns.Nodes[0].(ast.BooleanLiteral)
 		if !ok {
 			t.Fatalf("unexpected node: %T", ns.Nodes[0])
 		}
@@ -114,7 +115,7 @@ func TestDefaultTapeSizeIsEightBytes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("parse: %v", err)
 	}
-	if got := len(ns.Nodes[0].(BooleanLiteral).Value); got != byteutil.DefaultTapeSize {
+	if got := len(ns.Nodes[0].(ast.BooleanLiteral).Value); got != byteutil.DefaultTapeSize {
 		t.Errorf("unset tape size produced %d bytes, want %d", got, byteutil.DefaultTapeSize)
 	}
 }

--- a/repl/repl.go
+++ b/repl/repl.go
@@ -138,7 +138,7 @@ func (s *session) compile(text string) (emitter.Program, error) {
 	}
 	s.trace("lexer", func(w io.Writer) error { return trace.Tokens(w, tokens) })
 
-	ast, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{
 		Tokens:     tokens,
 		TapeSize:   s.tapeSize,
 		Directives: s.directives,
@@ -146,11 +146,11 @@ func (s *session) compile(text string) (emitter.Program, error) {
 	if err != nil {
 		return emitter.Program{}, err
 	}
-	s.trace("parser", func(w io.Writer) error { return trace.AST(w, ast) })
+	s.trace("parser", func(w io.Writer) error { return trace.AST(w, tree) })
 
 	program, err := emitter.New(emitter.NewEmitterOptions{
 		TapeSize: s.tapeSize,
-	}).EmitProgram(ast)
+	}).EmitProgram(tree)
 	if err != nil {
 		return emitter.Program{}, err
 	}

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -68,7 +68,8 @@ barato de mover: 37 + 41 linhas de declaração, sem comportamento. Depois disso
 > meio.
 
 **3. A árvore vira `wire`.** Mesmo desenho, custo maior: o emitter faz `switch` sobre vinte e
-um tipos concretos de nó.
+um tipos concretos de nó. A comparação de árvores vai junto — é pergunta sobre a forma, não
+sobre quem a construiu.
 
 **4. `logger` vira util de formatação.** Hoje ele escreve em `os.Stderr` e chama `os.Exit(2)`
 — um pacote decidindo o fim do processo. Passa a devolver a mensagem formatada; cada hosting
@@ -88,6 +89,19 @@ coisas a decidir junto, e nenhuma é detalhe:
   linhas e depois estoura não pode perder as três;
 - o usuário deixa de ver a saída **na hora**. Num programa longo, e principalmente no REPL,
   muda quando a linha aparece.
+
+## Achado ao mover a árvore
+
+**`Next()` não é chamado em lugar nenhum.** É o único método da interface `Node`, implementado
+vinte e cinco vezes, e nada no projeto o usa: a interface existe para marcar um tipo como nó, e
+faz isso através de um método que ninguém chama.
+
+Trocar por um método não exportado (`node()`) resolveria duas coisas de uma vez: some com umas
+setenta e cinco linhas mortas, e **fecha o conjunto** — ninguém de fora do `wire/ast` passa a
+poder inventar um nó, o que é exatamente o que a linguagem quer, já que o emitter faz `switch`
+sobre a lista inteira.
+
+Fica registrado em vez de feito: é mudança de desenho, não de lugar, e o passo era mover.
 
 ## Consequência para o que já foi feito
 

--- a/wire/ast/equal.go
+++ b/wire/ast/equal.go
@@ -1,6 +1,7 @@
-// Package parser: test helpers for AST comparison (same package so tests can use them without import cycle).
+// Comparing two trees is a question about the shape, so it travels with the shape: whoever
+// asks it — a parser test today, anything else tomorrow — should not need the parser to do it.
 
-package parser
+package ast
 
 import (
 	"bytes"
@@ -10,19 +11,11 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
-// TokenEqual compares two token.Token by value (GetMatch, GetTag).
-func TokenEqual(a, b token.Token) bool {
-	if a == nil && b == nil {
-		return true
-	}
-	if a == nil || b == nil {
-		return false
-	}
-	return bytes.Equal(a.GetMatch(), b.GetMatch()) && a.GetTag() == b.GetTag()
-}
-
-// ASTEqual compares two parsed files by structure and token value (ignores pointer identity).
-func ASTEqual(got, want AST) bool {
+// Equal compares two trees by structure and by the tokens they carry, ignoring pointer
+// identity. It travels with the tree: comparing two of them is a question about the shape,
+// and whoever asks it — a parser test today, anything else tomorrow — should not need the
+// parser to do it.
+func Equal(got, want AST) bool {
 	if got.Filename != want.Filename || len(got.Nodes) != len(want.Nodes) {
 		return false
 	}
@@ -105,19 +98,19 @@ func nodeEqual(a, b Node) bool {
 }
 
 func numberEqual(a, b NumberLiteral) bool {
-	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+	return a.Value == b.Value && token.Equal(a.Token, b.Token)
 }
 
 func booleanEqual(a, b BooleanLiteral) bool {
-	return bytes.Equal(a.Value, b.Value) && TokenEqual(a.Token, b.Token)
+	return bytes.Equal(a.Value, b.Value) && token.Equal(a.Token, b.Token)
 }
 
 func opEqual(a, b OperationLiteral) bool {
-	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+	return a.Value == b.Value && token.Equal(a.Token, b.Token)
 }
 
 func identifierEqual(a, b IdentifierLiteral) bool {
-	return a.Value == b.Value && TokenEqual(a.Token, b.Token)
+	return a.Value == b.Value && token.Equal(a.Token, b.Token)
 }
 
 // The three expressions with two operands differ only in what they mean, and the operator is
@@ -163,7 +156,7 @@ func deferEqual(a, b DeferExpression) bool {
 }
 
 func identEqual(a, b IdentLiteral) bool {
-	return a.Id == b.Id && TokenEqual(a.Token, b.Token) && nodeEqual(a.Value, b.Value)
+	return a.Id == b.Id && token.Equal(a.Token, b.Token) && nodeEqual(a.Value, b.Value)
 }
 
 func printEqual(a, b PrintStatement) bool {
@@ -171,7 +164,7 @@ func printEqual(a, b PrintStatement) bool {
 }
 
 func assertEqual(a, b AssertStatement) bool {
-	return TokenEqual(a.Token, b.Token) && nodeEqual(a.Condition, b.Condition) && a.Message == b.Message
+	return token.Equal(a.Token, b.Token) && nodeEqual(a.Condition, b.Condition) && a.Message == b.Message
 }
 
 // A struct's fields are positional, so their order is part of the shape and not a detail of

--- a/wire/ast/equal_test.go
+++ b/wire/ast/equal_test.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"testing"
@@ -20,10 +20,10 @@ func word(v string) IdentifierLiteral     { return IdentifierLiteral{Value: v} }
 func operation(v string) OperationLiteral { return OperationLiteral{Value: v} }
 
 var (
-	one = tok{[]byte("1"), token.TagNumber}
-	two = tok{[]byte("2"), token.TagNumber}
+	one = token.New([]byte("1"), token.TagNumber, 0, 0, 0)
+	two = token.New([]byte("2"), token.TagNumber, 0, 0, 0)
 	// Same text, different tag: TokenEqual reads both, and a token is not only its match.
-	oneAsIdent = tok{[]byte("1"), token.TagIdent}
+	oneAsIdent = token.New([]byte("1"), token.TagIdent, 0, 0, 0)
 )
 
 var comparisonCases = []struct {
@@ -466,34 +466,10 @@ func TestASTEqualComparesTheFilename(t *testing.T) {
 	a := AST{Filename: "main.ar", Nodes: []Node{number(1)}}
 	b := AST{Filename: "other.ar", Nodes: []Node{number(1)}}
 
-	if !ASTEqual(a, a) {
+	if !Equal(a, a) {
 		t.Error("a file does not compare equal to itself")
 	}
-	if ASTEqual(a, b) {
+	if Equal(a, b) {
 		t.Error("two filenames compared equal")
-	}
-}
-
-// TokenEqual reads both halves of a token, and nothing else about it.
-func TestTokenEqual(t *testing.T) {
-	cases := []struct {
-		name string
-		a, b token.Token
-		want bool
-	}{
-		{name: "nothing against nothing", want: true},
-		{name: "nothing against a token", b: one, want: false},
-		{name: "a token against nothing", a: one, want: false},
-		{name: "alike", a: one, b: tok{[]byte("1"), token.TagNumber}, want: true},
-		{name: "another match", a: one, b: two, want: false},
-		{name: "another tag", a: one, b: oneAsIdent, want: false},
-	}
-
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := TokenEqual(tc.a, tc.b); got != tc.want {
-				t.Errorf("answered %v, want %v", got, tc.want)
-			}
-		})
 	}
 }

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -1,4 +1,4 @@
-package parser
+package ast
 
 import (
 	"github.com/guiferpa/aurora/wire/token"

--- a/wire/token/equal.go
+++ b/wire/token/equal.go
@@ -1,0 +1,16 @@
+package token
+
+import "bytes"
+
+// Equal compares two tokens by what they matched and what kind of thing they are, which is
+// what a test asks about. Where they sit in the source is deliberately not part of it: the
+// same word written on another line is the same token.
+func Equal(a, b Token) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	return bytes.Equal(a.GetMatch(), b.GetMatch()) && a.GetTag() == b.GetTag()
+}

--- a/wire/token/equal_test.go
+++ b/wire/token/equal_test.go
@@ -1,0 +1,35 @@
+package token
+
+import "testing"
+
+// The three tokens these cases are made of: the same text under two tags, and a different
+// text, which is what tells the two halves of a comparison apart.
+var (
+	one        = New([]byte("1"), TagNumber, 1, 1, 0)
+	two        = New([]byte("2"), TagNumber, 1, 1, 0)
+	oneAsIdent = New([]byte("1"), TagIdent, 1, 1, 0)
+)
+
+// Equal reads both halves of a token, and nothing else about it.
+func TestEqual(t *testing.T) {
+	cases := []struct {
+		name string
+		a, b Token
+		want bool
+	}{
+		{name: "nothing against nothing", want: true},
+		{name: "nothing against a token", b: one, want: false},
+		{name: "a token against nothing", a: one, want: false},
+		{name: "alike", a: one, b: New([]byte("1"), TagNumber, 0, 0, 0), want: true},
+		{name: "another match", a: one, b: two, want: false},
+		{name: "another tag", a: one, b: oneAsIdent, want: false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Equal(tc.a, tc.b); got != tc.want {
+				t.Errorf("answered %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Step 3, and the last of the artefacts. **No phase imports another phase now.**

## The chain, before and after

```
lexer        wire/token                          →  wire/token
parser       byteutil wire/token                 →  byteutil wire/token wire/ast
emitter      byteutil wire/token parser wire/ir  →  byteutil wire/token wire/ast wire/ir
evaluator    byteutil wire/ir                    →  byteutil wire/ir
builder/evm  byteutil wire/ir                    →  byteutil wire/ir
wire/ast                                         →  wire/token
wire/ir                                          →  byteutil
wire/token                                       →  (nothing)
```

Four steps ago every phase imported the one before it. What the parser keeps is what it *does* — reading tokens into a tree; what left is what a tree *is*.

**Comparing two trees travels with the tree**, and comparing two tokens with the token: they are questions about a shape, and whoever asks — a parser test today, anything else tomorrow — should not need the phase that built it. `ASTEqual` becomes `ast.Equal` and `TokenEqual` becomes `token.Equal`, each losing the stutter it carried while it lived beside a parser.

## Two things the move forced, both improvements

- **The parser built its nodes with unkeyed fields** — legal inside a package, a lint error across one. Every literal now names what it fills, which is also what stops a field added in the middle from silently changing what a node means. 21 sites.
- **Everyone called the variable `ast`**, which is now the package name. They are trees, and the code says `tree`.

## What it found

**`Next()` is implemented twenty-five times and called never.** It is the only method of the `Node` interface, so the interface marks a type as a node with something nobody reads.

An unexported method would do the marking *and* close the set: nothing outside `wire/ast` could invent a node, which is what the language wants, since the emitter switches over the whole list. That is ~75 lines of dead code and a stronger type at the same time.

**Recorded in the RFC rather than done** — it is a change of design, and this step was a move. It is also why `wire/ast` reports 68.9% coverage while `wire/ir` and `wire/token` are at 100%: the uncovered statements are those twenty-five methods.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- Every existing test still passes; `parser/testutil_test.go` moved to `wire/ast/equal_test.go` unchanged except for the names it calls.
- Both commits verified in their own `git worktree` with `make check`.

Next in the RFC: `logger` becomes a formatting util (and `os.Exit` leaves it), then `fileutil`/`manifest`/`internal/trace` become `shared`, then assembly moves to `main`.