### PR TITLE
How wide a value is arrives at the parse

### DIFF
--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -19,7 +19,7 @@ func build(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -15,11 +15,11 @@ import (
 func build(t *testing.T, source string, tapeSize int) []byte {
 	t.Helper()
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -43,12 +43,12 @@ false;
 
 	for _, c := range cases {
 		bs := bytes.NewBufferString(c.SourceCode).Bytes()
-		tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
+		tokens, err := lexer.New().GetFilledTokens(bs)
 		if err != nil {
 			t.Errorf("%v: %v", c.Name, err)
 			return
 		}
-		tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
+		tree, err := parser.New().Parse(parser.ParseInput{Tokens: tokens})
 		if err != nil {
 			t.Errorf("%v: %v", c.Name, err)
 			return
@@ -144,12 +144,12 @@ func TestPickRuntimeCode(t *testing.T) {
 		t.Run(c.Name, func(t *testing.T) {
 			bs := bytes.NewBufferString(c.SourceCode).Bytes()
 
-			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
+			tokens, err := lexer.New().GetFilledTokens(bs)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
+			tree, err := parser.New().Parse(parser.ParseInput{Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -236,12 +236,12 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			bs := bytes.NewBufferString(tc.source).Bytes()
-			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
+			tokens, err := lexer.New().GetFilledTokens(bs)
 			if err != nil {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Tokens: tokens})
+			tree, err := parser.New().Parse(parser.ParseInput{Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", tc.name, err)
 				return

--- a/cmd/aurora/build.go
+++ b/cmd/aurora/build.go
@@ -65,7 +65,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	// A build compiles and writes bytecode; nothing evaluates, so no evaluator is made.
 	_, err = cli.NewSession(cli.NewSessionOptions{
 		Lexer:    lexer.New(lexer.NewLexerOptions{}),
-		Parser:   parser.New(parser.NewParserOptions{TapeSize: size}),
+		Parser:   parser.New(parser.NewParserOptions{}),
 		Emitter:  emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		TapeSize: size,
 		Stdout:   cmd.OutOrStdout(),

--- a/cmd/aurora/build.go
+++ b/cmd/aurora/build.go
@@ -64,8 +64,8 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	// A build compiles and writes bytecode; nothing evaluates, so no evaluator is made.
 	_, err = cli.NewSession(cli.NewSessionOptions{
-		Lexer:    lexer.New(lexer.NewLexerOptions{}),
-		Parser:   parser.New(parser.NewParserOptions{}),
+		Lexer:    lexer.New(),
+		Parser:   parser.New(),
 		Emitter:  emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		TapeSize: size,
 		Stdout:   cmd.OutOrStdout(),

--- a/cmd/aurora/repl.go
+++ b/cmd/aurora/repl.go
@@ -34,7 +34,7 @@ var replCmd = &cobra.Command{
 
 		repl.NewSession(repl.NewSessionOptions{
 			Lexer:   lexer.New(lexer.NewLexerOptions{}),
-			Parser:  parser.New(parser.NewParserOptions{TapeSize: size}),
+			Parser:  parser.New(parser.NewParserOptions{}),
 			Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 			// One evaluator lasts the session: a name bound on one line is there on the next.
 			Evaluator: evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/aurora/repl.go
+++ b/cmd/aurora/repl.go
@@ -33,8 +33,8 @@ var replCmd = &cobra.Command{
 		out := os.Stdout
 
 		repl.NewSession(repl.NewSessionOptions{
-			Lexer:   lexer.New(lexer.NewLexerOptions{}),
-			Parser:  parser.New(parser.NewParserOptions{}),
+			Lexer:   lexer.New(),
+			Parser:  parser.New(),
 			Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 			// One evaluator lasts the session: a name bound on one line is there on the next.
 			Evaluator: evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/aurora/run.go
+++ b/cmd/aurora/run.go
@@ -54,8 +54,8 @@ func runRun(cmd *cobra.Command, args []string) error {
 	out := os.Stdout
 
 	return cli.NewSession(cli.NewSessionOptions{
-		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{}),
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/aurora/run.go
+++ b/cmd/aurora/run.go
@@ -55,7 +55,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 
 	return cli.NewSession(cli.NewSessionOptions{
 		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{TapeSize: size}),
+		Parser:  parser.New(parser.NewParserOptions{}),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/aurora/test.go
+++ b/cmd/aurora/test.go
@@ -57,7 +57,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 
 	report, err := cli.NewSession(cli.NewSessionOptions{
 		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{TapeSize: size}),
+		Parser:  parser.New(parser.NewParserOptions{}),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/aurora/test.go
+++ b/cmd/aurora/test.go
@@ -56,8 +56,8 @@ func runTest(cmd *cobra.Command, args []string) error {
 	}
 
 	report, err := cli.NewSession(cli.NewSessionOptions{
-		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{}),
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -53,12 +53,12 @@ func init() {
 			bs := bytes.NewBufferString(value)
 			// Read for every run, so changing the width is a matter of running again.
 			size := tapeSize()
-			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs.Bytes())
+			tokens, err := lexer.New().GetFilledTokens(bs.Bytes())
 			if err != nil {
 				fmt.Println(err)
 				return nil
 			}
-			tree, err := parser.New(parser.NewParserOptions{}).
+			tree, err := parser.New().
 				Parse(parser.ParseInput{Tokens: tokens, TapeSize: size})
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))

--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -58,8 +58,8 @@ func init() {
 				fmt.Println(err)
 				return nil
 			}
-			tree, err := parser.New(parser.NewParserOptions{TapeSize: size}).
-				Parse(parser.ParseInput{Tokens: tokens})
+			tree, err := parser.New(parser.NewParserOptions{}).
+				Parse(parser.ParseInput{Tokens: tokens, TapeSize: size})
 			if err != nil {
 				errorWriter.Write([]byte(err.Error()))
 				return nil

--- a/emitter/golden_test.go
+++ b/emitter/golden_test.go
@@ -30,11 +30,11 @@ func TestEmittedProgramMatchesTheGolden(t *testing.T) {
 		t.Fatalf("reading the golden: %v", err)
 	}
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(source)
+	tokens, err := lexer.New().GetFilledTokens(source)
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "wide.ar", Tokens: tokens})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "wide.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -15,7 +15,7 @@ func compileWith(t *testing.T, source string, tapeSize int) ir.Program {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -11,11 +11,11 @@ import (
 
 func compileWith(t *testing.T, source string, tapeSize int) ir.Program {
 	t.Helper()
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
@@ -63,8 +63,8 @@ func TestEmitMatchesEmitProgram(t *testing.T) {
 	const source = "ident a = 1;\nprintb a + 1;\n"
 	program := compile(t, source)
 
-	tokens, _ := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
-	tree, _ := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tokens, _ := lexer.New().GetFilledTokens([]byte(source))
+	tree, _ := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	insts, err := New(NewEmitterOptions{}).Emit(tree)
 	if err != nil {
 		t.Fatalf("Emit: %v", err)

--- a/evaluator/assert_test.go
+++ b/evaluator/assert_test.go
@@ -14,11 +14,11 @@ import (
 func evaluateAsserts(t *testing.T, source string, asserts bool) *Evaluator {
 	t.Helper()
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "checks.test.ar", Tokens: tokens})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "checks.test.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -529,13 +529,13 @@ func runEvaluateCase(t *testing.T, cases []EvaluateCase, options RunEvaluateCase
 		t.Run(c.Name, func(t *testing.T) {
 			bs := bytes.NewBufferString(c.SourceCode).Bytes()
 
-			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
+			tokens, err := lexer.New().GetFilledTokens(bs)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
 
-			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: options.Filename, Tokens: tokens})
+			tree, err := parser.New().Parse(parser.ParseInput{Filename: options.Filename, Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
@@ -1220,12 +1220,12 @@ func runAssertCase(t *testing.T, cases []AssertCase) {
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			bs := bytes.NewBufferString(c.SourceCode).Bytes()
-			tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens(bs)
+			tokens, err := lexer.New().GetFilledTokens(bs)
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)
 				return
 			}
-			tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{ // assert is only accepted in a test file
+			tree, err := parser.New().Parse(parser.ParseInput{ // assert is only accepted in a test file
 				Filename: "assert.test.ar", Tokens: tokens})
 			if err != nil {
 				t.Errorf("%v: %v", c.Name, err)

--- a/evaluator/output_order_test.go
+++ b/evaluator/output_order_test.go
@@ -28,11 +28,11 @@ func (t tagged) Print(value []byte) ([]byte, error) {
 func runInOrder(t *testing.T, source string) []string {
 	t.Helper()
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}

--- a/evaluator/tape_size_test.go
+++ b/evaluator/tape_size_test.go
@@ -22,7 +22,7 @@ func runWithTapeSize(t *testing.T, source string, tapeSize int) []byte {
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
@@ -56,7 +56,7 @@ func runAndError(t *testing.T, source string, tapeSize int) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parser.New(parser.NewParserOptions{TapeSize: tapeSize}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		return nil, err
 	}

--- a/evaluator/tape_size_test.go
+++ b/evaluator/tape_size_test.go
@@ -18,11 +18,11 @@ import (
 func runWithTapeSize(t *testing.T, source string, tapeSize int) []byte {
 	t.Helper()
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		t.Fatalf("parser: %v", err)
 	}
@@ -52,11 +52,11 @@ func runWithTapeSize(t *testing.T, source string, tapeSize int) []byte {
 func runAndError(t *testing.T, source string, tapeSize int) ([]byte, error) {
 	t.Helper()
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		return nil, err
 	}
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 	if err != nil {
 		return nil, err
 	}

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -49,7 +49,7 @@ func (s *Session) Build(ctx context.Context, source, outputPath string) (BuildRe
 		return report, err
 	}
 
-	tree, err := s.parser.Parse(parser.ParseInput{Filename: source, Tokens: tokens})
+	tree, err := s.parser.Parse(parser.ParseInput{Filename: source, Tokens: tokens, TapeSize: s.tapeSize})
 	if err != nil {
 		return report, err
 	}

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -29,7 +29,7 @@ func (s *Session) Run(ctx context.Context, source string) error {
 		return err
 	}
 
-	tree, err := s.parser.Parse(parser.ParseInput{Filename: source, Tokens: tokens})
+	tree, err := s.parser.Parse(parser.ParseInput{Filename: source, Tokens: tokens, TapeSize: s.tapeSize})
 	if err != nil {
 		return err
 	}

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -42,7 +42,7 @@ func newSession(t *testing.T, o sessionOpts) *Session {
 
 	return NewSession(NewSessionOptions{
 		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{TapeSize: size}),
+		Parser:  parser.New(parser.NewParserOptions{}),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -41,8 +41,8 @@ func newSession(t *testing.T, o sessionOpts) *Session {
 	size := o.tapeSize
 
 	return NewSession(NewSessionOptions{
-		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{}),
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -217,6 +217,7 @@ func (s *Session) runTestFile(path string) FileReport {
 			Filename:     file,
 			Tokens:       tokens,
 			Declarations: declarations,
+			TapeSize:     s.tapeSize,
 		})
 		if err != nil {
 			report.Err = failedAt(file, source, err)

--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -92,7 +92,7 @@ type semanticToken struct {
 // and line breaks are needed to place comments, and a lexer error still yields the tokens
 // read so far — so a file being typed keeps its colors instead of going blank.
 func SemanticTokensFor(source string) []uint {
-	tokens, _ := lexer.New(lexer.NewLexerOptions{}).GetTokens([]byte(source))
+	tokens, _ := lexer.New().GetTokens([]byte(source))
 	mapper := lsp.NewMapper(source)
 	return encodeSemanticTokens(mapper, collectSemanticTokens(mapper, tokens))
 }

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -55,7 +55,7 @@ type Document struct {
 func Analyze(doc Document) *Analysis {
 	analysis := &Analysis{Source: doc.Source, Mapper: lsp.NewMapper(doc.Source)}
 
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(doc.Source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(doc.Source))
 	analysis.Tokens = tokens
 	if err != nil {
 		analysis.Err = err
@@ -64,7 +64,7 @@ func Analyze(doc Document) *Analysis {
 
 	// How wide a value is decides what fits in one, so the document is read in the dialect it
 	// belongs to rather than in the default.
-	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{
+	tree, err := parser.New().Parse(parser.ParseInput{
 		Filename: doc.Filename,
 		Tokens:   tokens,
 		TapeSize: doc.TapeSize,

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -64,9 +64,10 @@ func Analyze(doc Document) *Analysis {
 
 	// How wide a value is decides what fits in one, so the document is read in the dialect it
 	// belongs to rather than in the default.
-	tree, err := parser.New(parser.NewParserOptions{TapeSize: doc.TapeSize}).Parse(parser.ParseInput{
+	tree, err := parser.New(parser.NewParserOptions{}).Parse(parser.ParseInput{
 		Filename: doc.Filename,
 		Tokens:   tokens,
+		TapeSize: doc.TapeSize,
 	})
 	if err != nil {
 		analysis.Err = err

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -140,7 +140,8 @@ func (s *Session) compile(text string) (ir.Program, error) {
 	}
 
 	tree, err := s.parser.Parse(parser.ParseInput{
-		Tokens: tokens,
+		Tokens:   tokens,
+		TapeSize: s.tapeSize,
 		// A struct declared on one line has to still be known on the next, so what the
 		// session remembers goes in with every line.
 		Declarations: s.declarations,

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -26,7 +26,7 @@ func typed(t *testing.T, lines string, tapeSize int) string {
 
 	NewSession(NewSessionOptions{
 		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{TapeSize: size}),
+		Parser:  parser.New(parser.NewParserOptions{}),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		Evaluator: evaluator.New(evaluator.NewEvaluatorOptions{
 			PrintBytes:   printer.Bytes(out, size),

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -25,8 +25,8 @@ func typed(t *testing.T, lines string, tapeSize int) string {
 	out := &strings.Builder{}
 
 	NewSession(NewSessionOptions{
-		Lexer:   lexer.New(lexer.NewLexerOptions{}),
-		Parser:  parser.New(parser.NewParserOptions{}),
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
 		Evaluator: evaluator.New(evaluator.NewEvaluatorOptions{
 			PrintBytes:   printer.Bytes(out, size),

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -3,9 +3,8 @@ package lexer
 type Lexer struct {
 }
 
-type NewLexerOptions struct {
-}
-
-func New(options NewLexerOptions) *Lexer {
+// New builds a lexer. It takes nothing: a lexer is the same for every source, and the source
+// arrives at the read.
+func New() *Lexer {
 	return &Lexer{}
 }

--- a/lexer/scanner_test.go
+++ b/lexer/scanner_test.go
@@ -284,7 +284,7 @@ func TestScanStructDeclarations(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.source, func(t *testing.T) {
-			tokens, err := New(NewLexerOptions{}).GetFilledTokens([]byte(tc.source))
+			tokens, err := New().GetFilledTokens([]byte(tc.source))
 			if err != nil {
 				t.Fatalf("lexer: %v", err)
 			}
@@ -309,7 +309,7 @@ func TestScanStructDeclarations(t *testing.T) {
 
 // A dot is its own token and never part of a name, so p.x is three tokens and not one.
 func TestDotIsNotPartOfAName(t *testing.T) {
-	tokens, err := New(NewLexerOptions{}).GetFilledTokens([]byte("point.x"))
+	tokens, err := New().GetFilledTokens([]byte("point.x"))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}

--- a/lexer/token_test.go
+++ b/lexer/token_test.go
@@ -235,7 +235,7 @@ func TestGetTokens(t *testing.T) {
 		},
 	}
 	for _, c := range cases {
-		tokens, err := New(NewLexerOptions{}).GetTokens(c.Buffer)
+		tokens, err := New().GetTokens(c.Buffer)
 		if err != nil {
 			t.Errorf("param: %v, %v", string(c.Buffer), err)
 		}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -961,10 +961,8 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	return ast.AST{Filename: p.filename, Nodes: nodes}, nil
 }
 
-// NewParserOptions is empty: a parser is the same whatever it is asked to read. It stays as a
-// struct so that giving one an option later does not change every call.
-type NewParserOptions struct{}
-
-func New(opts NewParserOptions) Parser {
+// New builds a parser. It takes nothing: a parser is the same whatever it is asked to read,
+// and everything a parse needs arrives at Parse.
+func New() Parser {
 	return pr{}
 }

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -13,10 +13,10 @@ import (
 
 // A Parser turns a chain of tokens into a tree.
 //
-// One parser serves every source there is: what belongs to the project — how wide a value is —
-// is settled when it is built, and what belongs to one source arrives at Parse. It used to
-// take the tokens at build time, so an instance parsed exactly one file and nobody could be
-// handed a parser; only a way of making one.
+// One parser serves every source there is: everything a parse needs arrives at Parse, and a
+// parser is built from nothing at all. It used to take the tokens at build time, so an
+// instance parsed exactly one file and nobody could be handed a parser; only a way of making
+// one.
 //
 // Parse keeps no state of its own between calls, so the same parser may be asked for one tree
 // after another.
@@ -24,13 +24,21 @@ type Parser interface {
 	Parse(in ParseInput) (ast.AST, error)
 }
 
-// ParseInput is one source to read: everything that belongs to the file rather than to the
-// project.
+// ParseInput is one source to read, and everything reading it takes.
 type ParseInput struct {
 	// Filename is the source path. It decides file-scoped rules: assert is only accepted
 	// inside *.test.ar.
 	Filename string
 	Tokens   []token.Token
+	// TapeSize is the width in bytes of every value, which the parser needs to refuse a
+	// number that does not fit one, text longer than one, and a tape literal with too many
+	// items. Zero means the language's default.
+	//
+	// It is a property of the project the source belongs to, and it arrives here rather than
+	// at the build because a parser can outlive it: the language server holds one for a whole
+	// session, and answers for files of different projects — and for the same project after
+	// its manifest is edited, which has to reach the next keystroke.
+	TapeSize int
 	// Declarations carries what `struct` and `as` declared across parses of the same file.
 	// Nil starts empty, which is what compiling a file in one go wants; the REPL passes the
 	// same value every line so a struct declared earlier is still known.
@@ -938,6 +946,7 @@ func (p *pr) EatToken(tokenId string) (token.Token, error) {
 func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	p.filename = in.Filename
 	p.tokens = in.Tokens
+	p.tapeSize = byteutil.TapeSize(in.TapeSize)
 	p.cursor = 0
 	p.declarations = in.Declarations
 	if p.declarations == nil {
@@ -952,11 +961,10 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	return ast.AST{Filename: p.filename, Nodes: nodes}, nil
 }
 
-type NewParserOptions struct {
-	// TapeSize is the width in bytes of every value. Zero means the default (8).
-	TapeSize int
-}
+// NewParserOptions is empty: a parser is the same whatever it is asked to read. It stays as a
+// struct so that giving one an option later does not change every call.
+type NewParserOptions struct{}
 
 func New(opts NewParserOptions) Parser {
-	return pr{tapeSize: byteutil.TapeSize(opts.TapeSize)}
+	return pr{}
 }

--- a/parser/parser_test.go
+++ b/parser/parser_test.go
@@ -143,7 +143,7 @@ func TestParse(t *testing.T) {
 			},
 		},
 	}
-	tree, err := New(NewParserOptions{}).Parse(ParseInput{Filename: "testing.ar", Tokens: tokens})
+	tree, err := New().Parse(ParseInput{Filename: "testing.ar", Tokens: tokens})
 	if err != nil {
 		t.Errorf("param: %v, %v", tokens, err)
 	}

--- a/parser/reuse_test.go
+++ b/parser/reuse_test.go
@@ -47,6 +47,41 @@ func TestOneParserReadsOneSourceAfterAnother(t *testing.T) {
 	}
 }
 
+// Two sources, two widths, one parser. The width used to be settled when the parser was built,
+// so a caller serving more than one project — the language server holds a parser for a whole
+// session and answers for files of any project the editor opens — would read the second one in
+// the dialect of the first. The same goes for one project whose manifest is edited while the
+// editor is open: the new width has to reach the next keystroke.
+func TestOneParserReadsSourcesOfDifferentWidths(t *testing.T) {
+	p := New(NewParserOptions{})
+
+	// 300 does not fit a single byte, and does fit eight.
+	if _, err := p.Parse(ParseInput{
+		Filename: "narrow.ar",
+		Tokens:   tokensOf(t, "ident a = 300;"),
+		TapeSize: 1,
+	}); err == nil {
+		t.Fatal("300 was accepted into a one-byte tape")
+	}
+
+	if _, err := p.Parse(ParseInput{
+		Filename: "wide.ar",
+		Tokens:   tokensOf(t, "ident a = 300;"),
+		TapeSize: 8,
+	}); err != nil {
+		t.Fatalf("the next source was read in the width of the one before it: %v", err)
+	}
+
+	// And back, so it is the input that decides rather than the last call.
+	if _, err := p.Parse(ParseInput{
+		Filename: "narrow.ar",
+		Tokens:   tokensOf(t, "ident a = 300;"),
+		TapeSize: 1,
+	}); err == nil {
+		t.Fatal("the parser kept the wider width from the parse before it")
+	}
+}
+
 // A source that does not parse leaves the parser where it was, so the next one still reads.
 // This is the REPL: a line that fails is answered and forgotten.
 func TestAParserSurvivesASourceThatFails(t *testing.T) {

--- a/parser/reuse_test.go
+++ b/parser/reuse_test.go
@@ -15,7 +15,7 @@ import (
 // tokensOf lexes a source, which is what a parse is given.
 func tokensOf(t *testing.T, source string) []token.Token {
 	t.Helper()
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
@@ -23,7 +23,7 @@ func tokensOf(t *testing.T, source string) []token.Token {
 }
 
 func TestOneParserReadsOneSourceAfterAnother(t *testing.T) {
-	p := New(NewParserOptions{})
+	p := New()
 
 	first, err := p.Parse(ParseInput{Filename: "first.ar", Tokens: tokensOf(t, "1 + 2;")})
 	if err != nil {
@@ -53,7 +53,7 @@ func TestOneParserReadsOneSourceAfterAnother(t *testing.T) {
 // the dialect of the first. The same goes for one project whose manifest is edited while the
 // editor is open: the new width has to reach the next keystroke.
 func TestOneParserReadsSourcesOfDifferentWidths(t *testing.T) {
-	p := New(NewParserOptions{})
+	p := New()
 
 	// 300 does not fit a single byte, and does fit eight.
 	if _, err := p.Parse(ParseInput{
@@ -85,7 +85,7 @@ func TestOneParserReadsSourcesOfDifferentWidths(t *testing.T) {
 // A source that does not parse leaves the parser where it was, so the next one still reads.
 // This is the REPL: a line that fails is answered and forgotten.
 func TestAParserSurvivesASourceThatFails(t *testing.T) {
-	p := New(NewParserOptions{})
+	p := New()
 
 	if _, err := p.Parse(ParseInput{Filename: "broken.ar", Tokens: tokensOf(t, "1 +;")}); err == nil {
 		t.Fatal("a source that does not parse was accepted")
@@ -103,7 +103,7 @@ func TestAParserSurvivesASourceThatFails(t *testing.T) {
 // What `struct` and `as` declare belongs to whoever is compiling, not to the parser: the REPL
 // hands the same declarations back every line so a struct declared earlier is still known.
 func TestDeclarationsComeFromTheCaller(t *testing.T) {
-	p := New(NewParserOptions{})
+	p := New()
 	declarations := NewDeclarations()
 
 	if _, err := p.Parse(ParseInput{
@@ -126,7 +126,7 @@ func TestDeclarationsComeFromTheCaller(t *testing.T) {
 // leak into each other, which is what lets "aurora test" read a source and its test file
 // without the test inheriting a name it never declared.
 func TestASourceDoesNotSeeWhatAnotherDeclared(t *testing.T) {
-	p := New(NewParserOptions{})
+	p := New()
 
 	if _, err := p.Parse(ParseInput{
 		Tokens:       tokensOf(t, "struct Point { x, y };"),

--- a/parser/shapes_test.go
+++ b/parser/shapes_test.go
@@ -26,11 +26,11 @@ func parse(t *testing.T, source string) []ast.Node {
 
 func parseSource(t *testing.T, source, filename string) (ast.AST, error) {
 	t.Helper()
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		return ast.AST{}, err
 	}
-	return New(NewParserOptions{}).Parse(ParseInput{Filename: filename, Tokens: tokens})
+	return New().Parse(ParseInput{Filename: filename, Tokens: tokens})
 }
 
 // first returns the single top-level node, asserting the type.
@@ -537,12 +537,12 @@ ident f = defer { feed(0) + 1; };
 if a bigger 0 { printb f(a); } else { printc "no"; };
 ident t = pull [1, 2] 3;
 `
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
 
-	tree, err := New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens})
+	tree, err := New().Parse(ParseInput{Filename: "main.ar", Tokens: tokens})
 	if err != nil {
 		t.Fatalf("parsing with logging on: %v", err)
 	}

--- a/parser/structs_test.go
+++ b/parser/structs_test.go
@@ -191,11 +191,11 @@ func TestDeclarationsSurviveSeveralParses(t *testing.T) {
 	declarations := NewDeclarations()
 
 	parseWith := func(source string) error {
-		tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+		tokens, err := lexer.New().GetFilledTokens([]byte(source))
 		if err != nil {
 			return err
 		}
-		_, err = New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens, Declarations: declarations})
+		_, err = New().Parse(ParseInput{Filename: "main.ar", Tokens: tokens, Declarations: declarations})
 		return err
 	}
 

--- a/parser/tape_size_test.go
+++ b/parser/tape_size_test.go
@@ -17,7 +17,7 @@ func parseWithTapeSize(t *testing.T, source string, tapeSize int) (ast.AST, erro
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	return New(NewParserOptions{TapeSize: tapeSize}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens})
+	return New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 }
 
 // A literal that the tape cannot hold is a compile-time error, not a silent truncation.

--- a/parser/tape_size_test.go
+++ b/parser/tape_size_test.go
@@ -13,11 +13,11 @@ import (
 
 func parseWithTapeSize(t *testing.T, source string, tapeSize int) (ast.AST, error) {
 	t.Helper()
-	tokens, err := lexer.New(lexer.NewLexerOptions{}).GetFilledTokens([]byte(source))
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
 		t.Fatalf("lexer: %v", err)
 	}
-	return New(NewParserOptions{}).Parse(ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
+	return New().Parse(ParseInput{Filename: "main.ar", Tokens: tokens, TapeSize: tapeSize})
 }
 
 // A literal that the tape cannot hold is a compile-time error, not a silent truncation.


### PR DESCRIPTION
```go
// before
parser.New(parser.NewParserOptions{TapeSize: size}).Parse(parser.ParseInput{Filename: …, Tokens: …})

// after
parser.New().Parse(parser.ParseInput{Filename: …, Tokens: …, TapeSize: size})
```

## Why the width moved

It was a build option, on the argument that it belongs to the **project** rather than to the source. It does — and a parser can outlive it.

The language server is where that shows. It holds a parser for a whole session and answers for:

- files of **any project** the editor opens — the width is cached per directory precisely because a workspace can hold more than one;
- the **same project after its manifest is edited**, which is a shipped, tested behaviour: *"widening a project reaches the next keystroke, not the next restart"*.

Nothing is broken today, because `textdoc` builds a parser per document. This is what lets it stop: a parser can now be handed to it, and it is the last host still building its own phases.

`TapeSize` joins `Filename`, `Tokens` and `Declarations` in `ParseInput` — everything a parse takes arrives at the parse. **Nothing changes for a program:** every caller passed the width it already had a line earlier.

## And then the constructors

That left `NewParserOptions` empty, and `NewLexerOptions` has been empty since it was written. An options struct with no options is a line to read at every call and a type to find when reading the package, and it buys the day someone adds an option — which costs six call sites, all of them in this repository.

```go
lexer.New()
parser.New()
```

The emitter and the evaluator keep theirs: they have options, and the width they are built with is the program's, settled once by the host about to compile or run one.

## Test

`TestOneParserReadsSourcesOfDifferentWidths`: one parser refuses `300` at one byte, accepts it at eight, and refuses it again at one — so it is the input that decides, not the last call. It cannot be written against `main`.

## Why not `SetTapeSize`

`Parse` writes the state of a parse on a **copy** of the receiver, which is what keeps two calls from treading on each other. A setter undoes exactly that: between one caller's `SetTapeSize` and its `Parse` fits another caller's `SetTapeSize`. Nothing would break today, since the server handles messages in series — it would break when someone parallelises it, silently and far from the cause. And forgetting the setter reads the document at the **previous** document's width, which is the bug being avoided; forgetting the field gives zero, which is the default.

## Verification

`make check` green; both commits build and pass on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)