### PR TITLE
feat: modules, PR 3 — a name knows which module it belongs to

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,0 +1,89 @@
+// Package loader turns the modules a resolver found into a program.
+//
+// Its first job is the one the last attempt at modules never had: checking that a qualified
+// name is really there. The parser writes `x.add` down as a/b/c.add because the use above it
+// says so, and it cannot know whether a/b/c has an add — only whoever holds every module
+// does, which is here.
+package loader
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Exports is what a module offers whoever imports it: the names it binds with ident at the
+// top of the file, in the order it binds them, as they were typed.
+//
+// A struct is not among them, because a struct does not cross a module. Neither is anything
+// bound inside a block or a deferred body: that lives in an environ which does not exist
+// until the body runs. A defer needs no special case at all — its value is its index, as a
+// tape, so it is already what an ident binds.
+func Exports(m module.Module) []string {
+	names := make([]string, 0, len(m.Tree.Nodes))
+	for _, node := range m.Tree.Nodes {
+		binding, ok := node.(ast.IdentLiteral)
+		if !ok {
+			continue
+		}
+		names = append(names, m.Symbol(binding.Id))
+	}
+	return names
+}
+
+// Check answers whether every qualified name in every module is really there.
+//
+// It reads the whole set rather than one module at a time because a reference points sideways:
+// the file that wrote it and the file that has to have the name are two different ones.
+func Check(modules []module.Module) error {
+	offered := make(map[module.ID]map[string]bool, len(modules))
+	for _, each := range modules {
+		names := make(map[string]bool)
+		for _, name := range Exports(each) {
+			names[name] = true
+		}
+		offered[each.ID] = names
+	}
+
+	for _, each := range modules {
+		for _, reference := range each.Tree.References {
+			if err := check(reference, offered); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+// check reads one qualified name against what its module offers.
+func check(reference ast.Reference, offered map[module.ID]map[string]bool) error {
+	id := module.ID(reference.Module)
+	names, loaded := offered[id]
+	if !loaded {
+		return token.NewError(reference.Token, "module %s was never loaded at line %d and column %d",
+			reference.Module, reference.Token.GetLine(), reference.Token.GetColumn())
+	}
+	if names[reference.Symbol] {
+		return nil
+	}
+	return token.NewError(reference.Token, "module %s has no %s at line %d and column %d (it has %s)",
+		reference.Module, reference.Symbol, reference.Token.GetLine(), reference.Token.GetColumn(), listing(names))
+}
+
+// listing names what a module does offer, so the message is enough to fix the line with. The
+// order is the map's, so it is sorted: a message that changed between two runs of the same
+// compiler would be worse than one that reads out of order.
+func listing(names map[string]bool) string {
+	if len(names) == 0 {
+		return "nothing"
+	}
+	offered := make([]string, 0, len(names))
+	for name := range names {
+		offered = append(offered, name)
+	}
+	slices.Sort(offered)
+	return strings.Join(offered, ", ")
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,0 +1,184 @@
+package loader
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// The whole path, in memory: the resolver finds the files, the parser writes each module's
+// names with the module in front of them, and the check here says whether a qualified name
+// is really there. Nothing touches a disk.
+func load(t *testing.T, sources map[string]string) ([]module.Module, error) {
+	t.Helper()
+
+	return resolver.New(resolver.Options{
+		SourceRoot: "src",
+		Read: func(path string) ([]byte, error) {
+			source, ok := sources[path]
+			if !ok {
+				return nil, fmt.Errorf("no such file")
+			}
+			return []byte(source), nil
+		},
+		Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+			tokens, err := lexer.New().GetFilledTokens(source)
+			if err != nil {
+				return ast.AST{}, err
+			}
+			return parser.New().Parse(parser.ParseInput{
+				Filename: filename,
+				Tokens:   tokens,
+				Module:   string(id),
+			})
+		},
+	}).Resolve("src/main.ar")
+}
+
+// What a module offers is what it binds at the top, under the name its own file typed.
+func TestWhatAModuleOffers(t *testing.T) {
+	modules, err := load(t, map[string]string{
+		"src/main.ar": "use a/b as x;\nprintd x.area(2, 3);",
+		"src/a/b.ar": "struct Point { x, y };\n" +
+			"ident base = 10;\n" +
+			"ident area = defer { ident inner = 1; feed(0) * feed(1); };\n" +
+			"printd 1;",
+	})
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	got := Exports(modules[0])
+	want := []string{"base", "area"}
+	if len(got) != len(want) {
+		t.Fatalf("exports = %q, want %q", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("exports = %q, want %q", got, want)
+		}
+	}
+}
+
+// The name a module binds and the name another file asks for are the same text, which is the
+// whole of the binding: two files arriving at one string.
+func TestAQualifiedNameIsTheNameTheModuleBound(t *testing.T) {
+	modules, err := load(t, map[string]string{
+		"src/main.ar": "use a/b as x;\nprintd x.area(2, 3);",
+		"src/a/b.ar":  "ident area = defer { feed(0) * feed(1); };",
+	})
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if err := Check(modules); err != nil {
+		t.Fatalf("checking: %v", err)
+	}
+
+	binding, ok := modules[0].Tree.Nodes[0].(ast.IdentLiteral)
+	if !ok {
+		t.Fatalf("the module binds %T", modules[0].Tree.Nodes[0])
+	}
+	if binding.Id != "a/b.area" {
+		t.Errorf("the module bound %q, want %q", binding.Id, "a/b.area")
+	}
+
+	references := modules[1].Tree.References
+	if len(references) != 1 {
+		t.Fatalf("the entry read %d qualified names, want 1", len(references))
+	}
+	if got := references[0].Name(); got != binding.Id {
+		t.Errorf("the entry asked for %q and the module bound %q", got, binding.Id)
+	}
+}
+
+// The entry keeps the names it typed, so nothing that exists today is written differently.
+func TestTheEntryIsNotPrefixed(t *testing.T) {
+	modules, err := load(t, map[string]string{
+		"src/main.ar": "use a/b as x;\nident base = 3;\nprintd base;",
+		"src/a/b.ar":  "ident base = 10;",
+	})
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	entry := modules[len(modules)-1]
+	if !entry.IsEntry() {
+		t.Fatal("the last module is not the entry")
+	}
+	if binding := entry.Tree.Nodes[1].(ast.IdentLiteral); binding.Id != "base" {
+		t.Errorf("the entry bound %q, want %q", binding.Id, "base")
+	}
+	// And the two files binding the same word are two different names, which is what lets
+	// them share one environ.
+	if binding := modules[0].Tree.Nodes[0].(ast.IdentLiteral); binding.Id != "a/b.base" {
+		t.Errorf("the module bound %q, want %q", binding.Id, "a/b.base")
+	}
+}
+
+// A name that is not there is refused where it was asked for, saying what is.
+func TestANameThatIsNotThere(t *testing.T) {
+	modules, err := load(t, map[string]string{
+		"src/main.ar": "use a/b as x;\nprintd x.perimeter(2, 3);",
+		"src/a/b.ar":  "ident base = 10;\nident area = defer { feed(0); };",
+	})
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+
+	err = Check(modules)
+	if err == nil {
+		t.Fatal("expected a refusal")
+	}
+	for _, want := range []string{"module a/b has no perimeter", "it has area, base"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error = %q, want it to say %q", err, want)
+		}
+	}
+	positioned, ok := err.(*token.Error)
+	if !ok {
+		t.Fatalf("error is %T, want a positioned *token.Error so an editor can underline it", err)
+	}
+	if positioned.Line != 2 {
+		t.Errorf("error is at line %d, want the line the name was asked on", positioned.Line)
+	}
+}
+
+// A module that offers nothing says so, rather than listing an empty list.
+func TestAModuleThatOffersNothing(t *testing.T) {
+	modules, err := load(t, map[string]string{
+		"src/main.ar": "use a/b as x;\nprintd x.area(1);",
+		"src/a/b.ar":  "printd 1;",
+	})
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if err := Check(modules); err == nil || !strings.Contains(err.Error(), "it has nothing") {
+		t.Errorf("error = %v, want it to say the module has nothing", err)
+	}
+}
+
+// A reference to a module nobody loaded cannot come out of a resolved program, so it is built
+// by hand — the check is what stands between a mistake upstream and a name resolving to
+// whatever happens to be around at run time.
+func TestAReferenceToAModuleThatWasNeverLoaded(t *testing.T) {
+	at := token.New([]byte("add"), token.TagId, 3, 7, 20)
+	modules := []module.Module{{
+		ID: "",
+		Tree: ast.AST{
+			Filename:   "main.ar",
+			References: []ast.Reference{{Module: "a/b", Symbol: "add", Token: at}},
+		},
+	}}
+
+	err := Check(modules)
+	if err == nil || !strings.Contains(err.Error(), "never loaded") {
+		t.Errorf("error = %v, want it to say the module was never loaded", err)
+	}
+}

--- a/parser/module.go
+++ b/parser/module.go
@@ -1,0 +1,47 @@
+package parser
+
+import (
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// How a name is written down, which is not always how it was typed.
+//
+// Inside a module every identifier carries the module in front of it: in a/b/c, `ident base`
+// is written a/b/c.base. It is a constant renaming of the file's own names, so nothing here
+// needs to know what is a binding and what is a mention — every one of them is renamed the
+// same way, and they go on finding each other.
+//
+// Two things come out of it. Two modules binding the same word are two different names, which
+// is what lets them share one environ at run time. And the name says which module it belongs
+// to, which is what the second hop of a lookup follows: see rfcs/module_system.md.
+
+// name is what an identifier is called in the program. The file somebody asked to run has no
+// module, and its names are written as they were typed.
+func (p *pr) name(text string) string {
+	if p.module == "" {
+		return text
+	}
+	return p.module + "." + text
+}
+
+// typed is what an identifier says in the file, which is what a struct name and an alias are
+// looked up by: neither ever reaches an instruction, and neither leaves the file.
+func typed(id ast.IdentifierLiteral) string {
+	return string(id.Token.GetMatch())
+}
+
+// parseMember reads what comes after the dot when the head is a module alias.
+//
+// What comes out is an ordinary identifier under the name the module itself writes, so
+// everything downstream — a call, a load, the environ — goes on treating it as any other
+// name. The alias is gone by then: it belonged to this file and to nothing else.
+func (p *pr) parseMember(specifier, symbol string, at token.Token) (ast.Node, error) {
+	p.references = append(p.references, ast.Reference{Module: specifier, Symbol: symbol, Token: at})
+
+	qualified := ast.IdentifierLiteral{Value: specifier + "." + symbol, Token: at}
+	if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.O_PAREN {
+		return p.ParseCallee(qualified)
+	}
+	return qualified, nil
+}

--- a/parser/module_test.go
+++ b/parser/module_test.go
@@ -1,0 +1,172 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// parseIn compiles source as the given module, which is what decides how the names in it are
+// written down.
+func parseIn(t *testing.T, source, name string) (ast.AST, error) {
+	t.Helper()
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		return ast.AST{}, err
+	}
+	return New().Parse(ParseInput{Filename: "main.ar", Tokens: tokens, Module: name})
+}
+
+func mustParseIn(t *testing.T, source, name string) ast.AST {
+	t.Helper()
+	tree, err := parseIn(t, source, name)
+	if err != nil {
+		t.Fatalf("parsing %q as %s: %v", source, name, err)
+	}
+	return tree
+}
+
+// Inside a module every name carries the module in front of it — binding and mention alike,
+// which is what lets them go on finding each other.
+func TestNamesInAModuleCarryIt(t *testing.T) {
+	tree := mustParseIn(t, "ident base = 10;\nprintd base;", "a/b")
+
+	binding, ok := tree.Nodes[0].(ast.IdentLiteral)
+	if !ok {
+		t.Fatalf("the first node is %T", tree.Nodes[0])
+	}
+	if binding.Id != "a/b.base" {
+		t.Errorf("bound %q, want %q", binding.Id, "a/b.base")
+	}
+
+	printed, ok := tree.Nodes[1].(ast.PrintStatement)
+	if !ok {
+		t.Fatalf("the second node is %T", tree.Nodes[1])
+	}
+	mention, ok := printed.Param.(ast.IdentifierLiteral)
+	if !ok {
+		t.Fatalf("what is printed is %T", printed.Param)
+	}
+	if mention.Value != "a/b.base" {
+		t.Errorf("mentioned %q, want %q", mention.Value, "a/b.base")
+	}
+}
+
+// The file somebody asked to run has no module, and its names are written as they were typed.
+// It is what keeps every program that exists today compiling to the same instructions.
+func TestNamesWithoutAModuleAreWhatWasTyped(t *testing.T) {
+	tree := mustParseIn(t, "ident base = 10;", "")
+	if binding := tree.Nodes[0].(ast.IdentLiteral); binding.Id != "base" {
+		t.Errorf("bound %q, want %q", binding.Id, "base")
+	}
+}
+
+// A qualified name is written the way the module writes it, and the alias is gone by then.
+func TestAQualifiedNameIsWrittenAsTheModuleWritesIt(t *testing.T) {
+	tree := mustParseIn(t, "use a/b as x;\nprintd x.area(2, 3);", "")
+
+	printed := tree.Nodes[1].(ast.PrintStatement)
+	call, ok := printed.Param.(ast.CalleeLiteral)
+	if !ok {
+		t.Fatalf("what is printed is %T, want a call", printed.Param)
+	}
+	if call.Id.Value != "a/b.area" {
+		t.Errorf("called %q, want %q", call.Id.Value, "a/b.area")
+	}
+	if len(call.Params) != 2 {
+		t.Errorf("called with %d values, want 2", len(call.Params))
+	}
+}
+
+// Reaching a name without calling it is the same name.
+func TestAQualifiedNameWithoutACall(t *testing.T) {
+	tree := mustParseIn(t, "use a/b as x;\nprintd x.base;", "")
+	printed := tree.Nodes[1].(ast.PrintStatement)
+	mention, ok := printed.Param.(ast.IdentifierLiteral)
+	if !ok {
+		t.Fatalf("what is printed is %T, want a name", printed.Param)
+	}
+	if mention.Value != "a/b.base" {
+		t.Errorf("read %q, want %q", mention.Value, "a/b.base")
+	}
+}
+
+// Every qualified name leaves with the tree, because only whoever holds the other modules can
+// say whether it is really there.
+func TestQualifiedNamesLeaveWithTheTree(t *testing.T) {
+	tree := mustParseIn(t, "use a/b as x;\nuse c as y;\nprintd x.area(1) + y.n;", "")
+
+	if len(tree.References) != 2 {
+		t.Fatalf("read %d qualified names, want 2: %+v", len(tree.References), tree.References)
+	}
+	for i, want := range []ast.Reference{{Module: "a/b", Symbol: "area"}, {Module: "c", Symbol: "n"}} {
+		got := tree.References[i]
+		if got.Module != want.Module || got.Symbol != want.Symbol {
+			t.Errorf("reference %d = %s.%s, want %s.%s", i, got.Module, got.Symbol, want.Module, want.Symbol)
+		}
+		if got.Token == nil {
+			t.Errorf("reference %d carries no token, so nothing can point at it", i)
+		}
+		if got.Name() != want.Module+"."+want.Symbol {
+			t.Errorf("reference %d is called %q", i, got.Name())
+		}
+	}
+}
+
+// A struct is still a struct inside a module: its name never reaches an instruction and never
+// leaves the file, so it is read as it was typed while everything around it is renamed.
+func TestAStructInsideAModule(t *testing.T) {
+	tree := mustParseIn(t, "struct Point { x, y };\nident p = Point{1, 2};\nprintd p.y;", "a/b")
+
+	if binding := tree.Nodes[1].(ast.IdentLiteral); binding.Id != "a/b.p" {
+		t.Errorf("bound %q, want %q", binding.Id, "a/b.p")
+	}
+	printed := tree.Nodes[2].(ast.PrintStatement)
+	field, ok := printed.Param.(ast.FieldExpression)
+	if !ok {
+		t.Fatalf("what is printed is %T, want a field", printed.Param)
+	}
+	if field.Index != 1 {
+		t.Errorf("read field %d, want 1", field.Index)
+	}
+}
+
+// And it is named as it was typed when something goes wrong with it.
+func TestAStructIsNamedAsItWasTyped(t *testing.T) {
+	_, err := parseIn(t, "struct Point { x, y };\nprintd Point;", "a/b")
+	if err == nil {
+		t.Fatal("expected a compile error")
+	}
+	if !strings.Contains(err.Error(), "Point is a struct") || strings.Contains(err.Error(), "a/b.Point") {
+		t.Errorf("error = %q, want it to name the struct as it was typed", err)
+	}
+}
+
+// What an alias is not.
+func TestAnAliasIsNotAValueAndNotAName(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"printed", "use a/b as x;\nprintd x;", "x is the module a/b"},
+		{"added", "use a/b as x;\nprintd x + 1;", "x is the module a/b"},
+		{"bound over", "use a/b as x;\nident x = 1;", "x is already the alias of a/b"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseIn(t, tc.source, "")
+			if err == nil {
+				t.Fatal("expected a compile error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to say %q", err, tc.want)
+			}
+			if positioned, ok := err.(*token.Error); !ok || positioned.Line == 0 {
+				t.Errorf("error is %T and unpositioned", err)
+			}
+		})
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -39,6 +39,12 @@ type ParseInput struct {
 	// session, and answers for files of different projects — and for the same project after
 	// its manifest is edited, which has to reach the next keystroke.
 	TapeSize int
+	// Module is the module this file is, and it decides what the names inside it are called:
+	// inside a/b/c, `ident base` is written a/b/c.base, so two modules binding the same word
+	// are two different names. Empty is the file somebody asked to run, whose names are
+	// written as they were typed — which is every file compiled on its own, the language
+	// server and the REPL included.
+	Module string
 	// Declarations carries what `struct` and `as` declared across parses of the same file.
 	// Nil starts empty, which is what compiling a file in one go wants; the REPL passes the
 	// same value every line so a struct declared earlier is still known.
@@ -58,6 +64,10 @@ type pr struct {
 	// useAllowed says whether a `use` may still be read: it is true at the start of a file
 	// and false from the first node that is not one, and inside every body.
 	useAllowed bool
+	module     string
+	// references is every qualified name this parse read. It leaves with the tree because
+	// only whoever holds the other modules can say whether the name is really there.
+	references []ast.Reference
 }
 
 // Helper functions to validate node types for tape operations
@@ -113,7 +123,7 @@ func (p *pr) ParseIdentifier() (ast.IdentifierLiteral, error) {
 	if err != nil {
 		return ast.IdentifierLiteral{}, err
 	}
-	return ast.IdentifierLiteral{Value: string(tok.GetMatch()), Token: tok}, nil
+	return ast.IdentifierLiteral{Value: p.name(string(tok.GetMatch())), Token: tok}, nil
 }
 
 func (p *pr) ParseBooleanTrue() (ast.BooleanLiteral, error) {
@@ -250,13 +260,24 @@ func (p *pr) parsePrimaryExpr() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	if _, declared := p.declarations.Structs[id.Value]; declared {
+	// An alias names a module, and a module is not a value: nothing loads under it. Reaching
+	// something inside is the only thing it is for, and that is a dot away.
+	if specifier, isModule := p.declarations.Modules[typed(id)]; isModule {
+		if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.DOT {
+			return id, nil
+		}
+		return nil, token.NewError(id.Token, "%s is the module %s at line %d and column %d: reach something inside it with %s.name",
+			typed(id), specifier, id.Token.GetLine(), id.Token.GetColumn(), typed(id))
+	}
+	// A struct's name never reaches the instructions and never leaves the file, so it is
+	// looked up as it was typed rather than as the module writes it.
+	if _, declared := p.declarations.Structs[typed(id)]; declared {
 		if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.O_CUR_BRK {
 			return p.ParseStructLiteral(id)
 		}
 		// A struct is a declaration, not a value: there is nothing to load under its name.
 		return nil, token.NewError(id.Token, "%s is a struct at line %d and column %d: build a value with %s{...}",
-			id.Value, id.Token.GetLine(), id.Token.GetColumn(), id.Value)
+			typed(id), id.Token.GetLine(), id.Token.GetColumn(), typed(id))
 	}
 	if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.O_PAREN {
 		return p.ParseCallee(id)
@@ -753,6 +774,13 @@ func (p *pr) ParseIdent() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
+	// An alias is a name in this file's scope and follows the rules of every other one, so
+	// binding over it is a redeclaration. It can only happen in this order: a use is read
+	// before anything else in the file.
+	if specifier, ok := p.declarations.Modules[string(id.GetMatch())]; ok {
+		return nil, token.NewError(id, "%s is already the alias of %s at line %d and column %d",
+			id.GetMatch(), specifier, id.GetLine(), id.GetColumn())
+	}
 	if _, err := p.EatToken(token.ASSIGN); err != nil {
 		return nil, err
 	}
@@ -762,10 +790,11 @@ func (p *pr) ParseIdent() (ast.Node, error) {
 	}
 	// Binding a value with a shape carries the shape to the name, so `p.x` reads after
 	// `ident p = feed(0) as Point;`.
+	name := p.name(string(id.GetMatch()))
 	if shape := p.shapeOf(expr); shape != "" {
-		p.declarations.Shapes[string(id.GetMatch())] = shape
+		p.declarations.Shapes[name] = shape
 	}
-	return ast.IdentLiteral{Id: string(id.GetMatch()), Token: id, Value: expr}, nil
+	return ast.IdentLiteral{Id: name, Token: id, Value: expr}, nil
 }
 
 func (p *pr) ParseExpr() (ast.Node, error) {
@@ -964,6 +993,8 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	p.tapeSize = byteutil.TapeSize(in.TapeSize)
 	p.cursor = 0
 	p.useAllowed = true
+	p.module = in.Module
+	p.references = nil
 	p.declarations = in.Declarations
 	if p.declarations == nil {
 		p.declarations = NewDeclarations()
@@ -974,7 +1005,7 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 		return ast.AST{}, err
 	}
 
-	return ast.AST{Filename: p.filename, Nodes: nodes}, nil
+	return ast.AST{Filename: p.filename, Nodes: nodes, References: p.references}, nil
 }
 
 // New builds a parser. It takes nothing: a parser is the same whatever it is asked to read,

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -106,7 +106,7 @@ func (p *pr) ParseStruct() (ast.Node, error) {
 // after a name; declaring a struct called `flag` and testing on it is the one ambiguity left,
 // and it is the same one Go has.
 func (p *pr) ParseStructLiteral(id ast.IdentifierLiteral) (ast.Node, error) {
-	fields := p.declarations.Structs[id.Value]
+	fields := p.declarations.Structs[typed(id)]
 
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
 		return nil, err
@@ -135,10 +135,10 @@ func (p *pr) ParseStructLiteral(id ast.IdentifierLiteral) (ast.Node, error) {
 	// rather than a run padded with the neutral value.
 	if len(values) != len(fields) {
 		return nil, token.NewError(closing, "struct %s has %d fields (%s) but got %d at line %d and column %d",
-			id.Value, len(fields), strings.Join(fields, ", "), len(values), closing.GetLine(), closing.GetColumn())
+			typed(id), len(fields), strings.Join(fields, ", "), len(values), closing.GetLine(), closing.GetColumn())
 	}
 
-	return ast.StructLiteral{Name: id.Value, Values: values, Token: id.Token}, nil
+	return ast.StructLiteral{Name: typed(id), Values: values, Token: id.Token}, nil
 }
 
 // parsePostfix applies what binds tightest of all: reading a field, and naming the shape a
@@ -177,6 +177,14 @@ func (p *pr) parseField(expr ast.Node) (ast.Node, error) {
 		return nil, err
 	}
 	field := string(name.GetMatch())
+
+	// The head decides which of the two things a dot is. An alias is a name in this file's
+	// scope and cannot also be a value, so there is nothing to be ambiguous about.
+	if head, ok := expr.(ast.IdentifierLiteral); ok {
+		if specifier, isModule := p.declarations.Modules[typed(head)]; isModule {
+			return p.parseMember(specifier, field, name)
+		}
+	}
 
 	shape := p.shapeOf(expr)
 	if shape == "" {

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -223,6 +223,28 @@ type AST struct {
 	mark
 	Filename string `json:"filename"`
 	Nodes    []Node `json:"nodes"`
+	// References is every qualified name the file used — `x.add` after `use a/b as x;`.
+	//
+	// It rides alongside the tree instead of in it because it is not shape: the nodes already
+	// carry the name the instruction will hold, and this is the list of what has to be found
+	// somewhere else. Only whoever holds the other modules can answer that, which is why the
+	// parse hands it over instead of deciding.
+	References []Reference `json:"references,omitempty"`
+}
+
+// A Reference is one qualified name, and where it was written.
+type Reference struct {
+	// Module is the module the name belongs to — the specifier, not the alias, because the
+	// alias means nothing outside the file that declared it.
+	Module string      `json:"module"`
+	Symbol string      `json:"symbol"`
+	Token  token.Token `json:"-"`
+}
+
+// Name is what the reference is called in the program: the module in front of the symbol,
+// which is the same text the module itself writes when it binds it.
+func (r Reference) Name() string {
+	return r.Module + "." + r.Symbol
 }
 
 // StructDeclaration names the fields of a run of tapes: `struct Point { x, y };`.

--- a/wire/module/module.go
+++ b/wire/module/module.go
@@ -5,7 +5,11 @@
 // have to name the same thing. Nothing here does any work.
 package module
 
-import "github.com/guiferpa/aurora/wire/ast"
+import (
+	"strings"
+
+	"github.com/guiferpa/aurora/wire/ast"
+)
 
 // An ID is a module's identity: the path it has from the source root, without the extension.
 // `use a/b/c as x;` names the module a/b/c, whoever writes the line and wherever they write
@@ -25,4 +29,14 @@ type Module struct {
 // IsEntry reports whether this is the file that was asked for rather than one it needed.
 func (m Module) IsEntry() bool {
 	return m.ID == ""
+}
+
+// Symbol is a name of this module as the file typed it, with the module taken off the front.
+// It is what somebody writing `x.add` asks for, and what an error about a missing name has to
+// say back to them.
+func (m Module) Symbol(name string) string {
+	if m.IsEntry() {
+		return name
+	}
+	return strings.TrimPrefix(name, string(m.ID)+".")
 }


### PR DESCRIPTION
Terceiro dos cinco do plano em [`rfcs/module_system.md`](https://github.com/guiferpa/aurora/blob/main/rfcs/module_system.md). **Empilhado sobre o #60** — a base é `feat/modules-resolver`, então revise aquele primeiro.

Continua sem dar nada ao usuário: nada roda ainda. Mas o compilador já **recusa** o que está errado, que é a metade que faltou na tentativa antiga.

## Os dois commits

**1. Um nome sabe de que módulo ele é.** Dentro de um módulo todo identificador é escrito com o módulo na frente — em `a/b/c`, `ident base` vira `a/b/c.base`. Ligação e menção igualmente: é uma renomeação constante dos nomes do próprio arquivo, então nada precisa saber o que é topo e o que é escopo interno, e todos continuam se achando. Dois módulos ligando a mesma palavra viram dois nomes diferentes, que é o que vai deixar eles dividirem um environ.

**O arquivo que você mandou rodar não leva prefixo**, e isso não é caso especial por capricho: é o que mantém todo programa que existe hoje compilando para as mesmas instruções — language server e REPL incluídos, já que arquivo compilado sozinho não é módulo de ninguém.

**O `struct` fica de fora.** O nome dele nunca chega numa instrução e nunca sai do arquivo, então é procurado e reportado como foi digitado: `Point is a struct`, não `a/b.Point is a struct`.

**O `.` lê membro de módulo quando a cabeça é um alias**, e campo de struct no resto. Não há ambiguidade: um alias é um nome no escopo do arquivo e não pode ser também um valor. O que sai é um identificador comum sob o nome que o próprio módulo liga — o alias já não existe daí para frente, porque pertencia àquele arquivo e a mais nenhum.

**2. O loader confere que o nome está lá.** O parser escreve `x.add` como `a/b/c.add` porque o `use` acima diz isso, e não tem como saber se `a/b/c` tem um `add`. Só quem segura todos os módulos tem. **Sem isso o nome seria resolvido em runtime, que é onde a camada de namespace antiga morria** — `call: identifier not found`, ou pior, silêncio.

O que um módulo oferece é o que ele liga com `ident` no topo, na ordem em que liga, sob os nomes que o arquivo dele digitou. `struct` não entra (não atravessa módulo), nem nada ligado dentro de bloco ou corpo de `defer` (vive num environ que não existe até aquele corpo rodar). Um `defer` não precisa de caso especial: o valor dele é o índice, como tape, então já é o que um `ident` liga.

## Um desvio do plano

A RFC punha a conferência de **alias colidindo com `ident`** no loader, por achar que o parser não teria como. Tem: o alias já está na tabela quando o `ident` é lido, e `use` só existe acima de tudo — então a colisão só acontece nessa ordem, e o parser recusa com posição, de graça. A RFC previa três commits; viraram dois, porque o prefixo e o `.` são a mesma história e não davam para separar sem partir arquivo no meio.

## Verificação

`make check` limpo, `make complexity` sem nada do código novo. O primeiro commit foi verificado passando sozinho, sem o segundo na árvore.

O teste do loader monta o caminho inteiro em memória — resolver, parser e conferência — e prova o que importa: `a/b.ar` liga `a/b.area`, o `main.ar` pede `a/b.area`, **e são a mesma string**. É nisso que a ligação consiste.

🤖 Generated with [Claude Code](https://claude.com/claude-code)