### PR TITLE
feat: modules, PR 1 — the compiler gets ready

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -90,7 +90,7 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 
 // emitIdentLiteral binds a name to a value.
 func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tapeSize int) ir.Label {
-	ll := n.Token.GetMatch()
+	ll := []byte(n.Id)
 	lr := EmitInstruction(tc, insts, n.Value, tapeSize)
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpIdent, ll, lr))
@@ -342,7 +342,7 @@ func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, ta
 		*insts = append(*insts, ir.NewInstruction(l, ir.OpPushFeed, byteutil.FromUint64(uint64(i)), ll))
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpCall, n.Id.Token.GetMatch(), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpCall, []byte(n.Id.Value), nil))
 	return l
 
 }
@@ -428,7 +428,7 @@ func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, 
 // emitIdentifierLiteral loads what a name is bound to.
 func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, n.Token.GetMatch(), nil))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, []byte(n.Value), nil))
 	return l
 
 }

--- a/emitter/symbol_test.go
+++ b/emitter/symbol_test.go
@@ -1,0 +1,68 @@
+package emitter
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/ir"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Where a symbol comes from: the node, and not the token it was read at.
+//
+// For everything the parser writes today the two are the same text, so no program compiled
+// from source can tell them apart — the golden does that job, and it not moving is what says
+// this changed no output. What needs a test of its own is the case that does not exist yet: a
+// name the compiler wrote rather than read, which is what a module prefix will be. Below the
+// token says "area" and the node says "geometry.area", and the instruction has to carry the
+// second.
+func symbolOf(t *testing.T, insts []ir.Instruction, opcode byte) string {
+	t.Helper()
+	for _, inst := range insts {
+		if inst.GetOpCode() == opcode {
+			return string(inst.GetLeft())
+		}
+	}
+	t.Fatalf("no %s was emitted", ir.ResolveOpCode(opcode))
+	return ""
+}
+
+func TestSymbolComesFromTheNodeAndNotItsToken(t *testing.T) {
+	read := token.New([]byte("area"), token.TagId, 1, 1, 0)
+	const written = "geometry.area"
+
+	insts, err := New(NewEmitterOptions{}).Emit(ast.AST{Filename: "main.ar", Nodes: []ast.Node{
+		ast.IdentLiteral{Id: written, Token: read, Value: ast.NumberLiteral{Value: 1}},
+		ast.IdentifierLiteral{Value: written, Token: read},
+		ast.CalleeLiteral{Id: ast.IdentifierLiteral{Value: written, Token: read}},
+	}})
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+
+	for _, opcode := range []byte{ir.OpIdent, ir.OpLoad, ir.OpCall} {
+		if got := symbolOf(t, insts, opcode); got != written {
+			t.Errorf("%s carries %q, want %q", ir.ResolveOpCode(opcode), got, written)
+		}
+	}
+}
+
+// And a node with no token at all still compiles, which is the other half of the same
+// statement: the token is carried for position, and nothing reads it to find out what a name
+// is. A synthesised node has nowhere to have been read from.
+func TestANodeWithoutATokenStillCarriesItsName(t *testing.T) {
+	insts, err := New(NewEmitterOptions{}).Emit(ast.AST{Filename: "main.ar", Nodes: []ast.Node{
+		ast.IdentLiteral{Id: "a", Value: ast.NumberLiteral{Value: 1}},
+		ast.IdentifierLiteral{Value: "a"},
+	}})
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+
+	if got := symbolOf(t, insts, ir.OpIdent); got != "a" {
+		t.Errorf("OpIdent carries %q, want %q", got, "a")
+	}
+	if got := symbolOf(t, insts, ir.OpLoad); got != "a" {
+		t.Errorf("OpLoad carries %q, want %q", got, "a")
+	}
+}

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -27,6 +27,7 @@ var keywordTags = []token.Tag{
 	token.TagAssert,
 	token.TagStruct,
 	token.TagAs,
+	token.TagUse,
 }
 
 var Keywords = func() map[string]token.Tag {

--- a/lexer/scanner_test.go
+++ b/lexer/scanner_test.go
@@ -68,8 +68,10 @@ func TestScanToken(t *testing.T) {
 		// "as" was an import keyword, became an ordinary identifier when namespaces were
 		// rolled back, and is a keyword again: it names the shape a value is read with.
 		{"keyword as", "as", true, token.AS, "as"},
-		// "use" was the other import keyword and stays an ordinary identifier.
-		{"use is an identifier", "use", true, token.ID, "use"},
+		// "use" was the other import keyword, became an ordinary identifier when namespaces
+		// were rolled back, and is a keyword again: it brings a module in.
+		{"keyword use", "use", true, token.USE, "use"},
+		{"use prefix", "useful", true, token.ID, "useful"},
 
 		{"if with space", "if x", true, token.IF, "if"},
 		{"if with paren", "if(", true, token.IF, "if"},

--- a/lexer/tag_test.go
+++ b/lexer/tag_test.go
@@ -98,8 +98,8 @@ func TestMatchToken(t *testing.T) {
 		{[]byte(`
 `), token.BREAK_LINE, []byte(`
 `), true},
-		// "use" was an import keyword: an ordinary identifier now
-		{[]byte(`use`), token.ID, []byte("use"), true},
+		// "use" is an import keyword again: it brings a module in under an alias
+		{[]byte(`use`), token.USE, []byte("use"), true},
 	}
 	for _, c := range cases {
 		matched, tag, match := MatchToken(c.Buffer)

--- a/parser/use_test.go
+++ b/parser/use_test.go
@@ -1,0 +1,15 @@
+package parser
+
+import "testing"
+
+// "use" is a keyword again, so it cannot be a name.
+//
+// It was one when namespaces existed, became an ordinary identifier when they were rolled
+// back, and comes back now that modules are designed — which makes this the one breaking
+// change the module system asks for. Nothing in the repository was using it as a name, and a
+// word that merely starts with it still is one: the lexer has "useful" for that.
+func TestUseCannotBeAName(t *testing.T) {
+	if _, err := parseSource(t, "ident use = 1;", "main.ar"); err == nil {
+		t.Fatal("ident use = 1; parsed, and use is a keyword")
+	}
+}

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -47,6 +47,7 @@ const (
 	SUM          = "SUM"       // +
 	TAIL         = "TAIL"      // tail
 	TRUE         = "TRUE"      // true
+	USE          = "USE"       // use - brings a module in under an alias
 	WHITESPACE   = "WHITESPACE"
 )
 
@@ -103,6 +104,7 @@ var (
 	TagSum        = Tag{SUM, "+", ""}
 	TagTail       = Tag{TAIL, "tail", "Get right to left nth items from a tape"}
 	TagTrue       = Tag{TRUE, "true", ""}
+	TagUse        = Tag{USE, "use", "Bring a module in under an alias"}
 	TagWhitespace = Tag{WHITESPACE, " ", ""}
 )
 


### PR DESCRIPTION
Primeiro dos cinco pull requests do plano em [`rfcs/module_system.md`](https://github.com/guiferpa/aurora/blob/main/rfcs/module_system.md) (aceita no #58). **Não muda comportamento nenhum**, e é de propósito: tira do caminho as duas suposições que todo o resto do sistema de módulos assume.

## Os dois commits

**1. Um símbolo vem do nó, não do token.** `OpIdent`, `OpLoad` e `OpCall` tiravam o nome de `Token.GetMatch()`. Passam a ler o campo do próprio nó, que o parser já preenche com exatamente esses bytes.

Isso destrava um nome que o compilador **escreve** em vez de ler: o prefixo de módulo (`a/b/c.add`) não é texto que ninguém digitou, e a única outra saída seria fabricar um token cujo match mente sobre de onde veio. O token continua no nó para o que ele serve — dizer onde a coisa foi escrita.

**2. `use` é uma palavra que a linguagem guarda.** Era palavra-chave até os namespaces serem revertidos na v0.2.0-alpha, virou identificador comum desde então, e volta a ser reservada.

## O que garante que nada mudou

O golden do emitter (`emitter/testdata/wide.ir`) **não se mexeu** — é o que prova o primeiro commit, já que para todo programa que existe hoje o nó e o token carregam o mesmo texto.

Os dois casos que fonte nenhuma consegue produzir ainda ganharam teste próprio em `emitter/symbol_test.go`: um nó cujo nome não é o texto do token emite o nome, e um nó **sem token nenhum** compila — esse último dava panic antes.

## Quebra

**Um identificador chamado `use` não parseia mais.** Nada no repositório usava — nenhum exemplo, nenhum teste, nenhum trecho na documentação. Uma palavra que só começa com ele continua sendo identificador, e `useful` está na tabela do lexer para manter assim.

Não há gramática atrás dele ainda: `use a/b/c as x;` é erro de sintaxe, não import. É esse o motivo de tomar a palavra primeiro — a declaração entra no PR que também a resolve, então ela nunca existe num estado em que parseia e não faz nada. Pelo mesmo motivo a tag **não** entrou em `processableTags`: o language server ofereceria uma palavra-chave que não dá para escrever.

A entrada no CHANGELOG sai com o PR 4, que é onde módulos passam a existir — a quebra precisa aparecer nas notas daquela release.

## Verificação

`make check` limpo: build, wasm, test, lint, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
