### PR TITLE
The language server is handed its phases

### DIFF
--- a/cmd/aurorals/main.go
+++ b/cmd/aurorals/main.go
@@ -8,6 +8,9 @@ import (
 	"os"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/version"
 )
 
@@ -38,21 +41,36 @@ func main() {
 	logger := log.New(out, "[aurorals] ", log.Ldate|log.Ltime|log.Lshortfile)
 	logger.Printf("Server started (version %s)", version.VERSION)
 
-	lsp.Listen(logger, os.Stdin, os.Stdout, handlers())
+	// The phases are built here, once, and the session that holds them answers every request.
+	// A document carries the width of the project it belongs to, which is why one session
+	// serves whatever the editor opens.
+	sv := server{textdoc: textdoc.NewSession(textdoc.NewSessionOptions{
+		Lexer:  lexer.New(),
+		Parser: parser.New(),
+	})}
+
+	lsp.Listen(logger, os.Stdin, os.Stdout, sv.handlers())
 
 	logger.Println("Server stopped")
 }
 
+// A server is what answers the editor: the session that reads a document, and the handlers
+// that are methods on it. It exists so the phases are built once, in main, rather than by
+// whoever happens to be answering a request.
+type server struct {
+	textdoc *textdoc.Session
+}
+
 // handlers maps the methods the server implements. shutdown and exit are answered by the
 // listener itself.
-func handlers() map[lsp.Method]lsp.MethodHandler {
+func (sv server) handlers() map[lsp.Method]lsp.MethodHandler {
 	return map[lsp.Method]lsp.MethodHandler{
 		"initialize":                       InitializeHandler,
-		"textDocument/didOpen":             TextdocDidOpenHandler,
-		"textDocument/didChange":           TextdocDidChangeHandler,
-		"textDocument/didClose":            TextdocDidCloseHandler,
-		"textDocument/completion":          TextdocCompletionHandler,
-		"textDocument/hover":               TextdocHoverHandler,
-		"textDocument/semanticTokens/full": TextdocSemanticTokensHandler,
+		"textDocument/didOpen":             sv.didOpen,
+		"textDocument/didChange":           sv.didChange,
+		"textDocument/didClose":            sv.didClose,
+		"textDocument/completion":          sv.completion,
+		"textDocument/hover":               sv.hover,
+		"textDocument/semanticTokens/full": sv.semanticTokens,
 	}
 }

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -10,6 +10,9 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
 )
 
 // A scripted session over the real handler map: what a client actually exchanges with the
@@ -25,7 +28,11 @@ func runSession(t *testing.T, messages ...string) []map[string]any {
 
 	in := strings.NewReader(strings.Join(messages, ""))
 	out := bytes.NewBuffer(nil)
-	lsp.Listen(log.New(io.Discard, "", 0), in, out, handlers())
+	sv := server{textdoc: textdoc.NewSession(textdoc.NewSessionOptions{
+		Lexer:  lexer.New(),
+		Parser: parser.New(),
+	})}
+	lsp.Listen(log.New(io.Discard, "", 0), in, out, sv.handlers())
 
 	replies := make([]map[string]any, 0)
 	rest := out.Bytes()

--- a/cmd/aurorals/textdoc.go
+++ b/cmd/aurorals/textdoc.go
@@ -20,7 +20,7 @@ func document(uri lsp.URI, text string) textdoc.Document {
 	}
 }
 
-func TextdocDidOpenHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) didOpen(l *log.Logger, s *state.State, contents []byte) any {
 	noti, err := textdoc.ParseDidOpenNotification(contents)
 	if err != nil {
 		l.Println(err)
@@ -31,10 +31,10 @@ func TextdocDidOpenHandler(l *log.Logger, s *state.State, contents []byte) any {
 	text := noti.Params.TextDocument.Text
 	s.UpdateDocument(string(uri), text)
 
-	return textdoc.NewDiagnosticsNotification(uri, textdoc.ValidateCode(document(uri, text)))
+	return textdoc.NewDiagnosticsNotification(uri, sv.textdoc.ValidateCode(document(uri, text)))
 }
 
-func TextdocDidChangeHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) didChange(l *log.Logger, s *state.State, contents []byte) any {
 	noti, err := textdoc.ParseDidChangeNotification(contents)
 	if err != nil {
 		l.Println(err)
@@ -51,10 +51,10 @@ func TextdocDidChangeHandler(l *log.Logger, s *state.State, contents []byte) any
 
 	// Published on every change, including when it comes back empty: that is what clears
 	// an error the user just fixed.
-	return textdoc.NewDiagnosticsNotification(uri, textdoc.ValidateCode(document(uri, text)))
+	return textdoc.NewDiagnosticsNotification(uri, sv.textdoc.ValidateCode(document(uri, text)))
 }
 
-func TextdocDidCloseHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) didClose(l *log.Logger, s *state.State, contents []byte) any {
 	noti, err := textdoc.ParseDidCloseNotification(contents)
 	if err != nil {
 		l.Println(err)
@@ -64,7 +64,7 @@ func TextdocDidCloseHandler(l *log.Logger, s *state.State, contents []byte) any 
 	return nil
 }
 
-func TextdocCompletionHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) completion(l *log.Logger, s *state.State, contents []byte) any {
 	req, err := textdoc.ParseCompletionRequest(contents)
 	if err != nil {
 		l.Println(err)
@@ -72,12 +72,12 @@ func TextdocCompletionHandler(l *log.Logger, s *state.State, contents []byte) an
 	}
 
 	uri := req.Params.TextDocument.URI
-	items := textdoc.CompletionItemsFor(document(uri, s.GetDocument(string(uri))), req.Params.Position, s.SnippetSupport())
+	items := sv.textdoc.CompletionItemsFor(document(uri, s.GetDocument(string(uri))), req.Params.Position, s.SnippetSupport())
 
 	return textdoc.NewCompletionResponse(req.ID, items)
 }
 
-func TextdocHoverHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) hover(l *log.Logger, s *state.State, contents []byte) any {
 	req, err := textdoc.ParseHoverRequest(contents)
 	if err != nil {
 		l.Println(err)
@@ -85,7 +85,7 @@ func TextdocHoverHandler(l *log.Logger, s *state.State, contents []byte) any {
 	}
 
 	uri := req.Params.TextDocument.URI
-	info := textdoc.HoverInfo(document(uri, s.GetDocument(string(uri))), req.Params.Position)
+	info := sv.textdoc.HoverInfo(document(uri, s.GetDocument(string(uri))), req.Params.Position)
 	if info == "" {
 		return nil
 	}
@@ -93,7 +93,7 @@ func TextdocHoverHandler(l *log.Logger, s *state.State, contents []byte) any {
 	return textdoc.NewHoverResponse(req.ID, info)
 }
 
-func TextdocSemanticTokensHandler(l *log.Logger, s *state.State, contents []byte) any {
+func (sv server) semanticTokens(l *log.Logger, s *state.State, contents []byte) any {
 	req, err := textdoc.ParseSemanticTokensRequest(contents)
 	if err != nil {
 		l.Println(err)
@@ -101,7 +101,7 @@ func TextdocSemanticTokensHandler(l *log.Logger, s *state.State, contents []byte
 	}
 
 	uri := req.Params.TextDocument.URI
-	data := textdoc.SemanticTokensFor(s.GetDocument(string(uri)))
+	data := sv.textdoc.SemanticTokensFor(s.GetDocument(string(uri)))
 
 	return textdoc.NewSemanticTokensResponse(req.ID, data)
 }

--- a/cmd/playground/analysis.go
+++ b/cmd/playground/analysis.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
 )
 
 // The page is a third client of the analyses the language server answers with, next to the
@@ -69,22 +71,29 @@ func marshal(v any) any {
 // small, and the alternative — telling the page how to describe a change — is a protocol,
 // which is what the editor plugin has and the page does not need.
 func analyses() []js.Func {
+	// One session for the page, the way the language server holds one for an editor: the
+	// phases are built here and the width comes with each document.
+	session := textdoc.NewSession(textdoc.NewSessionOptions{
+		Lexer:  lexer.New(),
+		Parser: parser.New(),
+	})
+
 	diagnostics := js.FuncOf(func(this js.Value, args []js.Value) any {
-		return marshal(textdoc.ValidateCode(documentFrom(args)))
+		return marshal(session.ValidateCode(documentFrom(args)))
 	})
 
 	semanticTokens := js.FuncOf(func(this js.Value, args []js.Value) any {
-		return marshal(textdoc.SemanticTokensFor(documentFrom(args).Source))
+		return marshal(session.SemanticTokensFor(documentFrom(args).Source))
 	})
 
 	hover := js.FuncOf(func(this js.Value, args []js.Value) any {
-		return marshal(textdoc.HoverInfo(documentFrom(args), positionFrom(args)))
+		return marshal(session.HoverInfo(documentFrom(args), positionFrom(args)))
 	})
 
 	// Snippets are always on: the page is one editor and it is known to expand them, where a
 	// language server has to ask because it does not know who is listening.
 	completions := js.FuncOf(func(this js.Value, args []js.Value) any {
-		return marshal(textdoc.CompletionItemsFor(documentFrom(args), positionFrom(args), true))
+		return marshal(session.CompletionItemsFor(documentFrom(args), positionFrom(args), true))
 	})
 
 	// The legend names what the numbers in the token data mean, and the page has to be given

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -168,15 +168,14 @@ A test that reads the repository — `docs/`, `examples/` — finds the root by 
 `go.mod`, never by counting directories: the second is a fact about where the test sits rather
 than about what it is reading, and it breaks on the next move.
 
-## What is not done yet
+## What a host may still name
 
-**The language server still builds its own phases.** `hosting/lsp/textdoc` calls `lexer.New`
-and `parser.New` while validating a document. The command line and the REPL no longer do —
-see below — and the same treatment is what the server is waiting for.
+Every host is handed its phases, and none of them calls `lexer.New`, `parser.New`,
+`emitter.New` or `evaluator.New` any more. They do still **import** those packages, to name a
+type: `hosting/cli` says `parser.ParseInput` and `parser.Declarations` because that is what it
+passes.
 
-**The builder writes where it is told.** `builder/evm` is handed an `io.Writer` and puts the
-bytecode into it, rather than answering with the bytes. It is a port, so nothing is decided
-inside — but the backend is parked, and this gets settled when it is not.
-
-Both are written down here rather than left to be discovered, because a document describing a
-repository that does not exist teaches people to ignore documents.
+That is not a breach of rule 1 and it is written down so nobody sets out to "fix" it. What the
+rule forbids is a **vital package knowing another** — the coupling that made the builder read
+the emitter's opcodes. Hosting and `main` exist to put the tribes together; naming the type
+you are handing over is what putting them together looks like.

--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
-	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -91,8 +90,8 @@ type semanticToken struct {
 // It uses the raw tk stream (GetTokens) rather than GetFilledTokens because whitespace
 // and line breaks are needed to place comments, and a lexer error still yields the tokens
 // read so far — so a file being typed keeps its colors instead of going blank.
-func SemanticTokensFor(source string) []uint {
-	tokens, _ := lexer.New().GetTokens([]byte(source))
+func (s *Session) SemanticTokensFor(source string) []uint {
+	tokens, _ := s.lexer.GetTokens([]byte(source))
 	mapper := lsp.NewMapper(source)
 	return encodeSemanticTokens(mapper, collectSemanticTokens(mapper, tokens))
 }

--- a/hosting/lsp/textdoc/semantic_tokens_test.go
+++ b/hosting/lsp/textdoc/semantic_tokens_test.go
@@ -86,7 +86,7 @@ func TestSemanticTokens(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := decode(SemanticTokensFor(tc.source))
+			got := decode(session().SemanticTokensFor(tc.source))
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("got:\n%v\nwant:\n%v", got, tc.want)
 			}
@@ -97,7 +97,7 @@ func TestSemanticTokens(t *testing.T) {
 // A file mid-edit must keep its colors: the lexer returns the tokens it managed to read
 // along with the error, and coloring uses them.
 func TestSemanticTokensOnBrokenSource(t *testing.T) {
-	data := SemanticTokensFor("ident a = 1;\nident b = @@@;")
+	data := session().SemanticTokensFor("ident a = 1;\nident b = @@@;")
 	tokens := decode(data)
 	if len(tokens) < 5 {
 		t.Fatalf("expected the valid prefix to still be colored, got %d tokens", len(tokens))
@@ -108,14 +108,14 @@ func TestSemanticTokensOnBrokenSource(t *testing.T) {
 }
 
 func TestSemanticTokensEmptyDocument(t *testing.T) {
-	if data := SemanticTokensFor(""); len(data) != 0 {
+	if data := session().SemanticTokensFor(""); len(data) != 0 {
 		t.Errorf("expected no tokens, got %v", data)
 	}
 }
 
 // Every entry must be a full 5-tuple, or clients misread the whole stream.
 func TestSemanticTokensDataIsWellFormed(t *testing.T) {
-	data := SemanticTokensFor("ident a = 1;\n#- note\nprintb a;\n")
+	data := session().SemanticTokensFor("ident a = 1;\n#- note\nprintb a;\n")
 	if len(data)%5 != 0 {
 		t.Fatalf("data length %d is not a multiple of 5", len(data))
 	}

--- a/hosting/lsp/textdoc/session.go
+++ b/hosting/lsp/textdoc/session.go
@@ -1,0 +1,27 @@
+package textdoc
+
+import (
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+)
+
+// A Session is one editor session: the phases it was handed, and the questions an editor asks
+// about a document. Every request the server answers is a method on it.
+//
+// The phases arrive built, from cmd/aurorals — the server is a host, and a host does not put
+// the compiler together. What it does decide is the width a document is read at, which comes
+// from the project the file belongs to and travels with each Document, since one session
+// answers for files of any project the editor opens.
+type Session struct {
+	lexer  *lexer.Lexer
+	parser parser.Parser
+}
+
+type NewSessionOptions struct {
+	Lexer  *lexer.Lexer
+	Parser parser.Parser
+}
+
+func NewSession(opts NewSessionOptions) *Session {
+	return &Session{lexer: opts.Lexer, parser: opts.Parser}
+}

--- a/hosting/lsp/textdoc/session_test.go
+++ b/hosting/lsp/textdoc/session_test.go
@@ -1,0 +1,12 @@
+package textdoc
+
+import (
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+)
+
+// session builds one the way cmd/aurorals does: the phases come from outside, and a test that
+// asks what the editor is told has to hand them over the same way.
+func session() *Session {
+	return NewSession(NewSessionOptions{Lexer: lexer.New(), Parser: parser.New()})
+}

--- a/hosting/lsp/textdoc/snippets_test.go
+++ b/hosting/lsp/textdoc/snippets_test.go
@@ -38,7 +38,7 @@ func TestKeywordSnippets(t *testing.T) {
 		{keyword: "pull", want: "pull ${1:tape} ${0:value}"},
 	}
 
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: ""}, lsp.Position{}, true)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: ""}, lsp.Position{}, true)
 	for _, tc := range cases {
 		t.Run(tc.keyword, func(t *testing.T) {
 			item := find(items, tc.keyword)
@@ -58,7 +58,7 @@ func TestKeywordSnippets(t *testing.T) {
 // A client that does not expand snippets gets the keyword and nothing else: the
 // placeholders would land in the buffer as the literal text they are.
 func TestNoSnippetsForAClientThatCannotExpandThem(t *testing.T) {
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: "struct Point { x, y };"}, lsp.Position{}, false)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: "struct Point { x, y };"}, lsp.Position{}, false)
 
 	for _, item := range items {
 		if item.InsertText != "" || item.InsertTextFormat != 0 {
@@ -75,7 +75,7 @@ func TestNoSnippetsForAClientThatCannotExpandThem(t *testing.T) {
 func TestStructCompletion(t *testing.T) {
 	const source = "struct Point { x, y };\nstruct Named { label, value, tag };\n"
 
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2}, true)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2}, true)
 
 	point := find(items, "Point")
 	if point == nil {
@@ -104,7 +104,7 @@ func TestStructCompletion(t *testing.T) {
 // are expanded.
 func TestFieldsAreNotSnippets(t *testing.T) {
 	source := "struct Point { x, y };\nident p = Point{1, 2};\np."
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 2}, true)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 2}, true)
 
 	if len(items) != 2 {
 		t.Fatalf("offered %d items, want the two fields", len(items))

--- a/hosting/lsp/textdoc/structs_test.go
+++ b/hosting/lsp/textdoc/structs_test.go
@@ -45,7 +45,7 @@ func TestCompletionAfterADotOffersTheFields(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			items := CompletionItemsFor(Document{Filename: "main.ar", Source: tc.source}, tc.pos, false)
+			items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: tc.source}, tc.pos, false)
 
 			got := make([]string, 0, len(items))
 			for _, item := range items {
@@ -65,11 +65,11 @@ func TestCompletionAfterADotOffersTheFields(t *testing.T) {
 // exactly when completion is asked for. The fields come from the tokens for that reason.
 func TestCompletionAfterADotWorksWhileBroken(t *testing.T) {
 	source := structSource + "printd p."
-	if diagnostics := ValidateCode(Document{Filename: "main.ar", Source: source}); len(diagnostics) == 0 {
+	if diagnostics := session().ValidateCode(Document{Filename: "main.ar", Source: source}); len(diagnostics) == 0 {
 		t.Fatal("this source is supposed not to parse; the test is about that")
 	}
 
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 5, Character: 9}, false)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 5, Character: 9}, false)
 	if len(items) != 2 || items[0].Label != "x" {
 		t.Errorf("offered %v, want the fields of Point", items)
 	}
@@ -77,7 +77,7 @@ func TestCompletionAfterADotWorksWhileBroken(t *testing.T) {
 
 // Anywhere else the ordinary list is what comes back.
 func TestCompletionAwayFromADotIsUnchanged(t *testing.T) {
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: structSource}, lsp.Position{Line: 5, Character: 0}, false)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: structSource}, lsp.Position{Line: 5, Character: 0}, false)
 
 	var hasKeyword bool
 	for _, item := range items {
@@ -106,7 +106,7 @@ func TestHoverDescribesStructsAndFields(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := HoverInfo(Document{Filename: "main.ar", Source: structSource}, tc.pos); !strings.Contains(got, tc.want) {
+			if got := session().HoverInfo(Document{Filename: "main.ar", Source: structSource}, tc.pos); !strings.Contains(got, tc.want) {
 				t.Errorf("hover = %q, want it to contain %q", got, tc.want)
 			}
 		})
@@ -115,7 +115,7 @@ func TestHoverDescribesStructsAndFields(t *testing.T) {
 
 func TestHoverOnAFieldSaysWhichTapeItReads(t *testing.T) {
 	source := structSource + "printd p.y;"
-	got := HoverInfo(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 5, Character: 9})
+	got := session().HoverInfo(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 5, Character: 9})
 
 	for _, want := range []string{"field y", "struct Point", "tape 1"} {
 		if !strings.Contains(got, want) {
@@ -127,7 +127,7 @@ func TestHoverOnAFieldSaysWhichTapeItReads(t *testing.T) {
 // struct and as colour as keywords, a field as a property, and the struct's own name as a
 // struct — the three places a name is not just a value.
 func TestSemanticTokensForStructs(t *testing.T) {
-	tokens := decode(SemanticTokensFor("struct Point { x, y };\nident p = Point{1, 2};\nprintd p.x;\n"))
+	tokens := decode(session().SemanticTokensFor("struct Point { x, y };\nident p = Point{1, 2};\nprintd p.x;\n"))
 
 	// struct, then the name it declares, then the two fields it names.
 	want := []uint{SemanticKeyword, SemanticStruct, SemanticProperty, SemanticProperty}

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
-	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/token"
@@ -52,10 +51,10 @@ type Document struct {
 }
 
 // Analyze lexes and parses a document.
-func Analyze(doc Document) *Analysis {
+func (s *Session) Analyze(doc Document) *Analysis {
 	analysis := &Analysis{Source: doc.Source, Mapper: lsp.NewMapper(doc.Source)}
 
-	tokens, err := lexer.New().GetFilledTokens([]byte(doc.Source))
+	tokens, err := s.lexer.GetFilledTokens([]byte(doc.Source))
 	analysis.Tokens = tokens
 	if err != nil {
 		analysis.Err = err
@@ -64,7 +63,7 @@ func Analyze(doc Document) *Analysis {
 
 	// How wide a value is decides what fits in one, so the document is read in the dialect it
 	// belongs to rather than in the default.
-	tree, err := parser.New().Parse(parser.ParseInput{
+	tree, err := s.parser.Parse(parser.ParseInput{
 		Filename: doc.Filename,
 		Tokens:   tokens,
 		TapeSize: doc.TapeSize,
@@ -147,14 +146,14 @@ func (a *Analysis) TokenAt(pos lsp.Position) token.Token {
 }
 
 // ValidateCode is the entry point used by the didOpen and didChange handlers.
-func ValidateCode(doc Document) Diagnostics {
-	return Analyze(doc).Diagnostics()
+func (s *Session) ValidateCode(doc Document) Diagnostics {
+	return s.Analyze(doc).Diagnostics()
 }
 
 // HoverInfo describes what sits under the cursor: the description the lexer already
 // carries for keywords, or the declaration of an identifier when it can be found.
-func HoverInfo(doc Document, pos lsp.Position) string {
-	analysis := Analyze(doc)
+func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
+	analysis := s.Analyze(doc)
 	tk := analysis.TokenAt(pos)
 	if tk == nil {
 		return ""
@@ -201,8 +200,8 @@ func HoverInfo(doc Document, pos lsp.Position) string {
 //
 // It takes a position for that last case: what to offer depends on what sits in front of
 // the cursor, and a document being edited usually does not parse.
-func CompletionItemsFor(doc Document, pos lsp.Position, snippets bool) []CompletionItem {
-	analysis := Analyze(doc)
+func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bool) []CompletionItem {
+	analysis := s.Analyze(doc)
 	shapes := scanStructs(analysis.Tokens)
 
 	// Right after a dot the fields are the answer, and the only one: nothing else can

--- a/hosting/lsp/textdoc/validator_test.go
+++ b/hosting/lsp/textdoc/validator_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestValidateCodeAcceptsValidSource(t *testing.T) {
-	diagnostics := ValidateCode(Document{Filename: "main.ar", Source: "ident a = 1;\nprintb a + 1;\n"})
+	diagnostics := session().ValidateCode(Document{Filename: "main.ar", Source: "ident a = 1;\nprintb a + 1;\n"})
 	if len(diagnostics) != 0 {
 		t.Fatalf("expected no diagnostics, got %v", diagnostics)
 	}
@@ -51,7 +51,7 @@ func TestValidateCodeReportsPositions(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			diagnostics := ValidateCode(Document{Filename: "main.ar", Source: tc.source})
+			diagnostics := session().ValidateCode(Document{Filename: "main.ar", Source: tc.source})
 			if len(diagnostics) != 1 {
 				t.Fatalf("expected 1 diagnostic, got %d: %v", len(diagnostics), diagnostics)
 			}
@@ -78,10 +78,10 @@ func TestValidateCodeReportsPositions(t *testing.T) {
 func TestValidateCodeHonoursTestFileRule(t *testing.T) {
 	const source = "assert(1 equals 1, \"ok\");\n"
 
-	if diagnostics := ValidateCode(Document{Filename: "math.test.ar", Source: source}); len(diagnostics) != 0 {
+	if diagnostics := session().ValidateCode(Document{Filename: "math.test.ar", Source: source}); len(diagnostics) != 0 {
 		t.Errorf("assert should be accepted in a .test.ar file, got %v", diagnostics)
 	}
-	diagnostics := ValidateCode(Document{Filename: "math.ar", Source: source})
+	diagnostics := session().ValidateCode(Document{Filename: "math.ar", Source: source})
 	if len(diagnostics) != 1 {
 		t.Fatalf("assert should be rejected outside .test.ar, got %v", diagnostics)
 	}
@@ -107,7 +107,7 @@ func TestHoverInfo(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := HoverInfo(Document{Filename: "main.ar", Source: source}, tc.pos)
+			got := session().HoverInfo(Document{Filename: "main.ar", Source: source}, tc.pos)
 			if tc.want == "" {
 				if got != "" {
 					t.Errorf("hover = %q, want empty", got)
@@ -122,7 +122,7 @@ func TestHoverInfo(t *testing.T) {
 }
 
 func TestCompletionItemsIncludeKeywordsAndDocumentIdents(t *testing.T) {
-	items := CompletionItemsFor(Document{Filename: "main.ar", Source: "ident total = 1;\n"}, lsp.Position{Line: 1, Character: 0}, false)
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: "ident total = 1;\n"}, lsp.Position{Line: 1, Character: 0}, false)
 
 	var hasKeyword, hasIdent bool
 	for _, item := range items {
@@ -142,7 +142,7 @@ func TestCompletionItemsIncludeKeywordsAndDocumentIdents(t *testing.T) {
 }
 
 func TestCompletionItemsSurviveBrokenSource(t *testing.T) {
-	if items := CompletionItemsFor(Document{Filename: "main.ar", Source: "ident @@@"}, lsp.Position{Line: 0, Character: 9}, false); len(items) == 0 {
+	if items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: "ident @@@"}, lsp.Position{Line: 0, Character: 9}, false); len(items) == 0 {
 		t.Error("keywords should still be offered while the document does not parse")
 	}
 }

--- a/hosting/lsp/textdoc/width_test.go
+++ b/hosting/lsp/textdoc/width_test.go
@@ -29,7 +29,7 @@ func TestTheWidthOfADocumentReachesTheParser(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			diagnostics := ValidateCode(Document{
+			diagnostics := session().ValidateCode(Document{
 				Filename: "main.ar",
 				Source:   nineBytes,
 				TapeSize: tc.width,
@@ -48,7 +48,7 @@ func TestTheWidthOfADocumentReachesTheParser(t *testing.T) {
 // A number too large for the tape is the other half of the same rule, and the message names
 // the width it was read at.
 func TestANumberIsCheckedAgainstTheDocumentsWidth(t *testing.T) {
-	diagnostics := ValidateCode(Document{Filename: "main.ar", Source: "printd 300;", TapeSize: 1})
+	diagnostics := session().ValidateCode(Document{Filename: "main.ar", Source: "printd 300;", TapeSize: 1})
 
 	if len(diagnostics) == 0 {
 		t.Fatal("300 was accepted on a one-byte tape")

--- a/rfcs/phase_coupling.md
+++ b/rfcs/phase_coupling.md
@@ -96,8 +96,8 @@ hosting, não uma interação. Util não toca no mundo; esses três tocam.
 injeta as fases prontas. É a etapa que muda mais assinatura: `cli` deixa de importar
 `lexer`, `parser` e `emitter`.
 
-> **Feito para o `cli` e para o `repl`; falta o language server.** Duas coisas mudaram de
-> figura ao aplicar.
+> **Feito.** `cli`, `repl` e o language server — o playground já montava no `main` desde
+> sempre, por ser `main`. Três coisas mudaram de figura ao aplicar.
 >
 > A primeira: **o parser não podia ser injetado.** Ele recebia os tokens na construção, então
 > uma instância parseava exatamente um arquivo — não havia o que entregar a um host, só um
@@ -107,10 +107,15 @@ injeta as fases prontas. É a etapa que muda mais assinatura: `cli` deixa de imp
 > regra é sobre um vital conhecer outro; `hosting` e `main` existem justamente para juntar as
 > tribos. Então `ParseInput` e `Declarations` ficaram no `parser` em vez de virarem wire.
 >
+> A terceira apareceu no servidor: **a largura da fita não podia ficar na construção do
+> parser.** Um servidor atende arquivos de vários projetos e relê o manifesto que é editado com
+> o editor aberto, então ela foi para o `ParseInput`, junto com o nome do arquivo e os tokens —
+> e o construtor do parser (e o do lexer) ficou sem opção alguma.
+>
 > A forma é uma `Session` por host, construída no handler, com um método por comando. O
 > `Compile` do `cli` deixou de existir: cada método escreve lexer → parser → emitter no próprio
-> corpo. Custa duas funções passando de 60 linhas no `funlen` — que é informação, não portão —
-> e em troca não há mais nível intermediário entre o comando e as fases.
+> corpo. Custa uma função passando de 60 linhas no `funlen` — que é informação, não portão — e
+> em troca não há mais nível intermediário entre o comando e as fases.
 
 **7. O evaluator para de escrever.** Os builtins de print saem do pacote. Duas coisas a decidir
 junto, e nenhuma é detalhe:


### PR DESCRIPTION
The last host still putting the compiler together. With this, rule 4 — *wiring happens only in `main`* — is obeyed everywhere.

## What changes

`textdoc` called `lexer.New` and `parser.New` while validating a document. It is now a `Session` built in `cmd/aurorals`, and what an editor asks is a method on it:

```go
sv := server{textdoc: textdoc.NewSession(textdoc.NewSessionOptions{
	Lexer:  lexer.New(),
	Parser: parser.New(),
})}

lsp.Listen(logger, os.Stdin, os.Stdout, sv.handlers())
```

The handlers become **methods** of a `server` that holds the session, so the map they are registered in reads exactly as before — a method value satisfies `lsp.MethodHandler` — and nothing threads through `lsp.Listen` or the document state.

The width still travels with each `Document`, and has to: one session answers for files of **any project** the editor opens, and for the same project after its manifest is edited. That is what #55 was for.

The **playground** holds its own session for the same reason, next to the phases it already built to run a program.

## The docs, and a note that was wrong

Rule 4 is obeyed, so *"what is not done yet"* had nothing left in it. What replaces it is worth writing down instead: a host still **imports** a phase to name a type — `hosting/cli` says `parser.ParseInput` — and that is not a breach. What the rule forbids is a vital package knowing another.

The section's other entry was wrong when I wrote it, in #47. It claimed `builder/evm` is handed an `io.Writer` rather than answering with the bytes; `Build` has answered with `([]byte, error)` since *"the builder stops disassembling and stops writing"*, which landed before the note did. The `io.Writer` left inside the package is the buffer it assembles into.

## Verification

`make check` green, wasm builds, both commits build and pass on their own. The language server's own session test now drives the same `server` that `main` builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)