### PR TITLE
A test could not use a struct its source declared

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -49,6 +49,25 @@ Three consequences follow, and none of them is worked around:
   conflict between identifiers named a
   ```
 
+A `struct` crosses as well, and it crosses earlier: a name is resolved while the program runs, a shape while it is read. So a test builds and reads a struct its source declared, without declaring it again:
+
+```aurora
+#- point.ar
+struct Point { x, y };
+
+ident origin = Point{0, 0};
+```
+
+```aurora
+#- point.test.ar
+ident p = Point{10, 20};
+
+assert(p.y equals 20, "a struct crosses the pair");
+assert(origin.x equals 0, "and so does what the source built with it");
+```
+
+The other way round does not hold: the source is read on its own, so it cannot use a shape only its test declares — under `aurora run` there is no test at all.
+
 ---
 
 ## Where the command looks

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -47,7 +47,7 @@ func Build(ctx context.Context, in BuildInput) (BuildReport, error) {
 	if err := ValidateTapeSize(in.TapeSize); err != nil {
 		return report, err
 	}
-	program, err := Compile(in.Source, in.TapeSize, in.Loggers, in.Stdout)
+	program, err := Compile(in.Source, in.TapeSize, in.Loggers, in.Stdout, nil)
 	if err != nil {
 		return report, err
 	}

--- a/hosting/cli/compile.go
+++ b/hosting/cli/compile.go
@@ -23,7 +23,11 @@ import (
 // designed (see docs/module_system_design.md).
 // traces receives what each phase produced, for the loggers that were asked for. Nil
 // discards it, which is what a caller that asked for none wants.
-func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (ir.Program, error) {
+//
+// declarations is what `struct` and `as` declared, carried in from outside when more than one
+// file makes up one scope: "aurora test" compiles a source and its test file, and the test
+// sees what the source declared. Nil starts empty, which is what compiling one file wants.
+func Compile(source string, tapeSize int, loggers []string, traces io.Writer, declarations *parser.Declarations) (ir.Program, error) {
 	if traces == nil {
 		traces = io.Discard
 	}
@@ -44,8 +48,9 @@ func Compile(source string, tapeSize int, loggers []string, traces io.Writer) (i
 	}
 
 	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{
-		Filename: source,
-		Tokens:   tokens,
+		Filename:     source,
+		Tokens:       tokens,
+		Declarations: declarations,
 	})
 	if err != nil {
 		return ir.Program{}, err

--- a/hosting/cli/compile_test.go
+++ b/hosting/cli/compile_test.go
@@ -20,7 +20,7 @@ func TestCompile(t *testing.T) {
 	dir := t.TempDir()
 	source := writeFile(t, dir, "main.ar", "ident a = 1;\nprintb a + 1;\n")
 
-	program, err := Compile(source, 0, nil, nil)
+	program, err := Compile(source, 0, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Compile: %v", err)
 	}
@@ -41,7 +41,7 @@ func TestCompileIgnoresNeighbouringFiles(t *testing.T) {
 	writeFile(t, dir, "other.ar", "ident a = 2;\nprintb a;\n")
 	writeFile(t, dir, "third.ar", "ident a = 3;\n")
 
-	if _, err := Compile(source, 0, nil, nil); err != nil {
+	if _, err := Compile(source, 0, nil, nil, nil); err != nil {
 		t.Fatalf("a neighbour must not be compiled in: %v", err)
 	}
 }
@@ -66,7 +66,7 @@ func TestCompileReportsErrors(t *testing.T) {
 				tapeSize = 1
 			}
 			source := writeFile(t, dir, strings.ReplaceAll(tc.name, " ", "_")+".ar", tc.source)
-			_, err := Compile(source, tapeSize, nil, nil)
+			_, err := Compile(source, tapeSize, nil, nil, nil)
 			if err == nil {
 				t.Fatal("expected an error")
 			}
@@ -78,7 +78,7 @@ func TestCompileReportsErrors(t *testing.T) {
 }
 
 func TestCompileFailsWhenSourceMissing(t *testing.T) {
-	if _, err := Compile(filepath.Join(t.TempDir(), "nope.ar"), 0, nil, nil); err == nil {
+	if _, err := Compile(filepath.Join(t.TempDir(), "nope.ar"), 0, nil, nil, nil); err == nil {
 		t.Error("expected an error for a missing file")
 	}
 }
@@ -88,10 +88,10 @@ func TestCompileHonoursTestFileRule(t *testing.T) {
 	dir := t.TempDir()
 	const source = "assert(1 equals 1, \"ok\");\n"
 
-	if _, err := Compile(writeFile(t, dir, "checks.test.ar", source), 0, nil, nil); err != nil {
+	if _, err := Compile(writeFile(t, dir, "checks.test.ar", source), 0, nil, nil, nil); err != nil {
 		t.Errorf("assert should be accepted in a .test.ar file: %v", err)
 	}
-	if _, err := Compile(writeFile(t, dir, "checks.ar", source), 0, nil, nil); err == nil {
+	if _, err := Compile(writeFile(t, dir, "checks.ar", source), 0, nil, nil, nil); err == nil {
 		t.Error("assert should be rejected outside .test.ar")
 	}
 }

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -26,7 +26,7 @@ func onChain(t *testing.T, source, function string, args []string, tapeSize int)
 	t.Helper()
 
 	path := writeAt(t, t.TempDir(), "contract.ar", source)
-	program, err := Compile(path, tapeSize, nil, io.Discard)
+	program, err := Compile(path, tapeSize, nil, io.Discard, nil)
 	if err != nil {
 		t.Fatalf("compiling: %v", err)
 	}

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -26,7 +26,7 @@ func Run(ctx context.Context, in RunInput) error {
 	if err := ValidateTapeSize(in.TapeSize); err != nil {
 		return err
 	}
-	program, err := Compile(in.Source, in.TapeSize, in.Loggers, in.Stdout)
+	program, err := Compile(in.Source, in.TapeSize, in.Loggers, in.Stdout, nil)
 	if err != nil {
 		return err
 	}

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/guiferpa/aurora/evaluator"
+	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/shared/printer"
 	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/ir"
@@ -184,13 +185,18 @@ func runTestFile(path string, tapeSize int, loggers []string) FileReport {
 		return report
 	}
 
-	sourceProgram, err := Compile(source, tapeSize, loggers, io.Discard)
+	// The two files are one scope, so they are one set of declarations: a struct declared in
+	// the source is known in the test. They are parsed apart because each keeps its own name —
+	// which is what decides that assert belongs to the test file — and its own line numbers.
+	declarations := parser.NewDeclarations()
+
+	sourceProgram, err := Compile(source, tapeSize, loggers, io.Discard, declarations)
 	if err != nil {
 		report.Err = fmt.Errorf("%s: %w", filepath.Base(source), err)
 		return report
 	}
 
-	testProgram, err := Compile(path, tapeSize, loggers, io.Discard)
+	testProgram, err := Compile(path, tapeSize, loggers, io.Discard, declarations)
 	if err != nil {
 		report.Err = err
 		return report

--- a/hosting/cli/test_test.go
+++ b/hosting/cli/test_test.go
@@ -216,6 +216,45 @@ func TestNameDeclaredInBothFilesConflicts(t *testing.T) {
 	}
 }
 
+// A test sees what its source declared, and a struct is declared while parsing rather than
+// while running. The two files used to be parsed with a set of declarations each, so a test
+// could call a defer from its source but could not build a struct it declared: `Point{1, 2}`
+// stopped at the brace, because the name meant nothing to that parse.
+func TestSeesAStructDeclaredInItsSource(t *testing.T) {
+	dir := project(t)
+	writeAt(t, dir, "src/main.ar", "struct Point { x, y };\n")
+	writeAt(t, dir, "src/main.test.ar",
+		"ident p = Point{10, 20};\nassert(p.y equals 20, \"a struct crosses the pair\");\n")
+
+	report, err := Test(t.Context(), TestInput{Stdout: io.Discard})
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if file := report.Files[0]; file.Err != nil {
+		t.Fatalf("the pair did not compile: %v", file.Err)
+	}
+	if !report.OK() {
+		t.Errorf("the assertion did not hold: %+v", report.Files[0].Results)
+	}
+}
+
+// The other way round is not true: what the test declares is its own. The source is compiled
+// before the test exists as far as the parser is concerned, and a source that leaned on its
+// test would not compile under "aurora run".
+func TestASourceDoesNotSeeWhatItsTestDeclares(t *testing.T) {
+	dir := project(t)
+	writeAt(t, dir, "src/main.ar", "ident p = Point{1, 2};\n")
+	writeAt(t, dir, "src/main.test.ar", "struct Point { x, y };\nassert(1 equals 1, \"unreached\");\n")
+
+	report, err := Test(t.Context(), TestInput{Stdout: io.Discard})
+	if err != nil {
+		t.Fatalf("Test: %v", err)
+	}
+	if file := report.Files[0]; file.Err == nil {
+		t.Fatal("the source built a struct that only its test declares")
+	}
+}
+
 func TestUsesTheProjectTapeSize(t *testing.T) {
 	dir := t.TempDir()
 	manifest := `[project]

--- a/hosting/cli/trace_test.go
+++ b/hosting/cli/trace_test.go
@@ -17,7 +17,7 @@ func compileWithLoggers(t *testing.T, source string, loggers []string) string {
 	}
 
 	traces := &strings.Builder{}
-	if _, err := Compile(entry, 0, loggers, traces); err != nil {
+	if _, err := Compile(entry, 0, loggers, traces, nil); err != nil {
 		t.Fatalf("compiling: %v", err)
 	}
 	return traces.String()
@@ -83,7 +83,7 @@ func TestCompileWithoutATraceWriter(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err := Compile(entry, 0, []string{"lexer", "parser", "emitter"}, nil); err != nil {
+	if _, err := Compile(entry, 0, []string{"lexer", "parser", "emitter"}, nil, nil); err != nil {
 		t.Errorf("compiling with every logger and no writer: %v", err)
 	}
 }


### PR DESCRIPTION
Found while working out how far the C-style `include` idea for `aurora test` could go. The bug is older than that conversation.

## What was wrong

A test belongs to the source file of the same name and runs in its scope. That held for **names** — `hello()` and `twice()` are there because the source was evaluated first — and it did not hold for a **struct**.

A name is resolved while the program runs; a shape while it is read. The two files were parsed with a set of declarations each, so this pair did not compile:

```aurora
#- point.ar
struct Point { x, y };
```

```aurora
#- point.test.ar
ident p = Point{10, 20};
assert(p.y equals 20, "a struct crosses the pair");
```

```
unexpected token { at line 1 and column 16
```

To that parse `Point` meant nothing, so `Point{...}` was an identifier followed by a brace. Nobody had hit it because no example carries a struct across the pair — and `docs/testing.md` promised the opposite: *"everything the source declared is already there, with no import"*.

## The fix

The two files share one `parser.Declarations`, which #50 made possible by moving them from the constructor to `Parse`.

They are still parsed **apart**, on purpose:

- each keeps its own filename, which is what decides that `assert` belongs to a `.test.ar`;
- each keeps its own line numbers, so an error still points where it was written.

That is the same reason the source-level include was set aside: merging the text would have made one parse with one filename, and both of those would have gone.

## Tests

- a struct declared in the source, built and read in the test (fails without the fix, with the message above);
- the other way round does not hold — a source cannot use a shape only its test declares, since under `aurora run` there is no test at all;
- `docs/testing.md` gains the example, and the harness that runs every documentation snippet runs it.

## Verification

`make check` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)