### PR TITLE
feat: modules, PR 2 — a file says which modules it depends on

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -48,6 +48,8 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 		return emitTapeBracketExpression(tc, insts, n, tapeSize)
 	case ast.StructDeclaration:
 		return emitStructDeclaration(tc, insts, n, tapeSize)
+	case ast.UseDeclaration:
+		return emitUseDeclaration(tc, insts, n, tapeSize)
 	case ast.StructLiteral:
 		return emitStructLiteral(tc, insts, n, tapeSize)
 	case ast.FieldExpression:
@@ -212,6 +214,17 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBrack
 func emitStructDeclaration(tc *int, insts *[]ir.Instruction, _ ast.StructDeclaration, tapeSize int) ir.Label {
 	// A declaration emits no work. It still answers with a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
+	l := GenerateLabel(tc)
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.FalseTape(tapeSize), nil))
+	return l
+
+}
+
+// emitUseDeclaration answers the neutral value: an import is resolved before the emitter runs.
+func emitUseDeclaration(tc *int, insts *[]ir.Instruction, _ ast.UseDeclaration, tapeSize int) ir.Label {
+	// Like a struct declaration, and for the same reason: it declares a name the compiler
+	// uses and the program never touches, so there is no work to do and still a value to
+	// answer with.
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, byteutil.FalseTape(tapeSize), nil))
 	return l

--- a/emitter/symbol_test.go
+++ b/emitter/symbol_test.go
@@ -66,3 +66,17 @@ func TestANodeWithoutATokenStillCarriesItsName(t *testing.T) {
 		t.Errorf("OpLoad carries %q, want %q", got, "a")
 	}
 }
+
+// A declaration does no work, and an import is one: it names a module the compiler resolves
+// before the emitter ever runs, so what comes out is the neutral value and nothing else. The
+// same shape as a struct declaration, and for the same reason.
+func TestAnImportEmitsNoWork(t *testing.T) {
+	program := compile(t, "use a/b/c as x;")
+
+	if len(program.Instructions) != 1 {
+		t.Fatalf("an import emitted %d instructions, want 1", len(program.Instructions))
+	}
+	if got := program.Instructions[0].GetOpCode(); got != ir.OpSave {
+		t.Errorf("an import emitted %s, want OpSave of the neutral value", ir.ResolveOpCode(got))
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -55,6 +55,9 @@ type pr struct {
 	// reference so a caller compiling one file across several parses — the REPL — keeps
 	// what was declared earlier.
 	declarations *Declarations
+	// useAllowed says whether a `use` may still be read: it is true at the start of a file
+	// and false from the first node that is not one, and inside every body.
+	useAllowed bool
 }
 
 // Helper functions to validate node types for tape operations
@@ -776,6 +779,9 @@ func (p *pr) ParseExpr() (ast.Node, error) {
 	if lookahead.GetTag().Id == token.ASSERT {
 		return p.ParseAssert()
 	}
+	if lookahead.GetTag().Id == token.USE {
+		return p.ParseUse()
+	}
 	if lookahead.GetTag().Id == token.STRUCT {
 		return p.ParseStruct()
 	}
@@ -897,6 +903,12 @@ func (p *pr) ParseFeed() (ast.Node, error) {
 }
 
 func (p *pr) ParseExprs(t token.Tag) ([]ast.Node, error) {
+	// Anything read until a token other than the end of the file is a body, and a body is
+	// not the top of a file.
+	if t.Id != token.EOF {
+		p.useAllowed = false
+	}
+
 	exprs := make([]ast.Node, 0)
 	for {
 		lookahead := p.GetLookahead()
@@ -909,6 +921,9 @@ func (p *pr) ParseExprs(t token.Tag) ([]ast.Node, error) {
 		}
 		if _, err := p.EatToken(token.SEMICOLON); err != nil {
 			return exprs, err
+		}
+		if _, isUse := expr.(ast.UseDeclaration); !isUse {
+			p.useAllowed = false
 		}
 		exprs = append(exprs, expr)
 	}
@@ -948,6 +963,7 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	p.tokens = in.Tokens
 	p.tapeSize = byteutil.TapeSize(in.TapeSize)
 	p.cursor = 0
+	p.useAllowed = true
 	p.declarations = in.Declarations
 	if p.declarations == nil {
 		p.declarations = NewDeclarations()

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -30,12 +30,16 @@ import (
 type Declarations struct {
 	Structs map[string][]string // struct name -> its fields, in order
 	Shapes  map[string]string   // identifier name -> the struct it is read as
+	// Modules is what `use` declared: alias -> specifier. It belongs to the file that wrote
+	// it and to no other, which is the whole point of the alias being mandatory.
+	Modules map[string]string
 }
 
 func NewDeclarations() *Declarations {
 	return &Declarations{
 		Structs: make(map[string][]string),
 		Shapes:  make(map[string]string),
+		Modules: make(map[string]string),
 	}
 }
 

--- a/parser/use.go
+++ b/parser/use.go
@@ -1,0 +1,107 @@
+package parser
+
+import (
+	"strings"
+
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// What `use` declares, and the rules that come with it.
+//
+// A module is a file, and the name of a module is the path it has from the source root:
+// `use a/b/c as x;` reads a/b/c.ar. The alias is how everything inside is reached, and it is
+// mandatory — reading `x.add(1, 2)` says where add lives without anyone scrolling anywhere.
+//
+// Nothing here resolves anything. The parser writes down which alias means which module and
+// refuses what is wrong about the line itself; finding the file, ordering it and checking
+// that a symbol exists in it are other people's jobs.
+
+// ParseUse reads `use a/b/c as x;`.
+func (p *pr) ParseUse() (ast.Node, error) {
+	tok, err := p.EatToken(token.USE)
+	if err != nil {
+		return nil, err
+	}
+	// The rule is the reader's: what a file depends on is known before anything happens, so
+	// nobody has to scroll to find out.
+	if !p.useAllowed {
+		return nil, token.NewError(tok, "use belongs to the top of the file at line %d and column %d: put it above everything else",
+			tok.GetLine(), tok.GetColumn())
+	}
+
+	specifier, err := p.parseSpecifier()
+	if err != nil {
+		return nil, err
+	}
+
+	// The alias is what the rest of the file reaches the module by, so leaving it out is the
+	// one mistake worth naming: everything else here is a token in the wrong place.
+	if lookahead := p.GetLookahead(); lookahead != nil && lookahead.GetTag().Id != token.AS {
+		return nil, token.NewError(lookahead, "an import needs a name to be reached by at line %d and column %d: use %s as x",
+			lookahead.GetLine(), lookahead.GetColumn(), specifier)
+	}
+	if _, err := p.EatToken(token.AS); err != nil {
+		return nil, err
+	}
+	name, err := p.EatToken(token.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	alias := string(name.GetMatch())
+	if declared, ok := p.declarations.Modules[alias]; ok {
+		return nil, token.NewError(name, "%s is already the alias of %s at line %d and column %d",
+			alias, declared, name.GetLine(), name.GetColumn())
+	}
+	p.declarations.Modules[alias] = specifier
+
+	return ast.UseDeclaration{Specifier: specifier, Alias: alias, Token: tok}, nil
+}
+
+// parseSpecifier reads `a/b/c` as one path.
+//
+// The segments are ordinary identifiers with the division sign between them, which is all the
+// lexer needs to know — a path needs no token of its own. What it does need is to be written
+// as one word: see glued.
+func (p *pr) parseSpecifier() (string, error) {
+	first, err := p.EatToken(token.ID)
+	if err != nil {
+		return "", err
+	}
+
+	segments := []string{string(first.GetMatch())}
+	previous := first
+	for p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.DIV {
+		slash, err := p.EatToken(token.DIV)
+		if err != nil {
+			return "", err
+		}
+		if err := glued(previous, slash); err != nil {
+			return "", err
+		}
+		segment, err := p.EatToken(token.ID)
+		if err != nil {
+			return "", err
+		}
+		if err := glued(slash, segment); err != nil {
+			return "", err
+		}
+		segments = append(segments, string(segment.GetMatch()))
+		previous = segment
+	}
+	return strings.Join(segments, "/"), nil
+}
+
+// glued refuses a space inside a path.
+//
+// `a / b` is a division everywhere else in the language, and reading the same three tokens as
+// a path here would make them mean two things depending on the line they sit in. A cursor is
+// a byte offset, so two tokens are one word when the second starts where the first ended.
+func glued(left, right token.Token) error {
+	if right.GetCursor() == left.GetCursor()+len(left.GetMatch()) {
+		return nil
+	}
+	return token.NewError(right, "a module path is written as one word at line %d and column %d: a/b/c, not a / b / c",
+		right.GetLine(), right.GetColumn())
+}

--- a/parser/use_test.go
+++ b/parser/use_test.go
@@ -1,6 +1,13 @@
 package parser
 
-import "testing"
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
 
 // "use" is a keyword again, so it cannot be a name.
 //
@@ -12,4 +19,111 @@ func TestUseCannotBeAName(t *testing.T) {
 	if _, err := parseSource(t, "ident use = 1;", "main.ar"); err == nil {
 		t.Fatal("ident use = 1; parsed, and use is a keyword")
 	}
+}
+
+// What the line declares: which module, and the name this file reaches it by.
+func TestUseDeclaresAModuleUnderAnAlias(t *testing.T) {
+	for _, tc := range []struct {
+		source    string
+		specifier string
+		alias     string
+	}{
+		{"use a/b/c as x;", "a/b/c", "x"},
+		{"use math as m;", "math", "m"},
+		{"use std/text/case as c;", "std/text/case", "c"},
+		// A segment is an ordinary identifier, so it is whatever one may be.
+		{"use my_lib/is_true? as t;", "my_lib/is_true?", "t"},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			declaration := first[ast.UseDeclaration](t, tc.source)
+			if declaration.Specifier != tc.specifier {
+				t.Errorf("specifier = %q, want %q", declaration.Specifier, tc.specifier)
+			}
+			if declaration.Alias != tc.alias {
+				t.Errorf("alias = %q, want %q", declaration.Alias, tc.alias)
+			}
+			if declaration.Token == nil {
+				t.Error("the declaration carries no token, so nothing can point at it")
+			}
+		})
+	}
+}
+
+// A file names as many modules as it needs, and each alias is written down for whoever reads
+// a qualified name later.
+func TestUseRecordsEveryAlias(t *testing.T) {
+	declarations := NewDeclarations()
+	tree, err := parseWithDeclarations(t, "use a/b as x;\nuse c/d as y;", declarations)
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	if len(tree.Nodes) != 2 {
+		t.Fatalf("expected two declarations, got %d", len(tree.Nodes))
+	}
+	for alias, specifier := range map[string]string{"x": "a/b", "y": "c/d"} {
+		if got := declarations.Modules[alias]; got != specifier {
+			t.Errorf("alias %s means %q, want %q", alias, got, specifier)
+		}
+	}
+}
+
+// Every way of writing the line wrong, and what it says about it.
+func TestUseRefusesWhatIsNotADeclaration(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"no alias", "use a/b/c;", "needs a name to be reached by"},
+		{"nothing to be called", "use a/b/c as;", "unexpected token"},
+		{"no module", "use as x;", "unexpected token"},
+		// A path is one word: the same three tokens are a division everywhere else.
+		{"spaces in the path", "use a / b as x;", "one word"},
+		{"a space before the slash", "use a /b as x;", "one word"},
+		{"a space after the slash", "use a/ b as x;", "one word"},
+		// The alias belongs to the file, so two of them are a redeclaration.
+		{"the alias twice", "use a/b as x;\nuse c/d as x;", "already the alias of a/b"},
+		// It belongs to the top, and the top ends at the first thing that is not a use.
+		{"after a binding", "ident a = 1;\nuse a/b as x;", "top of the file"},
+		{"after a print", "printd 1;\nuse a/b as x;", "top of the file"},
+		{"inside a block", "{ use a/b as x; };", "top of the file"},
+		{"inside a deferred scope", "ident f = defer { use a/b as x; };", "top of the file"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSource(t, tc.source, "main.ar")
+			if err == nil {
+				t.Fatal("expected a compile error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to say %q", err, tc.want)
+			}
+			positioned, ok := err.(*token.Error)
+			if !ok {
+				t.Fatalf("error is %T, want a positioned *token.Error", err)
+			}
+			if positioned.Line == 0 || positioned.Column == 0 {
+				t.Errorf("error has no position: line %d, column %d", positioned.Line, positioned.Column)
+			}
+		})
+	}
+}
+
+// A use is still an expression, so what follows one is read as usual.
+func TestUseSitsAboveTheRest(t *testing.T) {
+	nodes := parse(t, "use a/b as x;\nident n = 1;\nprintd n;")
+	if len(nodes) != 3 {
+		t.Fatalf("expected three nodes, got %d", len(nodes))
+	}
+	if _, ok := nodes[0].(ast.UseDeclaration); !ok {
+		t.Errorf("the first node is %T, want a use", nodes[0])
+	}
+}
+
+func parseWithDeclarations(t *testing.T, source string, declarations *Declarations) (ast.AST, error) {
+	t.Helper()
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		return ast.AST{}, err
+	}
+	return New().Parse(ParseInput{Filename: "main.ar", Tokens: tokens, Declarations: declarations})
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -1,0 +1,169 @@
+// Package resolver answers which files a program is made of, and in what order they load.
+//
+// It starts at the file somebody asked to run, reads what that file says it depends on, and
+// keeps going until nothing is left to find. What comes back is every module, dependencies
+// before dependents, each parsed once no matter how many files name it.
+//
+// It touches nothing. Source arrives through a port and trees come back from another, so the
+// same resolver serves a command line reading a disk and a page in a browser holding its
+// files in memory.
+package resolver
+
+import (
+	"fmt"
+	"path"
+	"strings"
+
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Extension is what a module's file is called. A specifier leaves it out — `use a/b/c as x;`
+// reads a/b/c.ar — because it names a module and not a path.
+const Extension = ".ar"
+
+// Read hands back the source of a file. It is how the world arrives here: the command line
+// reads a disk, the playground reads a map it already has, a test reads whatever it likes.
+type Read func(path string) ([]byte, error)
+
+// Parse turns one module's source into a tree. Filename is where it came from, which is what
+// positions and file-scoped rules are about; ID is the module the names inside belong to.
+type Parse func(filename string, id module.ID, source []byte) (ast.AST, error)
+
+// Options is what a resolver is built with.
+type Options struct {
+	// SourceRoot is the directory module names resolve from, and `a/b/c` under it is
+	// a/b/c.ar. Empty means the caller's own directory.
+	SourceRoot string
+	Read       Read
+	Parse      Parse
+}
+
+type Resolver struct {
+	sourceRoot string
+	read       Read
+	parse      Parse
+}
+
+func New(opts Options) *Resolver {
+	return &Resolver{sourceRoot: opts.SourceRoot, read: opts.Read, parse: opts.Parse}
+}
+
+// resolution is one call to Resolve: what has been found, what is being looked at right now,
+// and the order the answer is being built in.
+type resolution struct {
+	found map[module.ID]bool
+	order []module.Module
+	// open is the chain of modules being resolved, innermost last. A specifier that is
+	// already on it is a cycle, and the chain is the error.
+	open []module.ID
+	// entry is the path of the file that was asked for, so a module cannot import it: it
+	// would be read twice, under two names, and its top level would run twice.
+	entry string
+}
+
+// Resolve answers with the entry and everything it needs, dependencies first.
+//
+// The entry is a path rather than a module name because it is the file somebody asked to
+// run, and it is the one module with no id.
+func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
+	state := &resolution{found: make(map[module.ID]bool), entry: path.Clean(entry)}
+
+	source, err := r.read(entry)
+	if err != nil {
+		return nil, fmt.Errorf("reading %s: %w", entry, err)
+	}
+	tree, err := r.parse(entry, "", source)
+	if err != nil {
+		return nil, err
+	}
+	if err := r.dependencies(state, tree); err != nil {
+		return nil, err
+	}
+
+	return append(state.order, module.Module{ID: "", Tree: tree}), nil
+}
+
+// dependencies resolves every module a tree names, in the order the file names them.
+//
+// The declarations are top-level nodes, so this reads the list a file opens with rather than
+// walking anything.
+func (r *Resolver) dependencies(state *resolution, tree ast.AST) error {
+	for _, node := range tree.Nodes {
+		declaration, ok := node.(ast.UseDeclaration)
+		if !ok {
+			continue
+		}
+		if err := r.resolveOne(state, declaration); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// resolveOne finds one module, everything under it, and adds it to the order.
+//
+// A module already found is not read again: several files naming the same one is the ordinary
+// case, and it loads once — its body runs once, which is the whole premise of a module being
+// a file that executes.
+func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration) error {
+	id := module.ID(declaration.Specifier)
+	if state.found[id] {
+		return nil
+	}
+	if err := state.refuseCycle(id, declaration); err != nil {
+		return err
+	}
+
+	filename := r.Filename(id)
+	if path.Clean(filename) == state.entry {
+		return token.NewError(declaration.Token, "%s is the file being run at line %d and column %d: a program cannot import itself",
+			id, declaration.Token.GetLine(), declaration.Token.GetColumn())
+	}
+
+	source, err := r.read(filename)
+	if err != nil {
+		return token.NewError(declaration.Token, "module %s is not there at line %d and column %d: no %s",
+			id, declaration.Token.GetLine(), declaration.Token.GetColumn(), filename)
+	}
+	tree, err := r.parse(filename, id, source)
+	if err != nil {
+		return err
+	}
+
+	state.open = append(state.open, id)
+	if err := r.dependencies(state, tree); err != nil {
+		return err
+	}
+	state.open = state.open[:len(state.open)-1]
+
+	// Appended after everything it needs, which is what makes the order topological.
+	state.found[id] = true
+	state.order = append(state.order, module.Module{ID: id, Tree: tree})
+	return nil
+}
+
+// Filename is the file a module name reads: a/b/c under the source root, with the extension
+// back on.
+func (r *Resolver) Filename(id module.ID) string {
+	return path.Join(r.sourceRoot, string(id)+Extension)
+}
+
+// refuseCycle answers with the whole chain rather than the two ends of it, because a cycle of
+// four is read by following it and the middle is where the mistake usually is.
+func (s *resolution) refuseCycle(id module.ID, declaration ast.UseDeclaration) error {
+	for i, open := range s.open {
+		if open != id {
+			continue
+		}
+		chain := make([]string, 0, len(s.open)-i+1)
+		for _, each := range s.open[i:] {
+			chain = append(chain, string(each))
+		}
+		chain = append(chain, string(id))
+		return token.NewError(declaration.Token, "modules go in a circle at line %d and column %d: %s",
+			declaration.Token.GetLine(), declaration.Token.GetColumn(), strings.Join(chain, " → "))
+	}
+	return nil
+}

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -1,0 +1,258 @@
+package resolver
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// The resolver never opens a file: it asks the port it was handed. So does every test here,
+// and that is the point of them — a test that needed a directory on disk would be saying the
+// port is in the wrong place.
+
+// files is a project: the path a module would be read from, and what is in it.
+type files map[string]string
+
+// resolve runs the resolver over files, and answers with what it found and what it asked to
+// read, in the order it asked.
+func resolve(t *testing.T, root, entry string, sources files) ([]module.Module, []string, error) {
+	t.Helper()
+
+	asked := make([]string, 0)
+	resolver := New(Options{
+		SourceRoot: root,
+		Read: func(path string) ([]byte, error) {
+			asked = append(asked, path)
+			source, ok := sources[path]
+			if !ok {
+				return nil, fmt.Errorf("no such file")
+			}
+			return []byte(source), nil
+		},
+		Parse: func(filename string, _ module.ID, source []byte) (ast.AST, error) {
+			tokens, err := lexer.New().GetFilledTokens(source)
+			if err != nil {
+				return ast.AST{}, err
+			}
+			return parser.New().Parse(parser.ParseInput{Filename: filename, Tokens: tokens})
+		},
+	})
+
+	modules, err := resolver.Resolve(entry)
+	return modules, asked, err
+}
+
+// ids is the order that came back, as names, with the entry showing as the empty one.
+func ids(modules []module.Module) []string {
+	names := make([]string, 0, len(modules))
+	for _, each := range modules {
+		names = append(names, string(each.ID))
+	}
+	return names
+}
+
+func mustResolve(t *testing.T, root, entry string, sources files) []module.Module {
+	t.Helper()
+	modules, _, err := resolve(t, root, entry, sources)
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	return modules
+}
+
+// A file that needs nothing is a program of one module, and it is the entry: no name, because
+// nothing imports it.
+func TestAProgramOfOneFile(t *testing.T) {
+	modules := mustResolve(t, "src", "src/main.ar", files{
+		"src/main.ar": "printd 1;",
+	})
+
+	if got := ids(modules); len(got) != 1 || got[0] != "" {
+		t.Fatalf("order = %q, want the entry alone", got)
+	}
+	if !modules[0].IsEntry() {
+		t.Error("the file that was asked for is not the entry")
+	}
+}
+
+// What a file needs comes before it, and the entry is last: its body runs after everything it
+// depends on has run.
+func TestDependenciesComeFirst(t *testing.T) {
+	modules := mustResolve(t, "src", "src/main.ar", files{
+		"src/main.ar":     "use a/b as x;\nprintd 1;",
+		"src/a/b.ar":      "use deep/one as d;\nident v = 1;",
+		"src/deep/one.ar": "ident w = 2;",
+	})
+
+	want := []string{"deep/one", "a/b", ""}
+	if got := ids(modules); !equal(got, want) {
+		t.Errorf("order = %q, want %q", got, want)
+	}
+}
+
+// A module two files name is read once. Its body is a program that runs, so reading it twice
+// would run it twice.
+func TestAModuleIsReadOnce(t *testing.T) {
+	modules, asked, err := resolve(t, "src", "src/main.ar", files{
+		"src/main.ar":   "use left as l;\nuse right as r;\nprintd 1;",
+		"src/left.ar":   "use shared as s;\nident a = 1;",
+		"src/right.ar":  "use shared as s;\nident b = 2;",
+		"src/shared.ar": "ident c = 3;",
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+
+	want := []string{"shared", "left", "right", ""}
+	if got := ids(modules); !equal(got, want) {
+		t.Errorf("order = %q, want %q", got, want)
+	}
+
+	read := 0
+	for _, path := range asked {
+		if path == "src/shared.ar" {
+			read++
+		}
+	}
+	if read != 1 {
+		t.Errorf("src/shared.ar was read %d times, want 1", read)
+	}
+}
+
+// The same module under two names in the same file is still one module.
+func TestTwoAliasesForOneModule(t *testing.T) {
+	modules, asked, err := resolve(t, "src", "src/main.ar", files{
+		"src/main.ar":  "use thing as a;\nuse thing as b;\nprintd 1;",
+		"src/thing.ar": "ident v = 1;",
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if got := ids(modules); !equal(got, []string{"thing", ""}) {
+		t.Errorf("order = %q, want thing and the entry", got)
+	}
+	if len(asked) != 2 {
+		t.Errorf("read %d files, want the entry and thing once each: %q", len(asked), asked)
+	}
+}
+
+// The source root is where a module name resolves from, and the name says the rest.
+func TestTheSourceRootDecidesWhereToLook(t *testing.T) {
+	modules, asked, err := resolve(t, "lib", "lib/main.ar", files{
+		"lib/main.ar":           "use deep/down/here as d;\nprintd 1;",
+		"lib/deep/down/here.ar": "ident v = 1;",
+	})
+	if err != nil {
+		t.Fatalf("resolving: %v", err)
+	}
+	if got := ids(modules); !equal(got, []string{"deep/down/here", ""}) {
+		t.Errorf("order = %q", got)
+	}
+	if want := "lib/deep/down/here.ar"; asked[1] != want {
+		t.Errorf("read %q, want %q", asked[1], want)
+	}
+}
+
+// Everything that is not a program, and what it says about it.
+var refusals = []struct {
+	name    string
+	entry   string
+	sources files
+	want    []string
+}{
+	{
+		name:    "a module that is not there",
+		entry:   "src/main.ar",
+		sources: files{"src/main.ar": "use a/b as x;\nprintd 1;"},
+		want:    []string{"a/b is not there", "src/a/b.ar"},
+	},
+	{
+		name:  "two modules in a circle",
+		entry: "src/main.ar",
+		sources: files{
+			"src/main.ar": "use one as o;\nprintd 1;",
+			"src/one.ar":  "use two as t;\nident a = 1;",
+			"src/two.ar":  "use one as o;\nident b = 2;",
+		},
+		want: []string{"circle", "one → two → one"},
+	},
+	{
+		name:  "three modules in a circle",
+		entry: "src/main.ar",
+		sources: files{
+			"src/main.ar":  "use one as o;\nprintd 1;",
+			"src/one.ar":   "use two as t;\nident a = 1;",
+			"src/two.ar":   "use three as t;\nident b = 2;",
+			"src/three.ar": "use one as o;\nident c = 3;",
+		},
+		want: []string{"one → two → three → one"},
+	},
+	{
+		name:  "a module that imports itself",
+		entry: "src/main.ar",
+		sources: files{
+			"src/main.ar": "use one as o;\nprintd 1;",
+			"src/one.ar":  "use one as o;\nident a = 1;",
+		},
+		want: []string{"one → one"},
+	},
+	{
+		// It would be read twice, under two names, and its top level would run twice.
+		name:    "the program importing itself",
+		entry:   "src/main.ar",
+		sources: files{"src/main.ar": "use main as m;\nprintd 1;"},
+		want:    []string{"the file being run", "cannot import itself"},
+	},
+}
+
+func TestRefusals(t *testing.T) {
+	for _, tc := range refusals {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, err := resolve(t, "src", tc.entry, tc.sources)
+			if err == nil {
+				t.Fatal("expected a refusal")
+			}
+			for _, want := range tc.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error = %q, want it to say %q", err, want)
+				}
+			}
+			positioned, ok := err.(*token.Error)
+			if !ok {
+				t.Fatalf("error is %T, want a positioned *token.Error so an editor can underline it", err)
+			}
+			if positioned.Line == 0 || positioned.Column == 0 {
+				t.Errorf("error has no position: line %d, column %d", positioned.Line, positioned.Column)
+			}
+		})
+	}
+}
+
+// The entry not being readable is not about a module, so it is not underlined at a use.
+func TestTheEntryNotBeingThere(t *testing.T) {
+	_, _, err := resolve(t, "src", "src/main.ar", files{})
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	if !strings.Contains(err.Error(), "src/main.ar") {
+		t.Errorf("error = %q, want it to name the file", err)
+	}
+}
+
+func equal(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/wire/ast/equal.go
+++ b/wire/ast/equal.go
@@ -70,6 +70,8 @@ func nodeEqual(a, b Node) bool {
 		return sameKind(b, va, unaryEqual)
 	case StructDeclaration:
 		return sameKind(b, va, structDeclarationEqual)
+	case UseDeclaration:
+		return sameKind(b, va, useDeclarationEqual)
 	case StructLiteral:
 		return sameKind(b, va, structLiteralEqual)
 	case FieldExpression:
@@ -171,6 +173,12 @@ func assertEqual(a, b AssertStatement) bool {
 // how the declaration was written.
 func structDeclarationEqual(a, b StructDeclaration) bool {
 	return a.Name == b.Name && slices.Equal(a.Fields, b.Fields)
+}
+
+// An import is the module it names and the name it is reached by. The same module under two
+// aliases is two declarations, and so is two modules under one alias.
+func useDeclarationEqual(a, b UseDeclaration) bool {
+	return a.Specifier == b.Specifier && a.Alias == b.Alias
 }
 
 func structLiteralEqual(a, b StructLiteral) bool {

--- a/wire/ast/equal_test.go
+++ b/wire/ast/equal_test.go
@@ -309,6 +309,27 @@ var comparisonCases = []struct {
 	},
 
 	{
+		name: "use declaration, alike",
+		a:    UseDeclaration{Specifier: "a/b/c", Alias: "x"},
+		b:    UseDeclaration{Specifier: "a/b/c", Alias: "x"},
+		want: true,
+	},
+	{
+		name: "use declaration, another module",
+		a:    UseDeclaration{Specifier: "a/b/c", Alias: "x"},
+		b:    UseDeclaration{Specifier: "a/b/d", Alias: "x"},
+		want: false,
+	},
+	{
+		// The alias belongs to the file that wrote it, so it is part of the declaration and
+		// not a way of spelling the same one.
+		name: "use declaration, another alias",
+		a:    UseDeclaration{Specifier: "a/b/c", Alias: "x"},
+		b:    UseDeclaration{Specifier: "a/b/c", Alias: "y"},
+		want: false,
+	},
+
+	{
 		name: "struct literal, alike",
 		a:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},
 		b:    StructLiteral{Name: "Point", Values: []Node{number(1), number(2)}},

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -265,3 +265,19 @@ type ShapedExpression struct {
 	Struct     string      `json:"struct"`
 	Token      token.Token `json:"-"`
 }
+
+// UseDeclaration brings a module in under an alias: `use a/b/c as x;`.
+//
+// It declares rather than binds. The alias names something only the compiler resolves — a
+// module — and not a value, so nothing prints it, passes it or keeps it, exactly like the
+// name a struct declares. That is also why it emits no work.
+type UseDeclaration struct {
+	mark
+	// Specifier is the module's path from the source root, without the extension: "a/b/c"
+	// reads a/b/c.ar. It is the module's identity, and it is the same text for every file
+	// that imports it, which is what makes it the key of everything downstream.
+	Specifier string `json:"specifier"`
+	// Alias is how this file reaches what is inside, and it belongs to this file alone.
+	Alias string      `json:"alias"`
+	Token token.Token `json:"-"`
+}

--- a/wire/module/module.go
+++ b/wire/module/module.go
@@ -1,0 +1,28 @@
+// Package module is what the resolver finds and the loader consumes: which files a program
+// is made of, in what order, and what is in each one.
+//
+// It is a wire package because those are two phases that may not know each other, and both
+// have to name the same thing. Nothing here does any work.
+package module
+
+import "github.com/guiferpa/aurora/wire/ast"
+
+// An ID is a module's identity: the path it has from the source root, without the extension.
+// `use a/b/c as x;` names the module a/b/c, whoever writes the line and wherever they write
+// it from — which is what lets it be the key of the cache, of the environ index and of the
+// prefix every name inside the module carries.
+//
+// The empty ID is the file somebody asked to run. It has no name because nothing imports it,
+// and the names inside it are written as they were typed.
+type ID string
+
+// A Module is one file, parsed, under the name the rest of the program reaches it by.
+type Module struct {
+	ID   ID
+	Tree ast.AST
+}
+
+// IsEntry reports whether this is the file that was asked for rather than one it needed.
+func (m Module) IsEntry() bool {
+	return m.ID == ""
+}

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -125,6 +125,7 @@ var processableTags = []Tag{
 	TagPull,
 	TagStruct,
 	TagAs,
+	TagUse,
 }
 
 func GetProcessableTags() []Tag {


### PR DESCRIPTION
Segundo dos cinco do plano em [`rfcs/module_system.md`](https://github.com/guiferpa/aurora/blob/main/rfcs/module_system.md). **Ainda não dá nada ao usuário** — `use` passa a parsear e o resolver passa a existir, mas nada resolve um nome nem roda. É o PR com mais código novo dos cinco.

## Os dois commits

**1. Um arquivo diz de quem depende.** `use a/b/c as x;` parseia. Declara em vez de ligar: o alias nomeia um módulo, que é coisa que só o compilador resolve, então ele fica com o `struct` e não com o `ident` — e, como uma declaração de struct, emite o valor neutro e trabalho nenhum.

Um caminho não precisa de token próprio: os segmentos já são identificadores com a divisão no meio, e o parser remonta. O que ele confere é que foram escritos **como uma palavra só** — `a / b` é divisão em todo o resto da linguagem, e ler os mesmos três tokens como caminho faria eles significarem duas coisas conforme a linha. Cursor é offset em bytes, então dois tokens são uma palavra quando o segundo começa onde o primeiro terminou.

Três regras, todas sobre este arquivo e nenhuma sobre outro: alias obrigatório (a única falta que ganhou mensagem própria — o resto é token no lugar errado, e o `EatToken` já diz), alias não declarado duas vezes, e `use` acima de tudo — o topo do arquivo termina no primeiro nó que não é um `use`, e um corpo nunca é o topo.

**2. O resolver diz de que arquivos um programa é feito.** Parte do arquivo que mandaram rodar, lê o que ele diz que precisa, e segue até não sobrar nada. Devolve todo módulo com **dependência antes de dependente**, cada um parseado **uma vez** por mais arquivos que o nomeiem — o que importa porque um módulo é um arquivo que executa, então lê-lo duas vezes o rodaria duas vezes.

`wire/module` veio junto em vez de num commit próprio: um pacote de dados que ninguém lê não compila nada de novo.

## O gate: nada toca em disco

O resolver não abre arquivo. A fonte chega por uma porta `Read` e as árvores por uma porta `Parse` — **o mesmo resolver serve a linha de comando lendo disco e a página no navegador com os arquivos em memória**, que é o que o playground vai precisar (`js/wasm` não tem sistema de arquivos).

Todo teste aqui entrega um mapa. Um teste que precisasse de um diretório em disco estaria dizendo que a porta está no lugar errado.

## O que é recusado

Quatro coisas, todas posicionadas no `use` que as causou, para um editor conseguir sublinhar:

- **módulo que não está lá**, nomeando o arquivo que procurou (`src/a/b.ar`);
- **círculo**, com a **cadeia inteira** (`one → two → three → one`) em vez das duas pontas — um ciclo de quatro se lê seguindo;
- **módulo que importa a si mesmo**, que é a mesma recusa;
- **o programa importando a si mesmo**, que leria a entrada duas vezes sob dois nomes e rodaria o topo dela duas vezes.

## Verificação

`make check` limpo. `make complexity` não acusa nada do código novo. Cobertura do `resolver`: 95.9%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)