### PR TITLE
The parser takes its source at the parse

### DIFF
--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -19,7 +19,7 @@ func build(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -48,9 +48,7 @@ false;
 			t.Errorf("%v: %v", c.Name, err)
 			return
 		}
-		tree, err := parser.New(parser.NewParserOptions{
-			Tokens: tokens,
-		}).Parse()
+		tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
 		if err != nil {
 			t.Errorf("%v: %v", c.Name, err)
 			return
@@ -151,9 +149,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{
-				Tokens: tokens,
-			}).Parse()
+			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -241,9 +241,7 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{
-				Tokens: tokens,
-			}).Parse()
+			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", tc.name, err)
 				return

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -67,10 +67,8 @@ func init() {
 					return nil
 				}
 			}
-			tree, err := parser.New(parser.NewParserOptions{
-				Tokens:   tokens,
-				TapeSize: size,
-			}).Parse()
+			tree, err := parser.New(parser.NewParserOptions{TapeSize: size}).
+				Parse(parser.ParseInput{Tokens: tokens})
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))
 				return nil

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -174,8 +174,8 @@ A struct names the tapes of a run. `Point{10, 20}` is two tapes laid end to end,
 nothing in it saying a struct built it: no header, no length and no tag. A field is exactly
 one tape wide, so the field at index *i* sits at `i × tape_size`.
 
-`struct` and `as` are **directives**: they exist for the compiler to turn a name into an
-index, to report a mistake where it was written, and to tell the language server what is
+`struct` and `as` are **keywords that declare rather than do**: they exist for the compiler to
+turn a name into an index, to report a mistake where it was written, and to tell the language server what is
 there. Nothing about them reaches the IR or the binary — the flow is static and the fields
 are positional, so an index is all that is needed. `Point{97, 98}` and `"ab"` are the same
 value, and compare equal.
@@ -206,7 +206,7 @@ a brace after a name.
 A struct name is not a value: writing it on its own is an error, because there is nothing to
 load under it.
 
-Because the directive exists to catch mistakes, these are compile errors: a field the struct
+Because the declaration exists to catch mistakes, these are compile errors: a field the struct
 does not have, a value whose shape nothing declared, a construction that miscounts the
 and a struct name used as a value. Reading a field past the end of a value is not one — it gives the neutral value, the
 way `head` saturates and `feed` wraps.

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -310,17 +310,18 @@ printd p;   #- 10 20 — the whole run
 no header, no length, no tag. A struct is not a new kind of value, and a field is exactly one
 tape wide, so the field at index *i* sits at `i × tape_size`.
 
-### The directives die at compile time
+### What they declare dies at compile time
 
-`struct` and `as` are **directives for whoever writes the source**, and they exist for three
-things, all of them before the program runs:
+`struct` and `as` **declare, and do nothing**. They are keywords like any other — a token, a
+rule, errors of their own — and what sets them apart is that they leave a declaration instead
+of work. It exists for three things, all of them before the program runs:
 
 1. reporting a mistake — a field that does not exist, a construction that miscounts;
 2. saying how to reach the data — which index a name is;
 3. telling the language server what is there, so it can complete a field and describe one.
 
 None of it needs to exist in the compiled program: the flow is static, the fields are
-positional and every one is the same width. The compiler reads the directive, resolves an
+positional and every one is the same width. The compiler reads the declaration, resolves an
 index and drops the rest. Nothing about a struct — not its name, not its fields — reaches
 the IR or the binary.
 
@@ -348,16 +349,16 @@ stopping the program — the same rule `head` and `feed` follow.
 
 ### What is an error
 
-Because the directive exists to catch mistakes, these stop the compilation, with the line
+Because the declaration exists to catch mistakes, these stop the compilation, with the line
 and column where they were written:
 
 - reading a field the struct does not have;
 - reading a field of a value whose shape nothing declared;
 - building with the wrong number of values;
-- using a struct name as a value: it is a directive, not something to load.
+- using a struct name as a value: it declares a shape, it is not something to load.
 
 Padding a short construction with the neutral value would match how `feed` and `head` never
-fail, and would give up the only thing the directive does.
+fail, and would give up the only thing the declaration does.
 
 See [examples/structs.ar](../examples/structs.ar).
 

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -19,8 +19,8 @@ Document sync is **full** (`textDocumentSync: 1`): the client resends the whole 
 
 Three things come back, depending on where the cursor is.
 
-**Right after a dot**, the fields of that struct and nothing else. The shape comes from the
-directives — `ident p = Point{...}` or `... as Point` — read straight from the tokens rather
+**Right after a dot**, the fields of that struct and nothing else. The shape comes from what
+was declared — `ident p = Point{...}` or `... as Point` — read straight from the tokens rather
 than from the tree, because a document being edited hardly ever parses: the moment someone
 types `p.` there is no field name yet, and that is exactly when completion is wanted. The
 dot is declared as a trigger character, so the client asks on its own.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -208,9 +208,9 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBrack
 
 }
 
-// emitStructDeclaration answers the neutral value: a directive does no work.
+// emitStructDeclaration answers the neutral value: a declaration does no work.
 func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclaration, tapeSize int) ir.Label {
-	// A directive emits no work. It still answers with a value, because everything in
+	// A declaration emits no work. It still answers with a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.FalseTape(tapeSize), nil))

--- a/emitter/golden_test.go
+++ b/emitter/golden_test.go
@@ -34,7 +34,7 @@ func TestEmittedProgramMatchesTheGolden(t *testing.T) {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "wide.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "wide.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -15,7 +15,7 @@ func compileWith(t *testing.T, source string, tapeSize int) ir.Program {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
@@ -64,7 +64,7 @@ func TestEmitMatchesEmitProgram(t *testing.T) {
 	program := compile(t, source)
 
 	tokens, _ := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
-	tree, _ := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	tree, _ := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	insts, err := New(NewEmitterOptions{}).Emit(tree)
 	if err != nil {
 		t.Fatalf("Emit: %v", err)

--- a/evaluator/assert_test.go
+++ b/evaluator/assert_test.go
@@ -18,7 +18,7 @@ func evaluateAsserts(t *testing.T, source string, asserts bool) *Evaluator {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "checks.test.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "checks.test.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -269,7 +269,7 @@ func (e *Evaluator) EvaluateJoin(label, left, right []byte) error {
 }
 
 // EvaluateField takes one tape out of a run, by index. The index is a literal operand
-// written inline by the emitter, resolved from a struct directive that no longer exists.
+// written inline by the emitter, resolved from a struct declaration that no longer exists.
 //
 // Reading past the end gives the neutral value rather than failing, the way head saturates
 // and feed wraps: an operation on tapes does not stop a running program.

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -535,10 +535,7 @@ func runEvaluateCase(t *testing.T, cases []EvaluateCase, options RunEvaluateCase
 				return
 			}
 
-			tree, err := parser.New(parser.NewParserOptions{
-				Filename: options.Filename,
-				Tokens:   tokens,
-			}).Parse()
+			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: options.Filename, Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
@@ -1228,11 +1225,8 @@ func runAssertCase(t *testing.T, cases []AssertCase) {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{
-				// assert is only accepted in a test file
-				Filename: "assert.test.ar",
-				Tokens:   tokens,
-			}).Parse()
+			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{ // assert is only accepted in a test file
+				Filename: "assert.test.ar", Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return

--- a/evaluator/output_order_test.go
+++ b/evaluator/output_order_test.go
@@ -32,7 +32,7 @@ func runInOrder(t *testing.T, source string) []string {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/evaluator/tape_size_test.go
+++ b/evaluator/tape_size_test.go
@@ -22,10 +22,7 @@ func runWithTapeSize(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{
-		Filename: "main.ar", Tokens: tokens,
-		TapeSize: tapeSize,
-	}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
@@ -59,11 +56,7 @@ func runAndError(t *testing.T, source string, tapeSize int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parser.New(parser.NewParserOptions{
-		Filename: "main.ar",
-		Tokens:   tokens,
-		TapeSize: tapeSize,
-	}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		return nil, err
 	}

--- a/hosting/cli/compile.go
+++ b/hosting/cli/compile.go
@@ -43,11 +43,10 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (i
 		}
 	}
 
-	tree, err := parser.New(parser.NewParserOptions{
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{
 		Filename: source,
 		Tokens:   tokens,
-		TapeSize: tapeSize,
-	}).Parse()
+	})
 	if err != nil {
 		return ir.Program{}, err
 	}

--- a/hosting/cli/struct_test.go
+++ b/hosting/cli/struct_test.go
@@ -32,10 +32,10 @@ func TestStructReadsItsFields(t *testing.T) {
 	}
 }
 
-// The invariant the whole design rests on: the directive dies at compile time. A struct
+// The invariant the whole design rests on: the declaration dies at compile time. A struct
 // value is a run of tapes and carries nothing that says a struct built it, so two structs
 // of the same width are one value — checked below — and the tape at index 0 is just a tape.
-func TestStructCarriesNothingOfTheDirective(t *testing.T) {
+func TestStructCarriesNothingOfTheDeclaration(t *testing.T) {
 	// A field read out of a struct is the same value written on its own.
 	fromStruct := output(t, "struct Pair { a, b };\nprintb Pair{97, 98}.a;", 0)[0]
 	onItsOwn := output(t, "printb 97;", 0)[0]

--- a/hosting/lsp/textdoc/snippets.go
+++ b/hosting/lsp/textdoc/snippets.go
@@ -52,7 +52,7 @@ func keywordCompletion(tag token.Tag, snippets bool) CompletionItem {
 }
 
 // structCompletions offers each declared struct as a way of building one, with the field
-// names as the places to fill in — the directive already said what they are.
+// names as the places to fill in — the declaration already said what they are.
 //
 //	struct Point { x, y };   ->   Point{${1:x}, ${2:y}}
 func structCompletions(shapes structShapes, snippets bool) []CompletionItem {

--- a/hosting/lsp/textdoc/snippets_test.go
+++ b/hosting/lsp/textdoc/snippets_test.go
@@ -70,7 +70,7 @@ func TestNoSnippetsForAClientThatCannotExpandThem(t *testing.T) {
 	}
 }
 
-// A declared struct is offered as a way of building one, and the directive already said
+// A declared struct is offered as a way of building one, and the declaration already said
 // what the fields are — so they become the places to fill in.
 func TestStructCompletion(t *testing.T) {
 	const source = "struct Point { x, y };\nstruct Named { label, value, tag };\n"

--- a/hosting/lsp/textdoc/structs.go
+++ b/hosting/lsp/textdoc/structs.go
@@ -7,7 +7,7 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
-// What the language server knows about the struct directives, read straight from the tokens
+// What the language server knows about the struct declarations, read straight from the tokens
 // rather than from the tree.
 //
 // It has to be the tokens. A document being edited is broken most of the time — the moment
@@ -19,7 +19,7 @@ type structShapes struct {
 	shapes map[string]string   // identifier name -> the struct it is read as
 }
 
-// scanStructs reads the directives out of a token stream: `struct Point { x, y }` for the
+// scanStructs reads the declarations out of a token stream: `struct Point { x, y }` for the
 // fields, and `ident p = Point{...}` or `... as Point` for what a name is read as.
 func scanStructs(tokens []token.Token) structShapes {
 	found := structShapes{

--- a/hosting/lsp/textdoc/structs_test.go
+++ b/hosting/lsp/textdoc/structs_test.go
@@ -14,7 +14,7 @@ ident p = Point{10, 20};
 ident n = feed(0) as Named;
 `
 
-// Completing after a dot is the reason the directive is worth having at all for whoever is
+// Completing after a dot is the reason the declaration is worth having at all for whoever is
 // typing: the fields are what to offer, and nothing else.
 func TestCompletionAfterADotOffersTheFields(t *testing.T) {
 	cases := []struct {

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -62,13 +62,12 @@ func Analyze(doc Document) *Analysis {
 		return analysis
 	}
 
-	tree, err := parser.New(parser.NewParserOptions{
+	// How wide a value is decides what fits in one, so the document is read in the dialect it
+	// belongs to rather than in the default.
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: doc.TapeSize}).Parse(parser.ParseInput{
 		Filename: doc.Filename,
 		Tokens:   tokens,
-		// How wide a value is decides what fits in one, so the document is read in the
-		// dialect it belongs to rather than in the default.
-		TapeSize: doc.TapeSize,
-	}).Parse()
+	})
 	if err != nil {
 		analysis.Err = err
 		return analysis

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -175,7 +175,7 @@ func HoverInfo(doc Document, pos lsp.Position) string {
 	case token.TRUE, token.FALSE:
 		return "boolean: " + match
 	case token.ID:
-		// A struct name or a field read out of one: the directive is what says these are
+		// A struct name or a field read out of one: the declaration is what says these are
 		// anything other than a name, so it is what hover has to answer with.
 		if shape, fields, index := scanStructs(analysis.Tokens).structAt(analysis.Tokens, tk); shape != "" {
 			if index < 0 {

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -139,11 +139,12 @@ func (s *session) compile(text string) (ir.Program, error) {
 	}
 	s.trace("lexer", func(w io.Writer) error { return trace.Tokens(w, tokens) })
 
-	tree, err := parser.New(parser.NewParserOptions{
-		Tokens:       tokens,
-		TapeSize:     s.tapeSize,
+	tree, err := parser.New(parser.NewParserOptions{TapeSize: s.tapeSize}).Parse(parser.ParseInput{
+		Tokens: tokens,
+		// A struct declared on one line has to still be known on the next, so what the
+		// session remembers goes in with every line.
 		Declarations: s.declarations,
-	}).Parse()
+	})
 	if err != nil {
 		return ir.Program{}, err
 	}

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -98,7 +98,7 @@ func newLineReader(in io.Reader, out io.Writer) (lineReader, *History) {
 // what it leaves behind for the line after it.
 //
 // It is a type rather than a handful of variables inside a loop because everything here
-// outlives the line that filled it — a name, a struct directive and a defer all have to
+// outlives the line that filled it — a name, a struct declaration and a defer all have to
 // still be there on the next one.
 type session struct {
 	ev       *evaluator.Evaluator
@@ -106,9 +106,9 @@ type session struct {
 	tapeSize int
 	loggers  []string
 
-	// A parser is built per line, so the struct directives are held here: a struct declared
+	// A parser is built per line, so the struct declarations are held here: a struct declared
 	// on one line has to still be known on the next.
-	directives *parser.Directives
+	declarations *parser.Declarations
 	// Every line's instructions go into the same buffer, which is what keeps the range a
 	// defer recorded valid when it is called on a later line.
 	insts []ir.Instruction
@@ -140,9 +140,9 @@ func (s *session) compile(text string) (ir.Program, error) {
 	s.trace("lexer", func(w io.Writer) error { return trace.Tokens(w, tokens) })
 
 	tree, err := parser.New(parser.NewParserOptions{
-		Tokens:     tokens,
-		TapeSize:   s.tapeSize,
-		Directives: s.directives,
+		Tokens:       tokens,
+		TapeSize:     s.tapeSize,
+		Declarations: s.declarations,
 	}).Parse()
 	if err != nil {
 		return ir.Program{}, err
@@ -213,11 +213,11 @@ func Start(in io.Reader, out io.Writer, loggers []string, tapeSize int) {
 			PrintDecimal: printer.Decimal(out, tapeSize),
 			TapeSize:     tapeSize,
 		}),
-		out:        out,
-		tapeSize:   tapeSize,
-		loggers:    loggers,
-		directives: parser.NewDirectives(),
-		hist:       hist,
+		out:          out,
+		tapeSize:     tapeSize,
+		loggers:      loggers,
+		declarations: parser.NewDeclarations(),
+		hist:         hist,
 	}
 
 	editing, interactive := reader.(*editor)

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -36,7 +36,7 @@ func TestSessionAnswersWithTheTape(t *testing.T) {
 			want:  []string{"= [0 0 0 0 0 0 0 14]"},
 		},
 		{
-			// The directives are held across lines: a struct declared on one line has to still
+			// The declarations are held across lines: a struct declared on one line has to still
 			// be known on the next, and a parser is built per line.
 			name:  "a struct declared on one line is built on the next",
 			lines: "struct Point { x, y };\nident p = Point{10, 20};\np.y;\n",

--- a/lexer/scanner_test.go
+++ b/lexer/scanner_test.go
@@ -269,10 +269,10 @@ func TestUnderscoreIdentifier(t *testing.T) {
 	}
 }
 
-// struct and as are directives for whoever writes the source: they name the fields of a run
+// struct and as are keywords that declare rather than do: they name the fields of a run
 // of tapes and say which shape a value is read with. `as` was a keyword before namespaces
 // were rolled back, and comes back here for that.
-func TestScanStructDirectives(t *testing.T) {
+func TestScanStructDeclarations(t *testing.T) {
 	cases := []struct {
 		source string
 		want   []string

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -22,11 +22,11 @@ type pr struct {
 	cursor   int
 	tokens   []token.Token
 	tapeSize int
-	// directives is what `struct` and `as` leave behind, and nothing more: it turns `p.x`
+	// declarations is what `struct` and `as` leave behind, and nothing more: it turns `p.x`
 	// into an index and never reaches the tree, the IR or the binary. It is held by
 	// reference so a caller compiling one file across several parses — the REPL — keeps
 	// what was declared earlier.
-	directives *Directives
+	declarations *Declarations
 }
 
 // Helper functions to validate node types for tape operations
@@ -219,11 +219,11 @@ func (p *pr) parsePrimaryExpr() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, declared := p.directives.Structs[id.Value]; declared {
+	if _, declared := p.declarations.Structs[id.Value]; declared {
 		if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.O_CUR_BRK {
 			return p.ParseStructLiteral(id)
 		}
-		// A struct is a directive, not a value: there is nothing to load under its name.
+		// A struct is a declaration, not a value: there is nothing to load under its name.
 		return nil, token.NewError(id.Token, "%s is a struct at line %d and column %d: build a value with %s{...}",
 			id.Value, id.Token.GetLine(), id.Token.GetColumn(), id.Value)
 	}
@@ -732,7 +732,7 @@ func (p *pr) ParseIdent() (ast.Node, error) {
 	// Binding a value with a shape carries the shape to the name, so `p.x` reads after
 	// `ident p = feed(0) as Point;`.
 	if shape := p.shapeOf(expr); shape != "" {
-		p.directives.Shapes[string(id.GetMatch())] = shape
+		p.declarations.Shapes[string(id.GetMatch())] = shape
 	}
 	return ast.IdentLiteral{Id: string(id.GetMatch()), Token: id, Value: expr}, nil
 }
@@ -926,22 +926,22 @@ type NewParserOptions struct {
 	Tokens   []token.Token
 	// TapeSize is the width in bytes of every value. Zero means the default (8).
 	TapeSize int
-	// Directives carries the struct directives across parses of the same file. Nil starts
+	// Declarations carries the struct declarations across parses of the same file. Nil starts
 	// empty, which is what compiling a file in one go wants; the REPL passes the same value
 	// every line so a struct declared earlier is still known.
-	Directives *Directives
+	Declarations *Declarations
 }
 
 func New(opts NewParserOptions) Parser {
-	directives := opts.Directives
-	if directives == nil {
-		directives = NewDirectives()
+	declarations := opts.Declarations
+	if declarations == nil {
+		declarations = NewDeclarations()
 	}
 	return &pr{
-		filename:   opts.Filename,
-		cursor:     0,
-		tokens:     opts.Tokens,
-		tapeSize:   byteutil.TapeSize(opts.TapeSize),
-		directives: directives,
+		filename:     opts.Filename,
+		cursor:       0,
+		tokens:       opts.Tokens,
+		tapeSize:     byteutil.TapeSize(opts.TapeSize),
+		declarations: declarations,
 	}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -11,10 +11,30 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
+// A Parser turns a chain of tokens into a tree.
+//
+// One parser serves every source there is: what belongs to the project — how wide a value is —
+// is settled when it is built, and what belongs to one source arrives at Parse. It used to
+// take the tokens at build time, so an instance parsed exactly one file and nobody could be
+// handed a parser; only a way of making one.
+//
+// Parse keeps no state of its own between calls, so the same parser may be asked for one tree
+// after another.
 type Parser interface {
-	GetLookahead() token.Token
-	EatToken(tokenId string) (token.Token, error)
-	Parse() (ast.AST, error)
+	Parse(in ParseInput) (ast.AST, error)
+}
+
+// ParseInput is one source to read: everything that belongs to the file rather than to the
+// project.
+type ParseInput struct {
+	// Filename is the source path. It decides file-scoped rules: assert is only accepted
+	// inside *.test.ar.
+	Filename string
+	Tokens   []token.Token
+	// Declarations carries what `struct` and `as` declared across parses of the same file.
+	// Nil starts empty, which is what compiling a file in one go wants; the REPL passes the
+	// same value every line so a struct declared earlier is still known.
+	Declarations *Declarations
 }
 
 type pr struct {
@@ -910,8 +930,21 @@ func (p *pr) EatToken(tokenId string) (token.Token, error) {
 	return currtok, nil
 }
 
-func (p *pr) Parse() (ast.AST, error) {
-	nodes, err := p.ParseExprs(token.TagEOF)
+// Parse reads one source and answers with its tree.
+//
+// The receiver is a value, so what a parse needs — where it is in the chain, which tokens,
+// which file — is written on a copy and the parser itself is never touched. Two calls cannot
+// tread on each other, which is what lets a host hold one.
+func (p pr) Parse(in ParseInput) (ast.AST, error) {
+	p.filename = in.Filename
+	p.tokens = in.Tokens
+	p.cursor = 0
+	p.declarations = in.Declarations
+	if p.declarations == nil {
+		p.declarations = NewDeclarations()
+	}
+
+	nodes, err := (&p).ParseExprs(token.TagEOF)
 	if err != nil {
 		return ast.AST{}, err
 	}
@@ -920,28 +953,10 @@ func (p *pr) Parse() (ast.AST, error) {
 }
 
 type NewParserOptions struct {
-	// Filename is the source path. It decides file-scoped rules: assert is only
-	// accepted inside *.test.ar.
-	Filename string
-	Tokens   []token.Token
 	// TapeSize is the width in bytes of every value. Zero means the default (8).
 	TapeSize int
-	// Declarations carries the struct declarations across parses of the same file. Nil starts
-	// empty, which is what compiling a file in one go wants; the REPL passes the same value
-	// every line so a struct declared earlier is still known.
-	Declarations *Declarations
 }
 
 func New(opts NewParserOptions) Parser {
-	declarations := opts.Declarations
-	if declarations == nil {
-		declarations = NewDeclarations()
-	}
-	return &pr{
-		filename:     opts.Filename,
-		cursor:       0,
-		tokens:       opts.Tokens,
-		tapeSize:     byteutil.TapeSize(opts.TapeSize),
-		declarations: declarations,
-	}
+	return pr{tapeSize: byteutil.TapeSize(opts.TapeSize)}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -50,9 +50,9 @@ func TestEatTokenWithMismatch(t *testing.T) {
 		tok{nil, token.TagAssign},
 		tok{nil, token.TagSum},
 	}
-	p := New(NewParserOptions{
-		Tokens: tokens,
-	})
+	// EatToken is the mechanism a parse runs on, so it is asked of the parse state itself
+	// rather than through the Parser a host is handed.
+	p := &pr{tokens: tokens}
 	expected := token.IDENT
 	got, err := p.EatToken(expected)
 	if err == nil {
@@ -84,9 +84,7 @@ func TestEatToken(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		p := New(NewParserOptions{
-			Tokens: c.Tokens,
-		})
+		p := &pr{tokens: c.Tokens}
 		for _, tid := range c.TokenIds {
 			got, err := p.EatToken(tid)
 			if err != nil {
@@ -145,8 +143,7 @@ func TestParse(t *testing.T) {
 			},
 		},
 	}
-	p := &pr{filename: "testing.ar", cursor: 0, tokens: tokens}
-	tree, err := p.Parse()
+	tree, err := New(NewParserOptions{}).Parse(ParseInput{Filename: "testing.ar", Tokens: tokens})
 	if err != nil {
 		t.Errorf("param: %v, %v", tokens, err)
 	}

--- a/parser/reuse_test.go
+++ b/parser/reuse_test.go
@@ -1,0 +1,112 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// One parser answers for every source there is. It used to take its tokens at build time, so
+// an instance parsed exactly one file — which is why no host could be handed a parser, only a
+// way of making one. What follows is the property that changed.
+
+// tokensOf lexes a source, which is what a parse is given.
+func tokensOf(t *testing.T, source string) []token.Token {
+	t.Helper()
+	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("lexer: %v", err)
+	}
+	return tokens
+}
+
+func TestOneParserReadsOneSourceAfterAnother(t *testing.T) {
+	p := New(NewParserOptions{})
+
+	first, err := p.Parse(ParseInput{Filename: "first.ar", Tokens: tokensOf(t, "1 + 2;")})
+	if err != nil {
+		t.Fatalf("first: %v", err)
+	}
+	second, err := p.Parse(ParseInput{Filename: "second.ar", Tokens: tokensOf(t, "3 * 4;\n5;")})
+	if err != nil {
+		t.Fatalf("second: %v", err)
+	}
+
+	// Each tree is its own source's: a cursor left where the first parse stopped would read
+	// the second from the middle, or from its end.
+	if first.Filename != "first.ar" || second.Filename != "second.ar" {
+		t.Errorf("trees say %q and %q", first.Filename, second.Filename)
+	}
+	if len(first.Nodes) != 1 {
+		t.Errorf("the first source has %d expressions, want 1", len(first.Nodes))
+	}
+	if len(second.Nodes) != 2 {
+		t.Errorf("the second source has %d expressions, want 2", len(second.Nodes))
+	}
+}
+
+// A source that does not parse leaves the parser where it was, so the next one still reads.
+// This is the REPL: a line that fails is answered and forgotten.
+func TestAParserSurvivesASourceThatFails(t *testing.T) {
+	p := New(NewParserOptions{})
+
+	if _, err := p.Parse(ParseInput{Filename: "broken.ar", Tokens: tokensOf(t, "1 +;")}); err == nil {
+		t.Fatal("a source that does not parse was accepted")
+	}
+
+	tree, err := p.Parse(ParseInput{Filename: "fine.ar", Tokens: tokensOf(t, "7;")})
+	if err != nil {
+		t.Fatalf("after a failure: %v", err)
+	}
+	if len(tree.Nodes) != 1 {
+		t.Errorf("the next source has %d expressions, want 1", len(tree.Nodes))
+	}
+}
+
+// What `struct` and `as` declare belongs to whoever is compiling, not to the parser: the REPL
+// hands the same declarations back every line so a struct declared earlier is still known.
+func TestDeclarationsComeFromTheCaller(t *testing.T) {
+	p := New(NewParserOptions{})
+	declarations := NewDeclarations()
+
+	if _, err := p.Parse(ParseInput{
+		Tokens:       tokensOf(t, "struct Point { x, y };"),
+		Declarations: declarations,
+	}); err != nil {
+		t.Fatalf("declaring: %v", err)
+	}
+
+	// The next source is a different parse, and it knows the struct because the caller kept it.
+	if _, err := p.Parse(ParseInput{
+		Tokens:       tokensOf(t, "ident p = Point{10, 20};\np.y;"),
+		Declarations: declarations,
+	}); err != nil {
+		t.Fatalf("using what was declared: %v", err)
+	}
+}
+
+// And a parse that was handed none knows nothing: two files compiled by the same parser do not
+// leak into each other, which is what lets "aurora test" read a source and its test file
+// without the test inheriting a name it never declared.
+func TestASourceDoesNotSeeWhatAnotherDeclared(t *testing.T) {
+	p := New(NewParserOptions{})
+
+	if _, err := p.Parse(ParseInput{
+		Tokens:       tokensOf(t, "struct Point { x, y };"),
+		Declarations: NewDeclarations(),
+	}); err != nil {
+		t.Fatalf("declaring: %v", err)
+	}
+
+	_, err := p.Parse(ParseInput{Tokens: tokensOf(t, "ident p = Point{10, 20};")})
+	if err == nil {
+		t.Fatal("a source built a struct that nothing declared in it")
+	}
+	// A name nothing declared is not a construction at all — it is an identifier followed by
+	// a brace — so the parse stops there rather than at the name.
+	if !strings.Contains(err.Error(), "unexpected token {") {
+		t.Errorf("error = %q, want it to stop at the brace", err)
+	}
+}

--- a/parser/shapes_test.go
+++ b/parser/shapes_test.go
@@ -30,7 +30,7 @@ func parseSource(t *testing.T, source, filename string) (ast.AST, error) {
 	if err != nil {
 		return ast.AST{}, err
 	}
-	return New(NewParserOptions{Filename: filename, Tokens: tokens}).Parse()
+	return New(NewParserOptions{}).Parse(ParseInput{Filename: filename, Tokens: tokens})
 }
 
 // first returns the single top-level node, asserting the type.
@@ -542,10 +542,7 @@ ident t = pull [1, 2] 3;
 		t.Fatalf("lexer: %v", err)
 	}
 
-	tree, err := New(NewParserOptions{
-		Filename: "main.ar",
-		Tokens:   tokens,
-	}).Parse()
+	tree, err := New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parsing with logging on: %v", err)
 	}

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -8,27 +8,32 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
-// The struct directives, and everything they are: a way of naming the fields of a run of
-// tapes so the compiler can turn a name into an index, point at a mistake where it was
+// What `struct` and `as` declare, and everything it is: a way of naming the fields of a run
+// of tapes so the compiler can turn a name into an index, point at a mistake where it was
 // written, and tell the language server what is there.
 //
 // None of it outlives the compilation. A struct value is a run of tapes and nothing else —
 // the same run a reel of the same length is — so the tables here are read while parsing and
 // dropped, and the tree carries indexes rather than names.
 
-// Directives are what the struct directives leave behind while a file is compiled: the
-// fields each struct declared, and the struct a name is read as.
+// Declarations are what those two keywords leave behind while a file is compiled: the fields
+// each struct declared, and the struct a name is read as.
+//
+// They were called directives, which is what a language usually calls something outside its
+// own grammar — a pragma, an annotation. These are inside it: `struct` and `as` are keywords,
+// with a token, a parse rule and errors of their own. What sets them apart is not where they
+// live but what they leave: a declaration, and no work to do.
 //
 // They belong to a source file rather than to a parse, which is what the REPL needs — there
 // a file is typed one line at a time, with a fresh parser for each, and a struct declared on
 // one line has to still be there on the next.
-type Directives struct {
+type Declarations struct {
 	Structs map[string][]string // struct name -> its fields, in order
 	Shapes  map[string]string   // identifier name -> the struct it is read as
 }
 
-func NewDirectives() *Directives {
-	return &Directives{
+func NewDeclarations() *Declarations {
+	return &Declarations{
 		Structs: make(map[string][]string),
 		Shapes:  make(map[string]string),
 	}
@@ -46,7 +51,7 @@ func (p *pr) ParseStruct() (ast.Node, error) {
 		return nil, err
 	}
 	structName := string(name.GetMatch())
-	if _, declared := p.directives.Structs[structName]; declared {
+	if _, declared := p.declarations.Structs[structName]; declared {
 		return nil, token.NewError(name, "struct %s is already declared at line %d and column %d",
 			structName, name.GetLine(), name.GetColumn())
 	}
@@ -85,7 +90,7 @@ func (p *pr) ParseStruct() (ast.Node, error) {
 			structName, tok.GetLine(), tok.GetColumn())
 	}
 
-	p.directives.Structs[structName] = fields
+	p.declarations.Structs[structName] = fields
 	return ast.StructDeclaration{Name: structName, Fields: fields, Token: tok}, nil
 }
 
@@ -97,7 +102,7 @@ func (p *pr) ParseStruct() (ast.Node, error) {
 // after a name; declaring a struct called `flag` and testing on it is the one ambiguity left,
 // and it is the same one Go has.
 func (p *pr) ParseStructLiteral(id ast.IdentifierLiteral) (ast.Node, error) {
-	fields := p.directives.Structs[id.Value]
+	fields := p.declarations.Structs[id.Value]
 
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
 		return nil, err
@@ -122,7 +127,7 @@ func (p *pr) ParseStructLiteral(id ast.IdentifierLiteral) (ast.Node, error) {
 		return nil, err
 	}
 
-	// Pointing at a miscount is the whole reason the directive exists, so it is an error
+	// Pointing at a miscount is the whole reason the declaration exists, so it is an error
 	// rather than a run padded with the neutral value.
 	if len(values) != len(fields) {
 		return nil, token.NewError(closing, "struct %s has %d fields (%s) but got %d at line %d and column %d",
@@ -175,7 +180,7 @@ func (p *pr) parseField(expr ast.Node) (ast.Node, error) {
 			field, name.GetLine(), name.GetColumn())
 	}
 
-	fields := p.directives.Structs[shape]
+	fields := p.declarations.Structs[shape]
 	index := slices.Index(fields, field)
 	if index < 0 {
 		return nil, token.NewError(name, "struct %s has no field named %s at line %d and column %d (it has %s)",
@@ -197,7 +202,7 @@ func (p *pr) parseShape(expr ast.Node) (ast.Node, error) {
 		return nil, err
 	}
 	structName := string(name.GetMatch())
-	if _, declared := p.directives.Structs[structName]; !declared {
+	if _, declared := p.declarations.Structs[structName]; !declared {
 		return nil, token.NewError(name, "%s is not a declared struct at line %d and column %d",
 			structName, name.GetLine(), name.GetColumn())
 	}
@@ -214,7 +219,7 @@ func (p *pr) shapeOf(node ast.Node) string {
 	case ast.ShapedExpression:
 		return n.Struct
 	case ast.IdentifierLiteral:
-		return p.directives.Shapes[n.Value]
+		return p.declarations.Shapes[n.Value]
 	}
 	return ""
 }

--- a/parser/structs_test.go
+++ b/parser/structs_test.go
@@ -39,10 +39,10 @@ func TestFieldResolvesToItsIndex(t *testing.T) {
 	}
 }
 
-// Pointing at a mistake where it was written is what the directive is for, so these are the
+// Pointing at a mistake where it was written is what the declaration is for, so these are the
 // cases that justify having one at all. Every error carries a position, which is what puts
 // the squiggle under the right word in an editor.
-func TestStructDirectiveReportsMistakes(t *testing.T) {
+func TestStructDeclarationReportsMistakes(t *testing.T) {
 	cases := []struct {
 		name   string
 		source string
@@ -122,9 +122,9 @@ func TestFieldOfAFieldHasNoShape(t *testing.T) {
 	}
 }
 
-// The directive says nothing about how a value is built, so a name bound to a struct can be
+// The declaration says nothing about how a value is built, so a name bound to a struct can be
 // used as an ordinary value everywhere else.
-func TestStructNameIsOnlyADirective(t *testing.T) {
+func TestStructNameIsOnlyADeclaration(t *testing.T) {
 	for _, source := range []string{
 		"struct Point { x, y };\nident p = Point{1, 2};\nprintd p + 1;",
 		"struct Point { x, y };\nprintd Point{1, 2} equals Point{1, 2};",
@@ -137,7 +137,7 @@ func TestStructNameIsOnlyADirective(t *testing.T) {
 }
 
 // Braces build the value, as in Go. Parentheses could not: `Point(1, 2)` and `greet(1, 2)`
-// are the same shape, so telling them apart needed the directive; `Point{1, 2}` does not.
+// are the same shape, so telling them apart needed the declaration; `Point{1, 2}` does not.
 func TestConstructionUsesBraces(t *testing.T) {
 	nodes := parse(t, "struct Point { x, y };\nPoint{1, 2};")
 	if _, ok := nodes[1].(ast.StructLiteral); !ok {
@@ -157,7 +157,7 @@ func TestConstructionUsesBraces(t *testing.T) {
 	}
 }
 
-// A struct name is a directive, not a value: there is nothing to load under it. The error
+// A struct name is a declaration, not a value: there is nothing to load under it. The error
 // says how to build one instead, which is what someone reaching for it wanted.
 func TestStructNameIsNotAValue(t *testing.T) {
 	_, err := parseSource(t, "struct Point { x, y };\nPoint;", "main.ar")
@@ -185,17 +185,17 @@ func TestTextInAField(t *testing.T) {
 	}
 }
 
-// The directives belong to the file, not to one parse. The REPL compiles a line at a time
+// The declarations belong to the file, not to one parse. The REPL compiles a line at a time
 // with a fresh parser, so a struct declared on one line has to still be known on the next.
-func TestDirectivesSurviveSeveralParses(t *testing.T) {
-	directives := NewDirectives()
+func TestDeclarationsSurviveSeveralParses(t *testing.T) {
+	declarations := NewDeclarations()
 
 	parseWith := func(source string) error {
 		tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
 		if err != nil {
 			return err
 		}
-		_, err = New(NewParserOptions{Filename: "main.ar", Tokens: tokens, Directives: directives}).Parse()
+		_, err = New(NewParserOptions{Filename: "main.ar", Tokens: tokens, Declarations: declarations}).Parse()
 		return err
 	}
 

--- a/parser/structs_test.go
+++ b/parser/structs_test.go
@@ -195,7 +195,7 @@ func TestDeclarationsSurviveSeveralParses(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_, err = New(NewParserOptions{Filename: "main.ar", Tokens: tokens, Declarations: declarations}).Parse()
+		_, err = New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens, Declarations: declarations})
 		return err
 	}
 

--- a/parser/tape_size_test.go
+++ b/parser/tape_size_test.go
@@ -17,11 +17,7 @@ func parseWithTapeSize(t *testing.T, source string, tapeSize int) (ast.AST, erro
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	return New(NewParserOptions{
-		Filename: "main.ar",
-		Tokens:   tokens,
-		TapeSize: tapeSize,
-	}).Parse()
+	return New(NewParserOptions{TapeSize: tapeSize}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens})
 }
 
 // A literal that the tape cannot hold is a compile-time error, not a silent truncation.

--- a/shared/trace/trace_test.go
+++ b/shared/trace/trace_test.go
@@ -21,7 +21,7 @@ func compile(t *testing.T, source string) (ast.AST, ir.Program) {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{Filename: "main.ar", Tokens: tokens}).Parse()
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -227,7 +227,7 @@ type AST struct {
 
 // StructDeclaration names the fields of a run of tapes: `struct Point { x, y };`.
 //
-// It is a directive for whoever writes the source, not a value. The compiler reads it to
+// It declares a shape for whoever writes the source; it is not a value. The compiler reads it to
 // turn a field name into an index, to report a mistake where it was written, and to feed
 // the language server — and then it is gone. Nothing about it reaches the IR: the flow is
 // static, the fields are positional and every one of them is exactly a tape wide.


### PR DESCRIPTION
First step of the assembly moving to `main`. Nothing is injected yet — this makes injection possible, and it is the only API change the rest needs.

## Why the parser was the blocker

`parser.New` took the tokens, so an instance parsed exactly one chain of them. There was nothing a host could be **handed** — only a way of making a parser — which is why three hosts build one and the REPL builds a fresh one every line.

```go
// before
parser.New(parser.NewParserOptions{Filename, Tokens, TapeSize, Declarations}).Parse()

// after
p := parser.New(parser.NewParserOptions{TapeSize: size})   // once, in main
tree, err := p.Parse(parser.ParseInput{Filename: src, Tokens: tokens})
```

What belongs to the project — how wide a value is — stays at the build. What belongs to one source arrives at the parse. The lexer and the emitter already worked this way (`GetFilledTokens(src)`, `EmitProgram(tree)`), so the parser was the only one out of step.

**Declarations move with it, and that is not cosmetic.** As a build option, one parser would accumulate what every source declared — and `aurora test` compiles a source *and* its test file, so a `.test.ar` redeclaring a struct would have started failing with `struct Point is already declared`. As an argument they stay the caller's, which is what the REPL already did: it holds them and hands the same ones back every line. Behaviour is identical to before.

`Parse` writes the state of a parse on a copy of the receiver, never on the parser, so two calls cannot tread on each other — the language server is where that would have shown first.

The interface keeps only `Parse`. `GetLookahead` and `EatToken` are the mechanism a parse runs on, and nothing outside the package ever called them.

## And a word that was wrong

`struct` and `as` were called **directives**. A directive, in most languages, is something outside the grammar — a pragma, an annotation. These are inside it: keywords, with a token, a parse rule and errors of their own. What sets them apart is not where they live but what they leave: **a declaration, and no work to do**.

So `parser.Directives` is `parser.Declarations`, and the word changes with it in the compiler, the language server and the docs a user reads — including the section that promised "the directives die at compile time". First commit; nothing changes for a program.

## Tests

`parser/reuse_test.go` pins what the change is for: one parser reading one source after another and each tree being its own; a parser still working after a source that failed to parse (the REPL line that is answered and forgotten); declarations coming from the caller and carrying across parses; and a source not seeing what another declared.

## Verification

`make check` green; both commits build and pass on their own.

## Next

`hosting/cli` gets a struct that receives the phases, the way the REPL session does, with `main` building them and the handlers calling its methods. Then the language server, in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)