### PR TITLE
A node is marked, not walked

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -138,6 +138,12 @@ and it is the only thing lost.
   fixed; `^` is then the only level meant to recurse right.
 - **No modulo.** A remainder is `n - (n / d) * d`, which is also the expression that made the
   associativity bug matter.
+- **A node the emitter does not know emits nothing**, silently: the dispatch in
+  `EmitInstruction` ends by answering with the neutral value, because some nodes are handled by
+  their parent and it cannot tell those from a node nobody implemented. So a node type added to
+  the tree and wired into the parser, but never given a case, compiles a program that answers
+  zero. Saying so instead means an error where there is no way to raise one today —
+  `EmitInstruction` and the twenty-five `emit*` functions answer with a label and nothing else.
 - **`aurora test` discards what a program prints** (`io.Discard`), so a test cannot see the
   output of the source it runs.
 - **Mutable state** has a proposal and no implementation

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -126,15 +126,29 @@ junto, e nenhuma é detalhe:
 ## Achado ao mover a árvore
 
 **`Next()` não é chamado em lugar nenhum.** É o único método da interface `Node`, implementado
-vinte e cinco vezes, e nada no projeto o usa: a interface existe para marcar um tipo como nó, e
+trinta e uma vezes, e nada no projeto o usa: a interface existe para marcar um tipo como nó, e
 faz isso através de um método que ninguém chama.
 
-Trocar por um método não exportado (`node()`) resolveria duas coisas de uma vez: some com umas
-setenta e cinco linhas mortas, e **fecha o conjunto** — ninguém de fora do `wire/ast` passa a
-poder inventar um nó, o que é exatamente o que a linguagem quer, já que o emitter faz `switch`
-sobre a lista inteira.
+Trocar por um método não exportado (`node()`) resolve duas coisas de uma vez: some com as
+linhas mortas, e **fecha o conjunto** — ninguém de fora do `wire/ast` passa a poder inventar um
+nó, o que é exatamente o que a linguagem quer, já que o emitter faz `switch` sobre a lista
+inteira.
 
-Fica registrado em vez de feito: é mudança de desenho, não de lugar, e o passo era mover.
+> **Feito.** Uma `mark` não exportada, embutida como primeiro campo de todo nó, no lugar do
+> `Next() Node`: um método no arquivo inteiro em vez de trinta e um, e `node.go` de 337 para
+> 261 linhas.
+>
+> Ao aplicar ficou claro por que `Next()` nunca serviu de caminhada: um nó tem quantos filhos
+> quiser e ele devolve um só, então vinte e cinco das trinta e uma implementações devolviam
+> `nil`. Medida a árvore por tipo: 7 sem filho, 11 com um, 3 com dois, 3 com três — o
+> `BinaryExpression` inclusive, porque o operador também é nó — e 7 com lista. **A árvore é
+> n-ária**, o que descarta de uma vez `Next()` e qualquer par `Left()`/`Right()`.
+>
+> A caminhada que existe de verdade é o `childScopesOf`, um `switch` de tipo no
+> `emitter/warning.go`. Um `Children() []Node` a substituiria, e fica registrado como feature
+> própria: sendo exportado ele **não** veda nada, então conviveria com a marca em vez de
+> substituí-la — é o desenho do `go/ast` da biblioteca padrão, `Pos()` exportado e
+> `exprNode()` não.
 
 ## Consequência para o que já foi feito
 

--- a/shared/trace/trace.go
+++ b/shared/trace/trace.go
@@ -98,6 +98,11 @@ func wrapNode(n any) any {
 	fields := make(map[string]any)
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
+		// An unexported field cannot be read through reflection at all — asking panics — and
+		// it has nothing to show anyway: what a reader wants is what the node holds.
+		if !field.IsExported() {
+			continue
+		}
 		value := v.Field(i).Interface()
 
 		switch value := value.(type) {

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -4,61 +4,66 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
+// A Node is one node of the tree. The method is unexported and does nothing: it is a mark,
+// and marking is all the interface ever did.
+//
+// Being unexported closes the set — a node can only be declared here. The emitter switches
+// over every concrete type there is, so a node declared elsewhere would compile and then fall
+// through that switch in silence.
+//
+// The mark used to be "Next() Node", implemented thirty-one times and called never. It could
+// not have been the walk it read like: this tree is n-ary — seven types hold no child, eleven
+// hold one, three hold two, three hold three (a binary expression included, since the operator
+// is a node as well) and seven hold a list — and Next answered with a single child, so
+// twenty-five of the thirty-one answered nil. The walk that does exist is a type switch, in
+// emitter/warning.go, which is what asking a tree about its shape actually takes.
 type Node interface {
-	Next() Node
+	node()
 }
 
+// mark is what makes a type a node, embedded as the first field of every one of them.
+//
+// Embedding rather than writing the method thirty-one times: only this package can embed an
+// unexported type, so the set is closed just the same, and a node type declares what it is on
+// its first line instead of somewhere else in the file. It holds nothing and comes first, so
+// it costs no memory.
+type mark struct{}
+
+func (mark) node() {}
+
 type OperationLiteral struct {
+	mark
 	Value string      `json:"value"`
 	Token token.Token `json:"-"`
 }
 
-func (oln OperationLiteral) Next() Node {
-	return nil
-}
-
 type ParameterLiteral struct {
+	mark
 	Expression Node `json:"expression"`
 }
 
-func (pln ParameterLiteral) Next() Node {
-	return pln.Expression
-}
-
 type CalleeLiteral struct {
+	mark
 	Id     IdentifierLiteral  `json:"identifier"`
 	Params []ParameterLiteral `json:"parameters"`
 }
 
-func (cln CalleeLiteral) Next() Node {
-	return nil
-}
-
 type IdentifierLiteral struct {
+	mark
 	Value string      `json:"value"`
 	Token token.Token `json:"-"`
 }
 
-func (iln IdentifierLiteral) Next() Node {
-	return nil
-}
-
 type BooleanLiteral struct {
+	mark
 	Value []byte      `json:"value"`
 	Token token.Token `json:"-"`
 }
 
-func (bln BooleanLiteral) Next() Node {
-	return nil
-}
-
 type NumberLiteral struct {
+	mark
 	Value uint64      `json:"value"`
 	Token token.Token `json:"-"`
-}
-
-func (nln NumberLiteral) Next() Node {
-	return nil
 }
 
 // TextLiteral is `"text"`: the bytes of the text, packed into one tape.
@@ -72,119 +77,80 @@ func (nln NumberLiteral) Next() Node {
 // aligned like every other value, so "Gui" is three bytes and "a" is 97, the same tape the
 // number 97 is.
 type TextLiteral struct {
+	mark
 	Value []byte      `json:"value"`
 	Token token.Token `json:"-"`
 }
 
-func (tln TextLiteral) Next() Node {
-	return nil
-}
-
 type UnaryExpression struct {
+	mark
 	Expression Node             `json:"expression"`
 	Operation  OperationLiteral `json:"operation"`
 }
 
-func (uen UnaryExpression) Next() Node {
-	return uen.Expression
-}
-
 type BinaryExpression struct {
+	mark
 	Left      Node             `json:"left"`
 	Right     Node             `json:"right"`
 	Operation OperationLiteral `json:"operation"`
-}
-
-func (ben BinaryExpression) Next() Node {
-	return nil
 }
 
 type PrimaryExpression struct {
+	mark
 	Expression Node `json:"expression"`
 }
 
-func (pen PrimaryExpression) Next() Node {
-	return pen.Expression
-}
-
 type TapeExpression struct {
+	mark
 	Length uint64 `json:"length"`
 }
 
-func (TapeExpression) Next() Node {
-	return nil
-}
-
 type TapeBracketExpression struct {
+	mark
 	Items []Node `json:"items"`
 }
 
-func (TapeBracketExpression) Next() Node {
-	return nil
-}
-
 type PullExpression struct {
+	mark
 	Target Node `json:"target"`
 	Item   Node `json:"item"`
-}
-
-func (PullExpression) Next() Node {
-	return nil
 }
 
 type HeadExpression struct {
+	mark
 	Expression Node   `json:"expression"`
 	Length     uint64 `json:"length"`
-}
-
-func (HeadExpression) Next() Node {
-	return nil
 }
 
 type TailExpression struct {
+	mark
 	Expression Node   `json:"expression"`
 	Length     uint64 `json:"length"`
 }
 
-func (TailExpression) Next() Node {
-	return nil
-}
-
 type PushExpression struct {
+	mark
 	Target Node `json:"target"`
 	Item   Node `json:"item"`
 }
 
-func (PushExpression) Next() Node {
-	return nil
-}
-
 type RelativeExpression struct {
+	mark
 	Left      Node             `json:"left"`
 	Right     Node             `json:"right"`
 	Operation OperationLiteral `json:"operation"`
-}
-
-func (re RelativeExpression) Next() Node {
-	return nil
 }
 
 type BooleanExpression struct {
+	mark
 	Left      Node             `json:"left"`
 	Right     Node             `json:"right"`
 	Operation OperationLiteral `json:"operation"`
 }
 
-func (be BooleanExpression) Next() Node {
-	return nil
-}
-
 type BlockExpression struct {
+	mark
 	Body []Node `json:"body"`
-}
-
-func (ben BlockExpression) Next() Node {
-	return nil
 }
 
 // DeferExpression is "defer { ... }". It produces a value that is a pointer to the scope
@@ -192,29 +158,20 @@ func (ben BlockExpression) Next() Node {
 // Block is the body of the defer; it is a BlockExpression so the emitter can treat it
 // as a normal scope (BeginScope + body + Return) without duplicating scope logic.
 type DeferExpression struct {
+	mark
 	Block BlockExpression `json:"block"`
 }
 
-func (den DeferExpression) Next() Node {
-	return nil
-}
-
 type IfExpression struct {
+	mark
 	Test Node            `json:"test"`
 	Body []Node          `json:"body"`
 	Else *ElseExpression `json:"else"`
 }
 
-func (ien IfExpression) Next() Node {
-	return nil
-}
-
 type ElseExpression struct {
+	mark
 	Body []Node `json:"body"`
-}
-
-func (een ElseExpression) Next() Node {
-	return nil
 }
 
 // PrintFormat is how a print builtin reads the tape it is given.
@@ -229,31 +186,22 @@ const (
 // PrintStatement is one of the print builtins. They differ only in how the value is read,
 // so they are one node carrying which reading was asked for.
 type PrintStatement struct {
+	mark
 	Format PrintFormat `json:"format"`
 	Param  Node        `json:"parameter"`
 }
 
-func (psn PrintStatement) Next() Node {
-	return nil
-}
-
 // FeedExpression is "feed(n)": it reads the nth value applied to the running scope.
 type FeedExpression struct {
+	mark
 	Nth NumberLiteral `json:"nth"`
 }
 
-func (fen FeedExpression) Next() Node {
-	return nil
-}
-
 type IdentLiteral struct {
+	mark
 	Id    string      `json:"id"`
 	Token token.Token `json:"-"`
 	Value Node        `json:"value"`
-}
-
-func (isn IdentLiteral) Next() Node {
-	return isn.Value
 }
 
 // AssertStatement is `assert(condition, "message")`.
@@ -263,24 +211,18 @@ func (isn IdentLiteral) Next() Node {
 // the source. Keeping it out of the values is also what lets it be longer than a tape,
 // which a message usually is.
 type AssertStatement struct {
+	mark
 	Condition Node        `json:"condition"`
 	Message   string      `json:"message"`
 	Token     token.Token `json:"-"`
 }
 
-func (asn AssertStatement) Next() Node {
-	return nil
-}
-
 // AST is the top-level node: Aurora is expression-only, so a parsed file is the sequence
 // of expressions it holds. The unit of compilation is the file.
 type AST struct {
+	mark
 	Filename string `json:"filename"`
 	Nodes    []Node `json:"nodes"`
-}
-
-func (a AST) Next() Node {
-	return nil
 }
 
 // StructDeclaration names the fields of a run of tapes: `struct Point { x, y };`.
@@ -290,48 +232,36 @@ func (a AST) Next() Node {
 // the language server — and then it is gone. Nothing about it reaches the IR: the flow is
 // static, the fields are positional and every one of them is exactly a tape wide.
 type StructDeclaration struct {
+	mark
 	Name   string      `json:"name"`
 	Fields []string    `json:"fields"`
 	Token  token.Token `json:"-"`
 }
 
-func (sdn StructDeclaration) Next() Node {
-	return nil
-}
-
 // StructLiteral builds the run: `Point{10, 20}` is two tapes, one per field.
 type StructLiteral struct {
+	mark
 	Name   string      `json:"name"`
 	Values []Node      `json:"values"`
 	Token  token.Token `json:"-"`
 }
 
-func (sln StructLiteral) Next() Node {
-	return nil
-}
-
 // FieldExpression reads one tape out of a run. The index is resolved while parsing, from
 // the shape of the value, so nothing about the field's name survives here.
 type FieldExpression struct {
+	mark
 	Expression Node        `json:"expression"`
 	Index      uint64      `json:"index"`
 	Field      string      `json:"field"` // kept for the language server, never emitted
 	Token      token.Token `json:"-"`
 }
 
-func (fen FieldExpression) Next() Node {
-	return fen.Expression
-}
-
 // ShapedExpression is `expr as Point`: it says how to read a value the compiler cannot
 // trace back to a construction. It has no effect of its own — the emitter emits what is
 // inside it and drops the name.
 type ShapedExpression struct {
+	mark
 	Expression Node        `json:"expression"`
 	Struct     string      `json:"struct"`
 	Token      token.Token `json:"-"`
-}
-
-func (sen ShapedExpression) Next() Node {
-	return sen.Expression
 }


### PR DESCRIPTION
Closes the finding recorded while the tree moved to `wire/ast` ([rfcs/phase_coupling.md](https://github.com/guiferpa/aurora/blob/main/rfcs/phase_coupling.md#achado-ao-mover-a-árvore)).

## What was there

`Node`'s only method was `Next() Node`, implemented **thirty-one times and called never**:

```go
type Node interface {
	Next() Node
}
```

It reads like a walk and could not have been one. Measured, by node type:

| children | types | |
|---|---|---|
| none | 7 | `NumberLiteral`, `IdentifierLiteral`, `TextLiteral` |
| one | 11 | `PrintStatement{Param}`, `DeferExpression{Block}` |
| two | 3 | `PullExpression{Target, Item}` |
| three | 3 | `BinaryExpression{Left, Right, Operation}` |
| a list | 7 | `BlockExpression{Body []Node}`, `AST{Nodes []Node}` |

**The tree is n-ary**, and `Next` answered with a single child — so twenty-five of the thirty-one answered nil. The walk that does exist is a type switch in `emitter/warning.go`, which is what asking a tree about its shape actually takes.

## What it becomes

What the method was really doing was marking a type as a node, and that is what stays:

```go
type Node interface {
	node()
}

// mark is what makes a type a node, embedded as the first field of every one of them.
type mark struct{}

func (mark) node() {}

type BinaryExpression struct {
	mark
	Left      Node             `json:"left"`
	Right     Node             `json:"right"`
	Operation OperationLiteral `json:"operation"`
}
```

**Embedded rather than written thirty-one times.** Only this package can embed an unexported type, so the set is closed just the same, and a node declares what it is on its first line instead of somewhere else in the file. The field holds nothing and comes first, so it costs no memory.

Closing the set is the point: the emitter switches over every concrete type there is and **ends by answering with the neutral value**, so a node declared elsewhere would compile and then answer zero in silence.

`node.go` goes from 337 lines to 261, with one method in it.

## The two things found on the way

**`shared/trace` panicked on any unexported field.** `wrapNode` walks a node's fields with reflection and calls `Interface()` on each, which is not allowed for an unexported one. No node had one, so nothing ever hit it — the mark is the first, and `-l parser` brought the whole session down. First commit, on its own.

**The emitter answers zero for a node it does not know** — recorded in the roadmap, not fixed here. A node type added to the tree and wired into the parser but never given a case compiles a program that answers zero, and closing the set does not reach that: the node is legitimate, it is the case that is missing. Saying so instead needs an error path where there is none — `EmitInstruction` and the twenty-five `emit*` functions answer with a label and nothing else.

## No new test

Nothing to test in the mark: it removes code, and what replaces it is a compile-time property. A type that forgets the mark cannot be put in a `[]ast.Node` at all, which is stronger than anything a test could assert.

## Verification

`make check` green; each of the three commits builds and passes on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)