### PR TITLE
What a run answers with is wire

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,7 @@ packages of their own.
 | kind | who |
 |---|---|
 | **vital** | `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` |
-| **wire** | `wire/token`, `wire/ast`, `wire/ir`, `wire/diag` |
+| **wire** | `wire/token`, `wire/ast`, `wire/ir`, `wire/diag`, `wire/eval` |
 | **util** | `byteutil`, `logger` |
 | **hosting** | `hosting/cli`, `hosting/repl`, `hosting/lsp` |
 | **shared** | `shared/fileutil`, `shared/manifest`, `shared/trace` |

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -27,7 +27,7 @@ from.
 | kind | what it is | may import | is imported by |
 |---|---|---|---|
 | **vital** | a step of the pipeline: `lexer`, `parser`, `emitter`, `builder/evm`, `evaluator` | wire, util | nothing directly — it arrives injected |
-| **wire** | what crosses a boundary: `wire/token`, `wire/ast`, `wire/ir`, `wire/diag` | wire, util, and nothing else of the project | everyone |
+| **wire** | what crosses a boundary: `wire/token`, `wire/ast`, `wire/ir`, `wire/diag`, `wire/eval` | wire, util, and nothing else of the project | everyone |
 | **util** | behaviour worth reusing that never touches the world: `byteutil`, `logger` | nothing of the project | everyone |
 | **hosting** | one kind of interaction: `hosting/cli`, `hosting/repl`, `hosting/lsp` | wire, util, shared | `main` |
 | **shared** | serves the hosting *layer* rather than one interaction: `shared/fileutil`, `shared/manifest`, `shared/printer`, `shared/trace` | wire, util | hosting, `main` |
@@ -90,6 +90,11 @@ util. Neither can tie it to a phase, which is what the rule is protecting.
 they are written down — spelling something out is part of the vocabulary, the way a token
 knows how to spell itself. It also holds the comparison of two of them, which is a question
 about the shape rather than about whoever built it.
+
+**The end of the pipeline is a boundary too.** What the evaluator answers with — the value of
+every expression, and what became of every assertion — crosses to a host exactly the way
+tokens cross to the parser, so it is wire as well: `wire/eval`. Without it, `aurora test`
+had to name the evaluator to report on assertions.
 
 **What wire does not hold:** deciding to show something, and choosing where it goes. That is a
 host's, and `shared/trace` is where it lives.

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/evaluator/builtin"
 	"github.com/guiferpa/aurora/evaluator/environ"
+	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
@@ -65,14 +66,12 @@ type Printer interface {
 	Print(value []byte) ([]byte, error)
 }
 
-type ReturnsPerLabel map[string][]byte
-
 type Evaluator struct {
 	cursor        uint64
 	end           uint64
 	insts         []ir.Instruction
-	assertResults []AssertResult // what each assertion did, in the order they ran
-	asserts       bool           // whether assertions are evaluated at all
+	assertResults []eval.AssertResult // what each assertion did, in the order they ran
+	asserts       bool                // whether assertions are evaluated at all
 	printBytes    Printer
 	printChars    Printer
 	printDecimal  Printer
@@ -85,13 +84,6 @@ func (e *Evaluator) TapeSize() int {
 	return e.tapeSize
 }
 
-// AssertResult is one assertion and what became of it. A run collects every one, not only
-// the failures, so a report can say how many held.
-type AssertResult struct {
-	Passed  bool
-	Message string
-}
-
 // ClearTemps drops the temps left behind by a program. A caller running two programs in
 // one evaluator needs it: each is emitted on its own and numbers its labels from zero, so
 // what one left behind would sit under the labels the next is about to use.
@@ -100,7 +92,7 @@ func (e *Evaluator) ClearTemps() {
 }
 
 // GetAssertResults returns every assertion that ran, in order.
-func (e *Evaluator) GetAssertResults() []AssertResult {
+func (e *Evaluator) GetAssertResults() []eval.AssertResult {
 	return e.assertResults
 }
 
@@ -506,7 +498,7 @@ func (e *Evaluator) EvaluateAssert(label, left, right []byte) error {
 	}
 
 	passed, failure := builtin.AssertFunction(cond, msg)
-	result := AssertResult{Passed: passed}
+	result := eval.AssertResult{Passed: passed}
 	if passed {
 		result.Message = msg
 	} else {
@@ -642,7 +634,7 @@ func (e *Evaluator) ExecuteInstruction(inst ir.Instruction) error {
 	return op(e, inst.GetLabel(), inst.GetLeft(), inst.GetRight())
 }
 
-func (e *Evaluator) ExecuteInstructions(from, to uint64) (ReturnsPerLabel, error) {
+func (e *Evaluator) ExecuteInstructions(from, to uint64) (eval.Returns, error) {
 	e.SetInstructionsOffset(from, to)
 
 	for e.CanReadInstructions() {
@@ -655,7 +647,7 @@ func (e *Evaluator) ExecuteInstructions(from, to uint64) (ReturnsPerLabel, error
 	return e.environ.GetTemps(), nil
 }
 
-func (e *Evaluator) Evaluate(insts []ir.Instruction) (ReturnsPerLabel, error) {
+func (e *Evaluator) Evaluate(insts []ir.Instruction) (eval.Returns, error) {
 	e.SetInstructions(insts)
 	returns, err := e.ExecuteInstructions(0, uint64(len(e.insts)))
 	return returns, err
@@ -664,7 +656,7 @@ func (e *Evaluator) Evaluate(insts []ir.Instruction) (ReturnsPerLabel, error) {
 // EvaluateRange sets the full instruction slice and runs only the range [from, to).
 // Used by the REPL: buffer accumulates all instructions; each line we append and run only the new slice,
 // so defer from/to indices stay valid in the same buffer.
-func (e *Evaluator) EvaluateRange(insts []ir.Instruction, from, to uint64) (ReturnsPerLabel, error) {
+func (e *Evaluator) EvaluateRange(insts []ir.Instruction, from, to uint64) (eval.Returns, error) {
 	e.SetInstructions(insts)
 	e.environ.ClearTemps()
 	returns, err := e.ExecuteInstructions(from, to)
@@ -689,7 +681,7 @@ func New(options NewEvaluatorOptions) *Evaluator {
 		cursor:        0,
 		end:           0,
 		insts:         make([]ir.Instruction, 0),
-		assertResults: make([]AssertResult, 0),
+		assertResults: make([]eval.AssertResult, 0),
 		asserts:       options.Asserts,
 		printBytes:    options.PrintBytes,
 		printChars:    options.PrintChars,

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/guiferpa/aurora/evaluator/environ"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
-func containsReturn(returns ReturnsPerLabel, index int, want []byte) (bool, []byte) {
+func containsReturn(returns eval.Returns, index int, want []byte) (bool, []byte) {
 	keys := slices.Collect(maps.Keys(returns))
 	slices.SortFunc(keys, func(a, b string) int {
 		ia, _ := strconv.ParseInt(a, 10, 64)
@@ -515,7 +516,7 @@ func TestAddCursor(t *testing.T) {
 type EvaluateCase struct {
 	Name       string
 	SourceCode string
-	TestFn     func(t *testing.T, returns ReturnsPerLabel, err error)
+	TestFn     func(t *testing.T, returns eval.Returns, err error)
 }
 
 type RunEvaluateCaseOptions struct {
@@ -566,7 +567,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_1",
 			`1 different 2;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -586,7 +587,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_2",
 			`1 equals 2;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -606,7 +607,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_3",
 			`1 smaller 2;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -626,7 +627,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_4",
 			`1 bigger 2;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -646,7 +647,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_5",
 			`1 equals 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -666,7 +667,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_6",
 			`1 different 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -686,7 +687,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_7",
 			`1 smaller 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -710,7 +711,7 @@ func TestRelative(t *testing.T) {
 		{
 			"relative_8",
 			`1 bigger 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -736,7 +737,7 @@ func TestArithmetic(t *testing.T) {
 		{
 			"arithmetic_1",
 			`1 + 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -753,7 +754,7 @@ func TestArithmetic(t *testing.T) {
 		{
 			"arithmetic_2",
 			`1 - 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -770,7 +771,7 @@ func TestArithmetic(t *testing.T) {
 		{
 			"arithmetic_3",
 			`1 * 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -787,7 +788,7 @@ func TestArithmetic(t *testing.T) {
 		{
 			"arithmetic_4",
 			`1 / 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -804,7 +805,7 @@ func TestArithmetic(t *testing.T) {
 		{
 			"arithmetic_5",
 			`1 ^ 1;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -828,7 +829,7 @@ func TestBoolean(t *testing.T) {
 		{
 			"boolean_1",
 			`true or false;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -849,7 +850,7 @@ func TestBoolean(t *testing.T) {
 			"boolean_2",
 			`false or false;
       true and true;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -888,7 +889,7 @@ func TestIfAndElse(t *testing.T) {
 			"if_1",
 			`if 10 bigger 9 { 10; };
 if 11 bigger 10 { 20; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -909,7 +910,7 @@ if 11 bigger 10 { 20; };`,
 		{
 			"if_2",
 			`if 10 smaller 9 { 10; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -923,7 +924,7 @@ if 11 bigger 10 { 20; };`,
 		{
 			"if_with_else_1",
 			`if 10 bigger 9 { 10; } else { 20; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -937,7 +938,7 @@ if 11 bigger 10 { 20; };`,
 		{
 			"if_with_else_2",
 			`if 10 bigger 11 { 10; } else { 20; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -968,7 +969,7 @@ branch {
   op equals 2: 64, 
   128;
 };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -992,7 +993,7 @@ ident r = branch {
   128;
 };
 r;`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1022,7 +1023,7 @@ func TestCallableScope(t *testing.T) {
 		{
 			"callable_scope_1",
 			`{ 1 + 2; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1036,7 +1037,7 @@ func TestCallableScope(t *testing.T) {
 		{
 			"callable_scope_2",
 			`{ 1 + { 2 + 3; }; };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1056,7 +1057,7 @@ func TestCallableScope(t *testing.T) {
     a * 2;
   };
 };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1075,7 +1076,7 @@ func TestCallableScope(t *testing.T) {
     a * 2;
   };
 };`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1101,7 +1102,7 @@ func TestDefer(t *testing.T) {
 
 r(1, 2);
 r(3, 4);`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1137,7 +1138,7 @@ func TestDeferRecursivity(t *testing.T) {
 };
 
 fib(11);`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1165,7 +1166,7 @@ fib(11);`,
 };
 
 fib(11);`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return
@@ -1190,7 +1191,7 @@ fib(11);`,
 };
 
 factorial(4);`,
-			func(t *testing.T, returns ReturnsPerLabel, err error) {
+			func(t *testing.T, returns eval.Returns, err error) {
 				if err != nil {
 					t.Errorf("expected no error, got: %v", err)
 					return

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/guiferpa/aurora/evaluator"
 	"github.com/guiferpa/aurora/shared/printer"
+	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
@@ -35,7 +36,7 @@ type TestInput struct {
 // FileReport is what happened in one test file.
 type FileReport struct {
 	Path    string
-	Results []evaluator.AssertResult
+	Results []eval.AssertResult
 	Err     error // the file could not be compiled or run at all
 }
 

--- a/hosting/cli/warning_test.go
+++ b/hosting/cli/warning_test.go
@@ -1,0 +1,78 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/wire/diag"
+)
+
+// This is the line a user reads when the compiler has something to say and compiles anyway.
+// Nothing covered it: the builder's warnings were tested as a list of messages, and how they
+// reach a person was not tested at all.
+
+func TestReportWarningsWritesWhereToLook(t *testing.T) {
+	out := &strings.Builder{}
+
+	ReportWarnings(out, "main.ar", []diag.Warning{
+		{Message: "257 deferred scopes in one scope", Line: 12, Column: 5},
+	})
+
+	got := out.String()
+	// An editor follows file:line:column to jump there, so the shape is the feature.
+	if !strings.Contains(got, "main.ar:12:5: warning: 257 deferred scopes in one scope") {
+		t.Errorf("wrote %q, want it to point at the place in the source", got)
+	}
+}
+
+// A backend warns about the program, not about a line: writing "main.ar:0:0" would send an
+// editor to the top of the file for something that is not there.
+func TestReportWarningsWithNoPlaceToPointAt(t *testing.T) {
+	out := &strings.Builder{}
+
+	ReportWarnings(out, "main.ar", []diag.Warning{{Message: "printd writes a log"}})
+
+	got := out.String()
+	if !strings.Contains(got, "main.ar: warning: printd writes a log") {
+		t.Errorf("wrote %q, want the file and the message", got)
+	}
+	if strings.Contains(got, ":0:") {
+		t.Errorf("wrote %q, want no place at all", got)
+	}
+}
+
+// Every warning is written, in the order they were found: the first thing said is the first
+// thing that went missing.
+func TestReportWarningsWritesEveryOne(t *testing.T) {
+	out := &strings.Builder{}
+
+	ReportWarnings(out, "main.ar", []diag.Warning{
+		{Message: "first"},
+		{Message: "second", Line: 2, Column: 1},
+	})
+
+	got := out.String()
+	if lines := strings.Count(strings.TrimSpace(got), "\n") + 1; lines != 2 {
+		t.Errorf("wrote %d lines for two warnings: %q", lines, got)
+	}
+	if strings.Index(got, "first") > strings.Index(got, "second") {
+		t.Errorf("wrote %q, want them in the order they were found", got)
+	}
+}
+
+// Nowhere to write is not a failure: "aurora run" passes nil when nobody asked for warnings,
+// and it must not fall over on a program that has some.
+func TestReportWarningsWithNowhereToWrite(t *testing.T) {
+	ReportWarnings(nil, "main.ar", []diag.Warning{{Message: "printd writes a log"}})
+}
+
+// Nothing to say is nothing written, rather than an empty line.
+func TestReportWarningsWithNothingToSay(t *testing.T) {
+	out := &strings.Builder{}
+
+	ReportWarnings(out, "main.ar", nil)
+
+	if got := out.String(); got != "" {
+		t.Errorf("wrote %q for no warnings", got)
+	}
+}

--- a/wire/diag/warning_test.go
+++ b/wire/diag/warning_test.go
@@ -1,0 +1,49 @@
+package diag
+
+import "testing"
+
+// A warning is a message and sometimes a place. Whether it has one is the whole branch a host
+// takes to write it, so it is what this answers for.
+
+func TestAWarningSaysItsMessage(t *testing.T) {
+	warning := Warning{Message: "if does not reach the bytecode yet", Line: 3, Column: 1}
+
+	if got := warning.String(); got != "if does not reach the bytecode yet" {
+		t.Errorf("said %q, want the message", got)
+	}
+}
+
+// A backend answers about a program as a whole: the IR carries instructions, not lines, so
+// there is no place to point at and a host must not write "main.ar:0:0".
+func TestPositioned(t *testing.T) {
+	cases := []struct {
+		name    string
+		warning Warning
+		want    bool
+	}{
+		{
+			name:    "a warning about a place in the source",
+			warning: Warning{Message: "257 deferred scopes in one scope", Line: 12, Column: 5},
+			want:    true,
+		},
+		{
+			name:    "a warning about the program as a whole",
+			warning: Warning{Message: "printd writes a log"},
+			want:    false,
+		},
+		{
+			// A column with no line is not a place either: the line is what points.
+			name:    "a column and no line",
+			warning: Warning{Message: "somewhere", Column: 5},
+			want:    false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.warning.Positioned(); got != tc.want {
+				t.Errorf("Positioned() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/wire/eval/eval.go
+++ b/wire/eval/eval.go
@@ -1,0 +1,26 @@
+// Package eval holds what evaluating a program answers with.
+//
+// The evaluator is the end of the pipeline, and what it produces crosses to a host just like
+// tokens, a tree and IR cross between phases: the value of every expression, and what became
+// of every assertion. Those are the artefacts of a run, so they live here rather than inside
+// whoever produced them — "aurora test" reporting on assertions had to name the evaluator to
+// do it.
+//
+// It is named after the phase that produces it, the way wire/ir is named after what it holds.
+// Not "run": in Aurora a run is a run of tapes, which is a value, so the word is taken — two
+// functions of the evaluator already use it for exactly that.
+package eval
+
+// Returns is the value each expression answered with, by the label the IR gave it.
+//
+// It is keyed by label and not by position because a label is what an instruction carries: a
+// caller asking what one expression is worth asks for its label, and one that ran a whole
+// program walks the labels it emitted.
+type Returns map[string][]byte
+
+// AssertResult is one assertion and what became of it. A run collects every one, not only the
+// failures, so a report can say how many held.
+type AssertResult struct {
+	Passed  bool
+	Message string
+}


### PR DESCRIPTION
The last two types a host had to name a phase for. `aurora test` held a `[]evaluator.AssertResult` in its report — a host naming a vital package to say what a program did.

## What moves

`ReturnsPerLabel` and `AssertResult` leave the evaluator for **`wire/eval`**: the value of every expression, and what became of every assertion. They are artefacts the way tokens and IR are artefacts — the end of the pipeline is a boundary too.

```go
type Returns map[string][]byte

type AssertResult struct {
	Passed  bool
	Message string
}
```

The package is named after the phase that produces it, the way `wire/ir` is named after what it holds. **Not `run`**: in Aurora a run is a run of tapes, which is a value, and two functions of the evaluator use the word for exactly that — a package by that name would be shadowed inside them.

`ReturnsPerLabel` loses the suffix on the way in: `eval.Returns` says the same thing, and the type's comment says what the key is.

No test in `wire/eval`: there is nothing there but two declarations, and inventing behaviour to have something to test would be worse than the gap.

## And a gap that was there

Neither end of the warning path was covered — `wire/diag` had no test, and neither did `ReportWarnings`, the only thing that turns a warning into a line someone reads. What was tested was the builder answering with a list of messages, which is not what anybody sees.

The second commit pins it: `main.ar:12:5: warning: …` for a warning that points at a place, no place at all for one about the program as a whole (`main.ar:0:0` would send an editor to a line that has nothing to do with it), nowhere to write is not a failure since `aurora run` passes nil, and nothing to say writes nothing.

## Verification

`make check` green; each commit builds and passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)