### PR TITLE
The logger spells a failure, and main ends the process

### DIFF
--- a/cmd/aurora/exit_test.go
+++ b/cmd/aurora/exit_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// What a shell is told when a command fails is a contract with whoever runs the CLI — a
+// script, a CI job — and it is decided in main, so it is checked here. The check used to sit
+// in the logger, which is where the decision used to be.
+//
+// Ending the process cannot be exercised in the test that asks for it, so the test
+// re-executes itself: the parent reads the streams and the exit code, and the child is told
+// which run to make by an environment variable.
+const subprocessEnv = "AURORA_EXIT_SUBPROCESS"
+
+func TestMain(m *testing.M) {
+	switch os.Getenv(subprocessEnv) {
+	case "failing":
+		os.Args = []string{"aurora", "run", "a-file-that-is-not-there.ar"}
+		main()
+		return // not reached: main exits
+	case "succeeding":
+		os.Args = []string{"aurora", "version"}
+		main()
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// runSelf re-executes this test binary in the given mode and reports what happened.
+func runSelf(t *testing.T, mode string) (stdout, stderr string, code int) {
+	t.Helper()
+
+	cmd := exec.Command(os.Args[0], "-test.run=TestNothingRuns")
+	cmd.Env = append(os.Environ(), subprocessEnv+"="+mode)
+
+	var out, errOut strings.Builder
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if err != nil && !errors.As(err, &exitErr) {
+		t.Fatalf("running subprocess: %v", err)
+	}
+	return out.String(), errOut.String(), cmd.ProcessState.ExitCode()
+}
+
+// TestNothingRuns exists so the subprocess has a pattern that matches no test.
+func TestNothingRuns(t *testing.T) {}
+
+func TestAFailedCommandExitsTwo(t *testing.T) {
+	stdout, stderr, code := runSelf(t, "failing")
+
+	if code != 2 {
+		t.Errorf("exited %d, want 2", code)
+	}
+	// The diagnostic goes to stderr so a pipeline reading a program's output does not
+	// swallow it, and does not reach stdout at all.
+	if !strings.Contains(stderr, "a-file-that-is-not-there.ar") {
+		t.Errorf("stderr is %q, want it to name the file", stderr)
+	}
+	if strings.Contains(stdout, "a-file-that-is-not-there.ar") {
+		t.Errorf("the failure reached stdout: %q", stdout)
+	}
+}
+
+func TestACommandThatWorkedExitsZero(t *testing.T) {
+	_, stderr, code := runSelf(t, "succeeding")
+
+	if code != 0 {
+		t.Errorf("exited %d, want 0", code)
+	}
+	if stderr != "" {
+		t.Errorf("said %q on stderr for a command that worked", stderr)
+	}
+}

--- a/cmd/aurora/main.go
+++ b/cmd/aurora/main.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 
 	"github.com/guiferpa/aurora/logger"
@@ -18,7 +21,14 @@ var rootCmd = &cobra.Command{
 	SilenceUsage:  true,
 }
 
+// The exit code is a contract with whoever runs the CLI — a shell, a CI job — so it is
+// decided here, where the process is, and nowhere else. Diagnostics go to stderr, so a
+// pipeline reading a program's output does not swallow them.
 func main() {
 	rootCmd.AddCommand(versionCmd, runCmd, testCmd, replCmd, buildCmd, deployCmd, callCmd, initCmd)
-	logger.CommandError(rootCmd.Execute())
+
+	if err := rootCmd.Execute(); err != nil {
+		_, _ = fmt.Fprint(os.Stderr, logger.CommandError(err))
+		os.Exit(2)
+	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -5,7 +5,6 @@ import (
 	"io"
 
 	"github.com/guiferpa/aurora/evaluator"
-	"github.com/guiferpa/aurora/logger"
 )
 
 // RunInput is the input for the Run handler.
@@ -45,6 +44,5 @@ func Run(ctx context.Context, in RunInput) error {
 	if _, err := ev.Evaluate(program.Instructions); err != nil {
 		return err
 	}
-	logger.AssertError(ev.GetAssertErrors(), in.Source)
 	return nil
 }

--- a/logger/error.go
+++ b/logger/error.go
@@ -1,29 +1,17 @@
 package logger
 
-import (
-	"fmt"
-	"os"
+import "github.com/fatih/color"
 
-	"github.com/fatih/color"
-)
+// How a failure is spelled, so every host spells it the same way.
+//
+// Nothing here decides where a message goes or what happens next. It used to: this wrote to
+// stderr and ended the process, which is a package deciding the fate of the program that
+// called it. Whoever calls now writes and exits, and this says only what the words are.
 
-// CommandError reports a failed command and exits. Diagnostics go to stderr, so a shell
-// pipeline reading a program's output does not swallow them.
-func CommandError(err error) {
+// CommandError spells a command that failed, and answers with nothing when none did.
+func CommandError(err error) string {
 	if err == nil {
-		return
+		return ""
 	}
-	_, _ = color.New(color.BgBlack, color.FgHiMagenta).Fprintln(os.Stderr, err)
-	os.Exit(2)
-}
-
-func AssertError(errs []error, filename string) {
-	if len(errs) == 0 {
-		return
-	}
-	_, _ = color.New(color.FgWhite).Fprintln(os.Stderr, fmt.Sprintf("Assertion errors in %s:", filename))
-	for _, err := range errs {
-		_, _ = color.New(color.BgBlack, color.FgRed).Fprintln(os.Stderr, err)
-	}
-	os.Exit(3)
+	return color.New(color.BgBlack, color.FgHiMagenta).Sprintln(err)
 }

--- a/logger/error_test.go
+++ b/logger/error_test.go
@@ -2,109 +2,30 @@ package logger
 
 import (
 	"errors"
-	"os"
-	"os/exec"
 	"strings"
 	"testing"
 )
 
-// CommandError and AssertError end the process, so they are exercised in a subprocess: the
-// test re-runs itself with an environment variable telling it which one to call, and the
-// parent inspects the exit code and what came out of each stream.
-//
-// The exit codes are a contract with whoever runs the CLI — a shell, a CI job — so they are
-// worth pinning: 2 for a failed command, 3 for a failed assertion.
-const subprocessEnv = "AURORA_LOGGER_SUBPROCESS"
-
-func TestMain(m *testing.M) {
-	switch os.Getenv(subprocessEnv) {
-	case "command-error":
-		CommandError(errors.New("something went wrong"))
-		return // not reached: CommandError exits
-	case "command-error-nil":
-		CommandError(nil)
-		os.Exit(0)
-	case "assert-error":
-		AssertError([]error{errors.New("first failed"), errors.New("second failed")}, "checks.test.ar")
-		return
-	case "assert-error-empty":
-		AssertError(nil, "checks.test.ar")
-		os.Exit(0)
-	}
-	os.Exit(m.Run())
-}
-
-// run re-executes this test binary in the given mode and reports what happened.
-func run(t *testing.T, mode string) (stdout, stderr string, code int) {
-	t.Helper()
-
-	cmd := exec.Command(os.Args[0], "-test.run=TestNothing")
-	cmd.Env = append(os.Environ(), subprocessEnv+"="+mode)
-
-	var out, errOut strings.Builder
-	cmd.Stdout = &out
-	cmd.Stderr = &errOut
-
-	err := cmd.Run()
-	var exitErr *exec.ExitError
-	if err != nil && !errors.As(err, &exitErr) {
-		t.Fatalf("running subprocess: %v", err)
-	}
-	return out.String(), errOut.String(), cmd.ProcessState.ExitCode()
-}
-
-// TestNothing exists so the subprocess has a test pattern that matches nothing.
-func TestNothing(t *testing.T) {}
+// These used to run in a subprocess, because the package wrote to stderr and ended the
+// process: the test re-executed itself, read both streams and checked the exit code. None of
+// that is needed now that it spells a message and hands it back — which is the point of the
+// change, seen from a test.
 
 func TestCommandError(t *testing.T) {
-	stdout, stderr, code := run(t, "command-error")
+	got := CommandError(errors.New("something went wrong"))
 
-	if code != 2 {
-		t.Errorf("exit code = %d, want 2", code)
+	if !strings.Contains(got, "something went wrong") {
+		t.Errorf("spelled %q, want it to carry the error", got)
 	}
-	if !strings.Contains(stderr, "something went wrong") {
-		t.Errorf("stderr = %q, want the message", stderr)
-	}
-	// A pipeline reading the program's output should not receive diagnostics.
-	if stdout != "" {
-		t.Errorf("stdout = %q, want empty", stdout)
+	if !strings.HasSuffix(got, "\n") {
+		t.Errorf("spelled %q, want a line rather than a fragment", got)
 	}
 }
 
-func TestCommandErrorWithNilDoesNothing(t *testing.T) {
-	stdout, stderr, code := run(t, "command-error-nil")
-
-	if code != 0 {
-		t.Errorf("exit code = %d, want 0", code)
-	}
-	if stdout != "" || stderr != "" {
-		t.Errorf("nothing should have been written, got stdout %q and stderr %q", stdout, stderr)
-	}
-}
-
-func TestAssertError(t *testing.T) {
-	stdout, stderr, code := run(t, "assert-error")
-
-	if code != 3 {
-		t.Errorf("exit code = %d, want 3", code)
-	}
-	for _, want := range []string{"checks.test.ar", "first failed", "second failed"} {
-		if !strings.Contains(stderr, want) {
-			t.Errorf("stderr = %q, want it to contain %q", stderr, want)
-		}
-	}
-	if stdout != "" {
-		t.Errorf("stdout = %q, want empty", stdout)
-	}
-}
-
-func TestAssertErrorWithNoFailuresDoesNothing(t *testing.T) {
-	stdout, stderr, code := run(t, "assert-error-empty")
-
-	if code != 0 {
-		t.Errorf("exit code = %d, want 0", code)
-	}
-	if stdout != "" || stderr != "" {
-		t.Errorf("nothing should have been written, got stdout %q and stderr %q", stdout, stderr)
+// A command that did not fail has nothing to say, and nothing is not an empty line: whoever
+// writes this out would print a blank one.
+func TestCommandErrorOfNothing(t *testing.T) {
+	if got := CommandError(nil); got != "" {
+		t.Errorf("spelled %q for no error at all", got)
 	}
 }

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -75,6 +75,11 @@ sobre quem a construiu.
 — um pacote decidindo o fim do processo. Passa a devolver a mensagem formatada; cada hosting
 escreve, e o `os.Exit` sobe para `cmd/*`. É a etapa que conserta a regra 3.
 
+> Ao aplicar apareceu uma segunda coisa: **o código de saída 3 era inatingível.** Ele saía do
+> `AssertError`, chamado pelo `aurora run` — e `run` cria o evaluator sem `Asserts`, que só o
+> `aurora test` liga. Nenhuma asserção jamais falhou por ali. A função saiu junto com o
+> caminho morto, em vez de mudar de casa.
+
 **5. `fileutil`, `manifest` e `internal/trace` viram `shared`.** Eles servem a camada de
 hosting, não uma interação. Util não toca no mundo; esses três tocam.
 


### PR DESCRIPTION
Step 4 of the RFC. The strongest form of the rule being broken: **a package that ended the program that called it.**

## What was wrong

`logger.CommandError` and `logger.AssertError` wrote to `os.Stderr` and called `os.Exit`. That is an error handled outside hosting, I/O outside hosting, and a package deciding the fate of its caller — three rules in two functions.

The logger now **spells the message and hands it back**. Where it goes and what happens next is decided in `main`, which is the only place that knows there is a process to end.

## What it found: exit code 3 could not happen

`AssertError` exited with 3 and was called by `aurora run`. But **`run` builds its evaluator without `Asserts`** — only `aurora test` turns that on — so `GetAssertErrors()` was always empty there. The branch never ran, the message was never printed, and the code was never returned.

So it goes with the dead path instead of moving house. A failing test already answers `N of M assertions failed` and exits 2 like any other failure, which is what a shell has been seeing all along.

The first commit removes the call, the second removes the function — that order is what keeps each commit building on its own.

## The tests tell the same story

The logger's test used to **re-execute the test binary**, read both streams and check exit codes, to test two functions. It now compares two strings. That is what the change is for, seen from a test.

The exit code did not lose its check: it moved to `cmd/aurora`, where the decision now lives, with the same re-execution trick — ending a process still cannot be exercised in the test that asks for it. A failed command exits 2 and says so on **stderr and not stdout**; one that worked exits 0 and says nothing.

Proved to bite: changing `os.Exit(2)` to `os.Exit(1)` fails with `exited 1, want 2`.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- `logger` at 100% coverage, with no subprocess.
- Both commits verified in their own `git worktree` with `make check` — the first attempt got the order backwards, and the worktree caught it.

Next: `fileutil`, `manifest` and `internal/trace` become `shared` — they serve the hosting layer rather than one interaction, and two of them touch the world, which a util may not.