### PR TITLE
What a phase answers with is wire too

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ packages of their own.
 | kind | who |
 |---|---|
 | **vital** | `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` |
-| **wire** | `wire/token`, `wire/ast`, `wire/ir` |
+| **wire** | `wire/token`, `wire/ast`, `wire/ir`, `wire/diag` |
 | **util** | `byteutil`, `logger` |
 | **hosting** | `hosting/cli`, `hosting/repl`, `hosting/lsp` |
 | **shared** | `shared/fileutil`, `shared/manifest`, `shared/trace` |

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"fmt"
 
+	"github.com/guiferpa/aurora/wire/diag"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
@@ -66,22 +67,6 @@ var pending = map[byte]string{
 	ir.OpField: "struct",
 }
 
-// A Warning is what the builder has to say about a program it cannot carry whole.
-//
-// It is the builder's own word rather than the emitter's. A backend reporting on itself in
-// the vocabulary of the phase before it is one step from depending on that phase for meaning,
-// and the whole point of the layering is that someone could take this package and write a
-// different compiler around it.
-//
-// It carries no position: the IR has instructions, not lines.
-type Warning struct {
-	Message string
-}
-
-func (w Warning) String() string {
-	return w.Message
-}
-
 // Warnings reports what a program uses that does not reach the bytecode.
 //
 // They are warnings and not errors because the backend is being written in slices: refusing
@@ -89,8 +74,8 @@ func (w Warning) String() string {
 // coming out quietly wrong, which is what happened until now.
 //
 // They arrive in the order the program uses them, once each.
-func Warnings(insts []ir.Instruction) []Warning {
-	warnings := make([]Warning, 0)
+func Warnings(insts []ir.Instruction) []diag.Warning {
+	warnings := make([]diag.Warning, 0)
 	said := make(map[string]bool)
 
 	for _, inst := range insts {
@@ -113,7 +98,7 @@ func Warnings(insts []ir.Instruction) []Warning {
 			continue
 		}
 		said[message] = true
-		warnings = append(warnings, Warning{Message: message})
+		warnings = append(warnings, diag.Warning{Message: message})
 	}
 
 	return warnings

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -27,7 +27,7 @@ from.
 | kind | what it is | may import | is imported by |
 |---|---|---|---|
 | **vital** | a step of the pipeline: `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
-| **wire** | what crosses a boundary: `wire/token`, `wire/ast`, `wire/ir` | util, and nothing else of the project | everyone |
+| **wire** | what crosses a boundary: `wire/token`, `wire/ast`, `wire/ir`, `wire/diag` | wire, util, and nothing else of the project | everyone |
 | **util** | behaviour worth reusing that never touches the world: `byteutil`, `logger` | nothing of the project | everyone |
 | **hosting** | one kind of interaction: `hosting/cli`, `hosting/repl`, `hosting/lsp` | wire, util, shared | `main` |
 | **shared** | serves the hosting *layer* rather than one interaction: `shared/fileutil`, `shared/manifest`, `shared/trace` | wire, util | hosting, `main` |
@@ -73,6 +73,9 @@ have to name that type. Injecting the *behaviour* does not remove the type of th
 choice is between giving the artefact a home of its own, or having every phase declare its own
 interface and `main` convert — which, for the vocabulary (tags, opcodes), means a translation
 table in `main` where a missing entry is wrong output in silence instead of a compile error.
+
+A wire package may lean on another — the tree holds tokens, the IR holds warnings — and on a
+util. Neither can tie it to a phase, which is what the rule is protecting.
 
 **What wire holds:** the types, their constructors, the vocabulary (tags, opcodes), and how
 they are written down — spelling something out is part of the vocabulary, the way a token

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -10,27 +10,7 @@ import (
 
 type Emitter interface {
 	Emit(tree ast.AST) ([]ir.Instruction, error)
-	EmitProgram(tree ast.AST) (Program, error)
-}
-
-// Expression is one top-level expression of a program: the range of instructions it
-// compiled to, and the label the temp holding its value ends up under.
-//
-// A caller that wants to report values in source order needs this. Reading the temp map
-// after the whole program has run cannot give it: the map has no order, and everything
-// written by print along the way has already been emitted.
-type Expression struct {
-	From  int // index of its first instruction
-	To    int // index one past its last instruction
-	Label []byte
-}
-
-// Program is what a source file compiled to: the instruction stream, where each top-level
-// expression sits inside it, and anything worth saying that did not stop the compilation.
-type Program struct {
-	Instructions []ir.Instruction
-	Expressions  []Expression
-	Warnings     []Warning
+	EmitProgram(tree ast.AST) (ir.Program, error)
 }
 
 type emt struct {
@@ -43,8 +23,6 @@ func GenerateLabel(tc *int) []byte {
 	return t
 }
 
-type Label []byte
-
 // printOpCodes maps each reading of a value to the instruction that writes it.
 var printOpCodes = map[ast.PrintFormat]byte{
 	ast.PrintBytes:   ir.OpPrintBytes,
@@ -52,7 +30,7 @@ var printOpCodes = map[ast.PrintFormat]byte{
 	ast.PrintDecimal: ir.OpPrintDecimal,
 }
 
-func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize int) Label {
+func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize int) ir.Label {
 	switch n := expr.(type) {
 	case ast.IdentLiteral:
 		return emitIdentLiteral(tc, insts, n, tapeSize)
@@ -111,7 +89,7 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 }
 
 // emitIdentLiteral binds a name to a value.
-func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tapeSize int) Label {
+func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tapeSize int) ir.Label {
 	ll := n.Token.GetMatch()
 	lr := EmitInstruction(tc, insts, n.Value, tapeSize)
 	l := GenerateLabel(tc)
@@ -124,7 +102,7 @@ func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tape
 }
 
 // emitBlockExpression opens a scope and returns the value its body ended with.
-func emitBlockExpression(tc *int, insts *[]ir.Instruction, n ast.BlockExpression, tapeSize int) Label {
+func emitBlockExpression(tc *int, insts *[]ir.Instruction, n ast.BlockExpression, tapeSize int) ir.Label {
 	var l []byte
 	body := make([]ir.Instruction, 0)
 	for _, ins := range n.Body {
@@ -142,7 +120,7 @@ func emitBlockExpression(tc *int, insts *[]ir.Instruction, n ast.BlockExpression
 }
 
 // emitDeferExpression stores a scope to be run later, and skips over its body.
-func emitDeferExpression(tc *int, insts *[]ir.Instruction, n ast.DeferExpression, tapeSize int) Label {
+func emitDeferExpression(tc *int, insts *[]ir.Instruction, n ast.DeferExpression, tapeSize int) ir.Label {
 	body := make([]ir.Instruction, 0)
 	l := EmitInstruction(tc, &body, n.Block, tapeSize)
 	bodylength := uint64(len(body))
@@ -154,7 +132,7 @@ func emitDeferExpression(tc *int, insts *[]ir.Instruction, n ast.DeferExpression
 }
 
 // emitUnaryExpression negates: a tape is unsigned, so this is zero minus the value.
-func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n ast.UnaryExpression, tapeSize int) Label {
+func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n ast.UnaryExpression, tapeSize int) ir.Label {
 	// A tape is unsigned, so negating is taking the value away from zero and letting it
 	// wrap: -5 is the same tape as 0 - 5. Emitting the subtraction says exactly that,
 	// and every stage below — the evaluator, the lowering, the EVM writer — already
@@ -174,7 +152,7 @@ func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n ast.UnaryExpression
 }
 
 // emitRelativeExpression compares two values.
-func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n ast.RelativeExpression, tapeSize int) Label {
+func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n ast.RelativeExpression, tapeSize int) ir.Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -196,7 +174,7 @@ func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n ast.RelativeExpr
 }
 
 // emitBooleanExpression combines two truth values.
-func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n ast.BooleanExpression, tapeSize int) Label {
+func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n ast.BooleanExpression, tapeSize int) ir.Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -213,7 +191,7 @@ func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n ast.BooleanExpres
 }
 
 // emitTapeBracketExpression builds a tape byte by byte.
-func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBracketExpression, tapeSize int) Label {
+func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBracketExpression, tapeSize int) ir.Label {
 	// Create the initial tape, all zeros
 	l := GenerateLabel(tc)
 	tape := byteutil.FalseTape(tapeSize)
@@ -231,7 +209,7 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBrack
 }
 
 // emitStructDeclaration answers the neutral value: a directive does no work.
-func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclaration, tapeSize int) Label {
+func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclaration, tapeSize int) ir.Label {
 	// A directive emits no work. It still answers with a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
 	l := GenerateLabel(tc)
@@ -241,7 +219,7 @@ func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclara
 }
 
 // emitStructLiteral lays one tape per field, end to end.
-func emitStructLiteral(tc *int, insts *[]ir.Instruction, n ast.StructLiteral, tapeSize int) Label {
+func emitStructLiteral(tc *int, insts *[]ir.Instruction, n ast.StructLiteral, tapeSize int) ir.Label {
 	// One tape per field, laid end to end — the shape a reel of the same length has.
 	// Instructions carry two operands, so the run is built by chaining, the way a tape
 	// literal chains ir.OpPull.
@@ -263,7 +241,7 @@ func emitStructLiteral(tc *int, insts *[]ir.Instruction, n ast.StructLiteral, ta
 }
 
 // emitFieldExpression reads one tape out of a run, by an index resolved while parsing.
-func emitFieldExpression(tc *int, insts *[]ir.Instruction, n ast.FieldExpression, tapeSize int) Label {
+func emitFieldExpression(tc *int, insts *[]ir.Instruction, n ast.FieldExpression, tapeSize int) ir.Label {
 	// The index was resolved while parsing, so it goes in as an immediate — the same
 	// shape head and tail use. Nothing here knows the field had a name.
 	lv := EmitInstruction(tc, insts, n.Expression, tapeSize)
@@ -274,7 +252,7 @@ func emitFieldExpression(tc *int, insts *[]ir.Instruction, n ast.FieldExpression
 }
 
 // emitShapedExpression emits what was shaped: `as` is a claim, not an operation.
-func emitShapedExpression(tc *int, insts *[]ir.Instruction, n ast.ShapedExpression, tapeSize int) Label {
+func emitShapedExpression(tc *int, insts *[]ir.Instruction, n ast.ShapedExpression, tapeSize int) ir.Label {
 	// `as` says how to read a value, which is a question the compiler answers and the
 	// program never asks: what is left is the value itself.
 	return EmitInstruction(tc, insts, n.Expression, tapeSize)
@@ -282,7 +260,7 @@ func emitShapedExpression(tc *int, insts *[]ir.Instruction, n ast.ShapedExpressi
 }
 
 // emitPullExpression shifts a tape left, the value entering at the right.
-func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, tapeSize int) Label {
+func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, tapeSize int) ir.Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
@@ -292,7 +270,7 @@ func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, 
 }
 
 // emitHeadExpression keeps the first bytes of a tape.
-func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, tapeSize int) Label {
+func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, tapeSize int) ir.Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
@@ -302,7 +280,7 @@ func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, 
 }
 
 // emitTailExpression drops the first bytes of a tape.
-func emitTailExpression(tc *int, insts *[]ir.Instruction, n ast.TailExpression, tapeSize int) Label {
+func emitTailExpression(tc *int, insts *[]ir.Instruction, n ast.TailExpression, tapeSize int) ir.Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	ln := byteutil.FromUint64(n.Length)
 	l := GenerateLabel(tc)
@@ -312,7 +290,7 @@ func emitTailExpression(tc *int, insts *[]ir.Instruction, n ast.TailExpression, 
 }
 
 // emitPushExpression shifts a tape right, the value entering at the left.
-func emitPushExpression(tc *int, insts *[]ir.Instruction, n ast.PushExpression, tapeSize int) Label {
+func emitPushExpression(tc *int, insts *[]ir.Instruction, n ast.PushExpression, tapeSize int) ir.Label {
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
@@ -322,7 +300,7 @@ func emitPushExpression(tc *int, insts *[]ir.Instruction, n ast.PushExpression, 
 }
 
 // emitIfExpression lays out the test, the body and the else, with the jumps between them.
-func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tapeSize int) Label {
+func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tapeSize int) ir.Label {
 	var bl, eul []byte
 
 	/*Extract Else body*/
@@ -357,7 +335,7 @@ func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tape
 }
 
 // emitCalleeLiteral applies values to a scope.
-func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, tapeSize int) Label {
+func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, tapeSize int) ir.Label {
 	for i, p := range n.Params {
 		ll := EmitInstruction(tc, insts, p.Expression, tapeSize)
 		l := GenerateLabel(tc)
@@ -370,7 +348,7 @@ func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, ta
 }
 
 // emitPrintStatement writes a value in one of the three readings.
-func emitPrintStatement(tc *int, insts *[]ir.Instruction, n ast.PrintStatement, tapeSize int) Label {
+func emitPrintStatement(tc *int, insts *[]ir.Instruction, n ast.PrintStatement, tapeSize int) ir.Label {
 	ll := EmitInstruction(tc, insts, n.Param, tapeSize)
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, printOpCodes[n.Format], ll, nil))
@@ -379,7 +357,7 @@ func emitPrintStatement(tc *int, insts *[]ir.Instruction, n ast.PrintStatement, 
 }
 
 // emitAssertStatement checks a condition, carrying its message as bytes.
-func emitAssertStatement(tc *int, insts *[]ir.Instruction, n ast.AssertStatement, tapeSize int) Label {
+func emitAssertStatement(tc *int, insts *[]ir.Instruction, n ast.AssertStatement, tapeSize int) ir.Label {
 	// The message rides in the instruction as the bytes it is, not as a value: it is
 	// written for whoever reads the result, and a value would have to fit in a tape.
 	cond := EmitInstruction(tc, insts, n.Condition, tapeSize)
@@ -390,7 +368,7 @@ func emitAssertStatement(tc *int, insts *[]ir.Instruction, n ast.AssertStatement
 }
 
 // emitFeedExpression reads the nth value applied to this scope.
-func emitFeedExpression(tc *int, insts *[]ir.Instruction, n ast.FeedExpression, tapeSize int) Label {
+func emitFeedExpression(tc *int, insts *[]ir.Instruction, n ast.FeedExpression, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpGetFeed, byteutil.FromUint64(n.Nth.Value), nil))
 	return l
@@ -398,7 +376,7 @@ func emitFeedExpression(tc *int, insts *[]ir.Instruction, n ast.FeedExpression, 
 }
 
 // emitBinaryExpression does arithmetic on two values.
-func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpression, tapeSize int) Label {
+func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpression, tapeSize int) ir.Label {
 	ll := EmitInstruction(tc, insts, n.Left, tapeSize)
 	lr := EmitInstruction(tc, insts, n.Right, tapeSize)
 	var op byte
@@ -423,7 +401,7 @@ func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpressi
 }
 
 // emitNumberLiteral saves a number as a tape.
-func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, tapeSize int) Label {
+func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize), nil))
 	return l
@@ -431,7 +409,7 @@ func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, ta
 }
 
 // emitTextLiteral saves text as the tape of its bytes.
-func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSize int) Label {
+func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSize int) ir.Label {
 	// Text is a tape holding its bytes, so it saves like any other value.
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
@@ -440,7 +418,7 @@ func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSi
 }
 
 // emitBooleanLiteral saves true or false, which are tapes like any other.
-func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, tapeSize int) Label {
+func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, n.Value, nil))
 	return l
@@ -448,7 +426,7 @@ func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, 
 }
 
 // emitIdentifierLiteral loads what a name is bound to.
-func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLiteral, tapeSize int) Label {
+func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, n.Token.GetMatch(), nil))
 	return l
@@ -465,18 +443,18 @@ func (e *emt) Emit(tree ast.AST) ([]ir.Instruction, error) {
 
 // EmitProgram compiles ast and records where each top-level expression landed, so a caller
 // can run them one at a time and report each value as it is produced.
-func (e *emt) EmitProgram(tree ast.AST) (Program, error) {
+func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
 	tc := 0
 	insts := make([]ir.Instruction, 0)
-	exprs := make([]Expression, 0, len(tree.Nodes))
+	exprs := make([]ir.Expression, 0, len(tree.Nodes))
 
 	for _, node := range tree.Nodes {
 		from := len(insts)
 		label := EmitInstruction(&tc, &insts, node, e.tapeSize)
-		exprs = append(exprs, Expression{From: from, To: len(insts), Label: label})
+		exprs = append(exprs, ir.Expression{From: from, To: len(insts), Label: label})
 	}
 
-	return Program{
+	return ir.Program{
 		Instructions: insts,
 		Expressions:  exprs,
 		Warnings:     append(checkDeferCapacity(tree.Nodes, e.tapeSize), checkAsserts(tree.Nodes)...),

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
-func compileWith(t *testing.T, source string, tapeSize int) Program {
+func compileWith(t *testing.T, source string, tapeSize int) ir.Program {
 	t.Helper()
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
 	if err != nil {
@@ -26,7 +26,7 @@ func compileWith(t *testing.T, source string, tapeSize int) Program {
 	return program
 }
 
-func compile(t *testing.T, source string) Program {
+func compile(t *testing.T, source string) ir.Program {
 	t.Helper()
 	return compileWith(t, source, 0)
 }

--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -5,27 +5,8 @@ import (
 
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/diag"
 )
-
-// A Warning is something worth saying about a program that is not a reason to refuse it.
-// Compilation carries on and the program runs.
-//
-// Line and Column are 1-based and zero when the warning is about the program as a whole
-// rather than a place in it.
-type Warning struct {
-	Message string
-	Line    int
-	Column  int
-}
-
-func (w Warning) String() string {
-	return w.Message
-}
-
-// Positioned reports whether the warning points at a place in the source.
-func (w Warning) Positioned() bool {
-	return w.Line > 0
-}
 
 // checkDeferCapacity reports scopes holding more deferred scopes than a tape can index.
 //
@@ -37,7 +18,7 @@ func (w Warning) Positioned() bool {
 // This is a warning rather than an error because the count is static: it cannot know how
 // often a scope actually runs. And it is never checked at runtime — a program that is
 // already running should not be stopped by a limit its shape implied.
-func checkDeferCapacity(nodes []ast.Node, tapeSize int) []Warning {
+func checkDeferCapacity(nodes []ast.Node, tapeSize int) []diag.Warning {
 	tapeSize = byteutil.TapeSize(tapeSize)
 	if tapeSize >= 8 {
 		// A scope would need more than 2^64 defers to wrap; nothing to say.
@@ -45,7 +26,7 @@ func checkDeferCapacity(nodes []ast.Node, tapeSize int) []Warning {
 	}
 	capacity := uint64(1) << (8 * tapeSize)
 
-	warnings := make([]Warning, 0)
+	warnings := make([]diag.Warning, 0)
 	var walk func(scope []ast.Node)
 	walk = func(scope []ast.Node) {
 		defers := 0
@@ -55,7 +36,7 @@ func checkDeferCapacity(nodes []ast.Node, tapeSize int) []Warning {
 			}
 		}
 		if uint64(defers) > capacity {
-			warnings = append(warnings, Warning{Message: fmt.Sprintf(
+			warnings = append(warnings, diag.Warning{Message: fmt.Sprintf(
 				"%d deferred scopes in one scope, but a %d-byte tape can only name %d: calls past that reach the wrong scope",
 				defers, tapeSize, capacity)})
 		}
@@ -69,14 +50,14 @@ func checkDeferCapacity(nodes []ast.Node, tapeSize int) []Warning {
 // An assertion belongs to "aurora test"; a plain run consumes it and moves on, so the
 // point of the warning is to say that out loud rather than let someone believe a check
 // ran. Each one is named by position, so an editor can jump to it.
-func checkAsserts(nodes []ast.Node) []Warning {
-	warnings := make([]Warning, 0)
+func checkAsserts(nodes []ast.Node) []diag.Warning {
+	warnings := make([]diag.Warning, 0)
 
 	var walk func(scope []ast.Node)
 	walk = func(scope []ast.Node) {
 		for _, node := range scope {
 			if assertion, ok := node.(ast.AssertStatement); ok {
-				warning := Warning{Message: "assert only runs under 'aurora test'; ignored here"}
+				warning := diag.Warning{Message: "assert only runs under 'aurora test'; ignored here"}
 				if assertion.Token != nil {
 					warning.Line = assertion.Token.GetLine()
 					warning.Column = assertion.Token.GetColumn()

--- a/emitter/warning_test.go
+++ b/emitter/warning_test.go
@@ -1,12 +1,13 @@
 package emitter
 
 import (
+	"github.com/guiferpa/aurora/wire/diag"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-func warningsFor(t *testing.T, source string, tapeSize int) []Warning {
+func warningsFor(t *testing.T, source string, tapeSize int) []diag.Warning {
 	t.Helper()
 	return compileWith(t, source, tapeSize).Warnings
 }

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -53,8 +53,7 @@ func Build(ctx context.Context, in BuildInput) (BuildReport, error) {
 	}
 	// What the compiler has to say about the program, and what the backend has to say about
 	// what it can carry: the second is the builder's to answer, since it is the one writing.
-	warnings := append(CompilerWarnings(program.Warnings), BackendWarnings(evm.Warnings(program.Instructions))...)
-	ReportWarnings(in.Warnings, in.Source, warnings)
+	ReportWarnings(in.Warnings, in.Source, append(program.Warnings, evm.Warnings(program.Instructions)...))
 	report.Instructions = len(program.Instructions)
 
 	// Assembling and writing are two things, and the builder only does the first: it

--- a/hosting/cli/compile.go
+++ b/hosting/cli/compile.go
@@ -9,6 +9,7 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/shared/trace"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // Compile turns a source file into a program: read, lex, parse, emit.
@@ -22,23 +23,23 @@ import (
 // designed (see docs/module_system_design.md).
 // traces receives what each phase produced, for the loggers that were asked for. Nil
 // discards it, which is what a caller that asked for none wants.
-func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (emitter.Program, error) {
+func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (ir.Program, error) {
 	if traces == nil {
 		traces = io.Discard
 	}
 
 	bs, err := os.ReadFile(source)
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	if slices.Contains(loggers, "lexer") {
 		if err := trace.Tokens(traces, tokens); err != nil {
-			return emitter.Program{}, err
+			return ir.Program{}, err
 		}
 	}
 
@@ -48,13 +49,13 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (e
 		TapeSize: tapeSize,
 	}).Parse()
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	// A phase returns what it made and does not show it; showing is decided here, once the
 	// phase has finished, which is why the output is no longer on-time.
 	if slices.Contains(loggers, "parser") {
 		if err := trace.AST(traces, tree); err != nil {
-			return emitter.Program{}, err
+			return ir.Program{}, err
 		}
 	}
 
@@ -62,11 +63,11 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (e
 		TapeSize: tapeSize,
 	}).EmitProgram(tree)
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	if slices.Contains(loggers, "emitter") {
 		if err := trace.Instructions(traces, program.Instructions); err != nil {
-			return emitter.Program{}, err
+			return ir.Program{}, err
 		}
 	}
 

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -31,7 +31,7 @@ func Run(ctx context.Context, in RunInput) error {
 	if err != nil {
 		return err
 	}
-	ReportWarnings(in.Warnings, in.Source, CompilerWarnings(program.Warnings))
+	ReportWarnings(in.Warnings, in.Source, program.Warnings)
 
 	ev := evaluator.New(evaluator.NewEvaluatorOptions{
 		Output:   in.Stdout,

--- a/hosting/cli/warning.go
+++ b/hosting/cli/warning.go
@@ -5,54 +5,28 @@ import (
 
 	"github.com/fatih/color"
 
-	"github.com/guiferpa/aurora/builder/evm"
-	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/wire/diag"
 )
-
-// A Warning is something worth saying about a program that is not a reason to refuse it.
-//
-// The compiler and the backend each answer in their own words — a phase does not speak for
-// the one after it — so this is where the two are made into one thing to print. Line and
-// column are zero when the warning is about the program as a whole rather than a place in it.
-type Warning struct {
-	Message string
-	Line    int
-	Column  int
-}
-
-// CompilerWarnings and BackendWarnings carry each phase's answer across without either of
-// them having to know what the other calls a warning.
-func CompilerWarnings(warnings []emitter.Warning) []Warning {
-	out := make([]Warning, 0, len(warnings))
-	for _, warning := range warnings {
-		out = append(out, Warning{Message: warning.Message, Line: warning.Line, Column: warning.Column})
-	}
-	return out
-}
-
-func BackendWarnings(warnings []evm.Warning) []Warning {
-	out := make([]Warning, 0, len(warnings))
-	for _, warning := range warnings {
-		out = append(out, Warning{Message: warning.Message})
-	}
-	return out
-}
 
 // ReportWarnings prints what the compiler and the backend want to say about a program without
 // refusing it. They go to stderr, so a pipeline reading the program's output is unaffected.
 //
+// The two used to arrive as two types — one owned by the emitter, one by the backend — and
+// this file carried a pair of functions to make them into a third. They speak the same shape
+// now, which is what a warning was all along: a message, and sometimes a place.
+//
 // A warning that points at a place in the source is written as file:line:column, which is
 // what an editor follows to jump there.
-func ReportWarnings(w io.Writer, source string, warnings []Warning) {
+func ReportWarnings(w io.Writer, source string, warnings []diag.Warning) {
 	if w == nil {
 		return
 	}
 	yellow := color.New(color.FgHiYellow)
 	for _, warning := range warnings {
-		if warning.Line > 0 {
-			_, _ = yellow.Fprintf(w, "%s:%d:%d: warning: %s\n", source, warning.Line, warning.Column, warning.Message)
+		if warning.Positioned() {
+			_, _ = yellow.Fprintf(w, "%s:%d:%d: warning: %s\n", source, warning.Line, warning.Column, warning)
 			continue
 		}
-		_, _ = yellow.Fprintf(w, "%s: warning: %s\n", source, warning.Message)
+		_, _ = yellow.Fprintf(w, "%s: warning: %s\n", source, warning)
 	}
 }

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -129,12 +129,12 @@ func (s *session) run(text string) {
 
 // compile takes the line through the three phases, showing what each one produced when -l
 // asked for it.
-func (s *session) compile(text string) (emitter.Program, error) {
+func (s *session) compile(text string) (ir.Program, error) {
 	line := bytes.NewBufferString(text)
 
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(line.Bytes())
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	s.trace("lexer", func(w io.Writer) error { return trace.Tokens(w, tokens) })
 
@@ -144,7 +144,7 @@ func (s *session) compile(text string) (emitter.Program, error) {
 		Directives: s.directives,
 	}).Parse()
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	s.trace("parser", func(w io.Writer) error { return trace.AST(w, tree) })
 
@@ -152,7 +152,7 @@ func (s *session) compile(text string) (emitter.Program, error) {
 		TapeSize: s.tapeSize,
 	}).EmitProgram(tree)
 	if err != nil {
-		return emitter.Program{}, err
+		return ir.Program{}, err
 	}
 	s.trace("emitter", func(w io.Writer) error { return trace.Instructions(w, program.Instructions) })
 
@@ -172,7 +172,7 @@ func (s *session) trace(phase string, write func(w io.Writer) error) {
 
 // evaluate runs the line's expressions one at a time, so a line holding several of them
 // answers where each one happens rather than all of them at the end.
-func (s *session) evaluate(program emitter.Program) {
+func (s *session) evaluate(program ir.Program) {
 	offset := len(s.insts)
 	s.insts = append(s.insts, program.Instructions...)
 

--- a/shared/trace/trace_test.go
+++ b/shared/trace/trace_test.go
@@ -10,10 +10,11 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // compile runs the front end over source, which is what a host hands to trace.
-func compile(t *testing.T, source string) (ast.AST, emitter.Program) {
+func compile(t *testing.T, source string) (ast.AST, ir.Program) {
 	t.Helper()
 
 	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))

--- a/wire/diag/warning.go
+++ b/wire/diag/warning.go
@@ -1,0 +1,28 @@
+// Package diag holds what a phase has to say about a program without refusing it.
+//
+// A warning crosses from whoever found it to whoever shows it — from the emitter or the
+// backend to a command line — so it belongs to neither. Before this, the emitter owned the
+// type and the backend had one of its own, which meant a host converting between two shapes
+// of the same idea to print them in one list.
+package diag
+
+// A Warning is something worth saying about a program that is not a reason to refuse it.
+// Compilation carries on and the program runs.
+//
+// Line and Column are 1-based and zero when the warning is about the program as a whole
+// rather than a place in it — which is what a backend answers with, since the IR carries
+// instructions and not lines.
+type Warning struct {
+	Message string
+	Line    int
+	Column  int
+}
+
+func (w Warning) String() string {
+	return w.Message
+}
+
+// Positioned reports whether the warning points at a place in the source.
+func (w Warning) Positioned() bool {
+	return w.Line > 0
+}

--- a/wire/ir/program.go
+++ b/wire/ir/program.go
@@ -1,0 +1,26 @@
+package ir
+
+import "github.com/guiferpa/aurora/wire/diag"
+
+// Expression is one top-level expression of a program: the range of instructions it
+// compiled to, and the label the temp holding its value ends up under.
+//
+// A caller that wants to report values in source order needs this. Reading the temp map
+// after the whole program has run cannot give it: the map has no order, and everything
+// written by print along the way has already been emitted.
+type Expression struct {
+	From  int // index of its first instruction
+	To    int // index one past its last instruction
+	Label []byte
+}
+
+// Program is what a source file compiled to: the instruction stream, where each top-level
+// expression sits inside it, and anything worth saying that did not stop the compilation.
+type Program struct {
+	Instructions []Instruction
+	Expressions  []Expression
+	Warnings     []diag.Warning
+}
+
+// A Label names the value an instruction leaves behind, so a later instruction can read it.
+type Label []byte


### PR DESCRIPTION
The step before the last one. Moving the instructions was not enough: **everything wrapped around them stayed in the emitter**, so a host that reads a compiled program still imported the phase that compiled it — for types that describe the *answer*, not the work.

## What moved

`Program`, `Expression` and `Label` travel with the IR they describe.

A **warning** goes further and gets a package of its own: it crosses from whoever found it to whoever shows it, and the backend has its own to give as well. Owning it in the emitter is what forced #38 to invent `evm.Warning` and a host to convert between two shapes of the same idea.

```
emitter      byteutil wire/token wire/ast wire/ir  →  + wire/diag
builder/evm  byteutil wire/ir                      →  + wire/diag
wire/ir      byteutil                              →  + wire/diag
```

## A correction to the architecture document

It said a wire package may import *"util, and nothing else of the project"* — and `wire/ast` has held tokens since the day it was created, so the sentence was already narrower than its own reason. **A wire package may lean on another wire package**, because neither can tie it to a phase, which is what the rule protects. Written down now.

## This one meets #38

`builder/evm/support.go` is in #38, not in `main`, so the simplification the RFC promised — one `wire.Warning`, no conversion in the host — is only half visible here.

**Recommend merging #38 first**: it is older, green, and independent. Then this one rebases on top and the two conversion functions in `hosting/cli` disappear in the same PR, which is the shape the RFC described.

Nothing here blocks on that: what is in this branch stands on `main` as it is today.

## Verification

- `make check` — build, wasm, test, lint: green, 0 lint issues.
- Every dependency claim read off `go list -deps`.

After this, the last step: hosts stop building phases and `main` wires them.