### PR TITLE
feat: modules, PR 4a — an environ per module, and a name that says where to look

### DIFF
--- a/evaluator/environ/environ.go
+++ b/evaluator/environ/environ.go
@@ -11,6 +11,11 @@ type Environ struct {
 	defers map[string][]byte // key = hex(len at store time), value = blob (from, to, returnKey)
 	temps  map[string][]byte
 	prev   *Environ
+	// modules is where a program's modules keep their names, indexed by the module's own
+	// name. It is born on the environ every chain ends at, because a module's names belong
+	// to the program and not to a scope, and every module environ is handed the same map so
+	// that a body running anywhere can reach it.
+	modules map[string]*Environ
 }
 
 func (e *Environ) Ahead(next *Environ) *Environ {
@@ -45,10 +50,23 @@ func (e *Environ) SetIdent(key string, value []byte) {
 }
 
 func (e *Environ) GetIdent(key string) []byte {
+	if home := e.Holder(key); home != nil {
+		return home.idents[key]
+	}
+	return nil
+}
+
+// Holder answers the environ a name is bound in, from here outwards, and nil when nothing on
+// the chain has it.
+//
+// Which environ it was is worth knowing on its own: a deferred scope is an index counted in
+// the environ that created it, so whoever wants the body has to look for it where the name
+// was found and nowhere else.
+func (e *Environ) Holder(key string) *Environ {
 	curr := e
 	for curr != nil {
-		if c, ok := curr.idents[key]; ok {
-			return c
+		if _, ok := curr.idents[key]; ok {
+			return curr
 		}
 		curr = curr.prev
 	}
@@ -80,6 +98,61 @@ func (e *Environ) GetDefer(key string) []byte {
 		curr = curr.prev
 	}
 	return nil
+}
+
+// GetLocalDefer answers the deferred scope stored here, without walking outwards.
+func (e *Environ) GetLocalDefer(key string) []byte {
+	return e.defers[key]
+}
+
+// Module answers the environ a module keeps its names in, and nil when no module of that name
+// ever ran.
+func (e *Environ) Module(id string) *Environ {
+	return e.index()[id]
+}
+
+// OpenModule answers it too, making it the first time it is asked for. Whoever runs a module's
+// body is what calls this: what that body binds belongs to the module rather than to whatever
+// scope happened to be open.
+//
+// The environ it makes stands on its own, with no chain behind it. A module sees what it
+// declared and what it imported, and nothing of whoever imported it.
+func (e *Environ) OpenModule(id string) *Environ {
+	root := e.root()
+	if root.modules == nil {
+		root.modules = make(map[string]*Environ)
+	}
+	if existing, ok := root.modules[id]; ok {
+		return existing
+	}
+	next := NewEnviron(NewEnvironOptions{})
+	next.modules = root.modules
+	root.modules[id] = next
+	return next
+}
+
+// index answers the module index this environ can reach. A module body runs with its own
+// environ at the head of the chain and a called scope runs at the head of its caller's, so
+// either way the index is somewhere along it.
+func (e *Environ) index() map[string]*Environ {
+	curr := e
+	for curr != nil {
+		if curr.modules != nil {
+			return curr.modules
+		}
+		curr = curr.prev
+	}
+	return nil
+}
+
+// root is the far end of the chain: the environ a program starts in, and where its modules
+// are indexed.
+func (e *Environ) root() *Environ {
+	curr := e
+	for curr.prev != nil {
+		curr = curr.prev
+	}
+	return curr
 }
 
 func (e *Environ) SetArgument(key uint64, value []byte) {

--- a/evaluator/environ/environ_test.go
+++ b/evaluator/environ/environ_test.go
@@ -275,3 +275,86 @@ func TestGetDefer(t *testing.T) {
 		}
 	})
 }
+
+// A module keeps its names in an environ of its own, indexed by the module's name, and asking
+// for it twice is asking for the same one — a module's body runs once and what it bound has
+// to still be there when somebody calls into it.
+func TestOpenModuleAnswersTheSameEnviron(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+
+	first := root.OpenModule("a/b/c")
+	first.SetIdent("k", []byte{7})
+
+	if again := root.OpenModule("a/b/c"); again != first {
+		t.Fatal("opening a module twice made two environs")
+	}
+	if got := root.Module("a/b/c").GetLocalIdent("k"); !bytes.Equal(got, []byte{7}) {
+		t.Errorf("the module holds %v, want the value it bound", got)
+	}
+}
+
+// A module nobody ran is not there, and asking is not a way of making one.
+func TestAModuleThatNeverRan(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+	if got := root.Module("a/b/c"); got != nil {
+		t.Errorf("a module that never ran answered %v", got)
+	}
+}
+
+// The index is reachable from anywhere on a chain, which is what a scope called from another
+// module needs: it runs at the head of its caller's chain, and still has to find its own file.
+func TestTheModuleIndexIsReachableFromAScope(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+	root.OpenModule("a/b/c").SetIdent("k", []byte{7})
+
+	inner := root.Ahead(NewEnviron(NewEnvironOptions{})).Ahead(NewEnviron(NewEnvironOptions{}))
+
+	home := inner.Module("a/b/c")
+	if home == nil {
+		t.Fatal("a scope two levels down cannot reach the module index")
+	}
+	if got := home.GetLocalIdent("k"); !bytes.Equal(got, []byte{7}) {
+		t.Errorf("the module holds %v, want the value it bound", got)
+	}
+}
+
+// A module sees what it declared, and nothing of whoever imported it: its environ stands on
+// its own rather than hanging off the program's.
+func TestAModuleHasNoChainBehindIt(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+	root.SetIdent("outside", []byte{1})
+
+	if got := root.OpenModule("m").GetIdent("outside"); got != nil {
+		t.Errorf("a module read %v from the program that uses it", got)
+	}
+}
+
+// Holder is which environ has the name, which is what a call needs: a deferred scope is an
+// index counted where it was created, so the body is looked for exactly there.
+func TestHolderAnswersWhereANameLives(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+	root.SetIdent("k", []byte{1})
+	inner := root.Ahead(NewEnviron(NewEnvironOptions{}))
+
+	if got := inner.Holder("k"); got != root {
+		t.Error("the name was not found in the environ that has it")
+	}
+	if got := inner.Holder("nothing"); got != nil {
+		t.Errorf("a name nobody bound was found in %v", got)
+	}
+}
+
+// And a deferred scope is not looked for outwards: index 0 of one environ is a different
+// scope from index 0 of another.
+func TestGetLocalDeferDoesNotWalkOutwards(t *testing.T) {
+	root := NewEnviron(NewEnvironOptions{})
+	root.SetDefer("0", []byte{9})
+	inner := root.Ahead(NewEnviron(NewEnvironOptions{}))
+
+	if got := inner.GetLocalDefer("0"); got != nil {
+		t.Errorf("a scope of the environ outside was found: %v", got)
+	}
+	if got := inner.GetDefer("0"); !bytes.Equal(got, []byte{9}) {
+		t.Errorf("walking outwards answered %v, want the scope that is there", got)
+	}
+}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -12,6 +12,7 @@ import (
 	"github.com/guiferpa/aurora/evaluator/environ"
 	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/ir"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // deferMark opens every defer blob. The value handed to a program is an ordinary tape
@@ -360,8 +361,35 @@ func (e *Evaluator) EvaluateSave(label, left, right []byte) error {
 	return nil
 }
 
+// resolve answers what a name is bound to, and the environ it lives in.
+//
+// Two hops. The chain first — every scope open around here, which is what a deferred scope
+// sees of whoever called it, and what has always been the whole of a lookup. Then the environ
+// of the module the name says it belongs to, which is why a name inside a module carries the
+// module in front of it: a scope from another file, running in somebody else's chain, still
+// finds what its own file bound.
+//
+// The environ comes back with the value because a deferred scope is an index counted in the
+// environ that created it. A call has to look for the body where it found the name, and a
+// second module's index 0 is a different scope from the first one's.
+func (e *Evaluator) resolve(name []byte) ([]byte, *environ.Environ) {
+	key := byteutil.ToHex(name)
+	if home := e.environ.Holder(key); home != nil {
+		return home.GetLocalIdent(key), home
+	}
+	id, _, qualified := module.Split(string(name))
+	if !qualified {
+		return nil, nil
+	}
+	home := e.environ.Module(string(id))
+	if home == nil {
+		return nil, nil
+	}
+	return home.GetLocalIdent(key), home
+}
+
 func (e *Evaluator) EvaluateLoad(label, left, right []byte) error {
-	val := e.environ.GetIdent(byteutil.ToHex(left))
+	val, _ := e.resolve(left)
 	if val == nil {
 		return fmt.Errorf("identifier %s not found", left)
 	}
@@ -454,12 +482,12 @@ func (e *Evaluator) EvaluateDefer(label, left, right []byte) error {
 }
 
 func (e *Evaluator) EvaluateCall(label, left, right []byte) error {
-	val := e.environ.GetIdent(byteutil.ToHex(left))
+	val, home := e.resolve(left)
 	if val == nil {
 		return fmt.Errorf("call: %s identifier not found", left)
 	}
 	index := byteutil.ToUint256(val, e.tapeSize).Uint64()
-	blob := e.environ.GetDefer(deferKey(index))
+	blob := home.GetLocalDefer(deferKey(index))
 	if blob == nil {
 		return fmt.Errorf("call: value is not a deferred scope")
 	}
@@ -661,6 +689,27 @@ func (e *Evaluator) EvaluateRange(insts []ir.Instruction, from, to uint64) (eval
 	e.environ.ClearTemps()
 	returns, err := e.ExecuteInstructions(from, to)
 	return returns, err
+}
+
+// EvaluateModule runs one module's range, in the environ that module's names belong to.
+//
+// A program of several files is one stream of instructions, and each module is a range of it
+// — a call reaching across modules lands on a body that has to be there, so the stream is
+// never sliced. What changes from range to range is where the names go: a module binds into
+// an environ of its own, which is what lets two modules bind the same word.
+//
+// The empty name is the file somebody asked to run. It has no environ of its own; it has the
+// one every chain ends at, which is where a program with no modules at all has always run.
+func (e *Evaluator) EvaluateModule(insts []ir.Instruction, from, to uint64, id string) (eval.Returns, error) {
+	if id == "" {
+		return e.EvaluateRange(insts, from, to)
+	}
+
+	outer := e.environ
+	e.environ = outer.OpenModule(id)
+	defer func() { e.environ = outer }()
+
+	return e.EvaluateRange(insts, from, to)
 }
 
 type NewEvaluatorOptions struct {

--- a/evaluator/module_test.go
+++ b/evaluator/module_test.go
@@ -1,0 +1,155 @@
+package evaluator
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// A program of several files, in memory.
+//
+// Each module is compiled on its own and appended to one stream, and each is run as a range
+// of it. That is what the loader will do, written out here so the evaluator can be asked the
+// questions only a program of several modules raises — and the stream is never sliced,
+// because a call crossing a module lands on a body that has to be among the instructions the
+// evaluator is holding.
+
+// file is one module of a program: the name it is known by, and what is in it. The empty name
+// is the file somebody asked to run.
+type file struct {
+	id     string
+	source string
+}
+
+// decimals collects what a program printed, as numbers.
+type decimals struct{ printed *[]uint64 }
+
+func (d decimals) Print(value []byte) ([]byte, error) {
+	*d.printed = append(*d.printed, byteutil.ToUint64(byteutil.Padding64Bits(value)))
+	return value, nil
+}
+
+// runProgram compiles every file, lays them end to end, and runs each as its own range.
+func runProgram(t *testing.T, files ...file) ([]uint64, error) {
+	t.Helper()
+
+	printed := make([]uint64, 0)
+	ev := New(NewEvaluatorOptions{PrintDecimal: decimals{&printed}})
+
+	instructions := make([]ir.Instruction, 0)
+	ranges := make([]file, 0, len(files))
+	bounds := make([][2]uint64, 0, len(files))
+
+	for _, each := range files {
+		tokens, err := lexer.New().GetFilledTokens([]byte(each.source))
+		if err != nil {
+			t.Fatalf("lexer on %q: %v", each.id, err)
+		}
+		tree, err := parser.New().Parse(parser.ParseInput{
+			Filename: each.id + ".ar",
+			Tokens:   tokens,
+			Module:   each.id,
+		})
+		if err != nil {
+			t.Fatalf("parser on %q: %v", each.id, err)
+		}
+		insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
+		if err != nil {
+			t.Fatalf("emitter on %q: %v", each.id, err)
+		}
+
+		from := uint64(len(instructions))
+		instructions = append(instructions, insts...)
+		ranges = append(ranges, each)
+		bounds = append(bounds, [2]uint64{from, uint64(len(instructions))})
+	}
+
+	for i, each := range ranges {
+		if _, err := ev.EvaluateModule(instructions, bounds[i][0], bounds[i][1], each.id); err != nil {
+			return printed, err
+		}
+	}
+	return printed, nil
+}
+
+// Two modules binding the same word are two different names, and a scope from one of them
+// reads its own.
+//
+// This is the example the design was argued on. The module's add sums what it was fed and the
+// base its own file bound, which is 10; the entry feeds it the base it bound itself, which is
+// 3. Answering 7 would mean the imported scope had read the caller's name instead of its own.
+func TestAScopeReadsTheModuleItWasWrittenIn(t *testing.T) {
+	printed, err := runProgram(t,
+		file{"a/b/c", "ident base = 10;\nident add = defer { feed(0) + feed(1) + base; };"},
+		file{"", "use a/b/c as x;\nident base = 3;\nprintd x.add(base, 1);"},
+	)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(printed) != 1 || printed[0] != 14 {
+		t.Errorf("printed %v, want [14] — 7 would mean it read the caller's base", printed)
+	}
+}
+
+// A deferred scope is an index counted in the environ that created it, so two modules both
+// having a first one is the ordinary case and not a collision.
+func TestEachModuleCountsItsOwnDeferredScopes(t *testing.T) {
+	printed, err := runProgram(t,
+		file{"one", "ident f = defer { 1; };"},
+		file{"two", "ident g = defer { 2; };"},
+		file{"", "use one as a;\nuse two as b;\nprintd a.f();\nprintd b.g();"},
+	)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(printed) != 2 || printed[0] != 1 || printed[1] != 2 {
+		t.Errorf("printed %v, want [1 2] — both modules keep a scope at index 0", printed)
+	}
+}
+
+// A call crosses two modules: the entry reaches one, which reaches another.
+func TestAModuleCallsAnother(t *testing.T) {
+	printed, err := runProgram(t,
+		file{"two", "ident double = defer { feed(0) * 2; };"},
+		file{"one", "use two as t;\nident quad = defer { t.double(t.double(feed(0))); };"},
+		file{"", "use one as o;\nprintd o.quad(3);"},
+	)
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(printed) != 1 || printed[0] != 12 {
+		t.Errorf("printed %v, want [12]", printed)
+	}
+}
+
+// And what a module cannot do: read a name from whoever called it. A scope sees the chain of
+// its caller, which is how a deferred scope has always worked, but the names it asks for are
+// its own module's — so the entry's n is not what it finds, and there is nothing else to find.
+func TestAModuleDoesNotReadTheCallersNames(t *testing.T) {
+	_, err := runProgram(t,
+		file{"m", "ident f = defer { n; };"},
+		file{"", "use m as x;\nident n = 5;\nprintd x.f();"},
+	)
+	if err == nil {
+		t.Fatal("expected the name not to be found")
+	}
+	if !strings.Contains(err.Error(), "m.n not found") {
+		t.Errorf("error = %q, want it to say m.n was not found", err)
+	}
+}
+
+// A program of one file runs where it always ran, and is not a module of anything.
+func TestAProgramOfOneFileIsUnchanged(t *testing.T) {
+	printed, err := runProgram(t, file{"", "ident a = 1;\nident f = defer { a + 1; };\nprintd f();"})
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if len(printed) != 1 || printed[0] != 2 {
+		t.Errorf("printed %v, want [2]", printed)
+	}
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -93,7 +93,7 @@ func TestAQualifiedNameIsTheNameTheModuleBound(t *testing.T) {
 	if len(references) != 1 {
 		t.Fatalf("the entry read %d qualified names, want 1", len(references))
 	}
-	if got := references[0].Name(); got != binding.Id {
+	if got := module.Qualify(module.ID(references[0].Module), references[0].Symbol); got != binding.Id {
 		t.Errorf("the entry asked for %q and the module bound %q", got, binding.Id)
 	}
 }

--- a/parser/module.go
+++ b/parser/module.go
@@ -2,6 +2,7 @@ package parser
 
 import (
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -19,10 +20,7 @@ import (
 // name is what an identifier is called in the program. The file somebody asked to run has no
 // module, and its names are written as they were typed.
 func (p *pr) name(text string) string {
-	if p.module == "" {
-		return text
-	}
-	return p.module + "." + text
+	return module.Qualify(module.ID(p.module), text)
 }
 
 // typed is what an identifier says in the file, which is what a struct name and an alias are
@@ -39,7 +37,7 @@ func typed(id ast.IdentifierLiteral) string {
 func (p *pr) parseMember(specifier, symbol string, at token.Token) (ast.Node, error) {
 	p.references = append(p.references, ast.Reference{Module: specifier, Symbol: symbol, Token: at})
 
-	qualified := ast.IdentifierLiteral{Value: specifier + "." + symbol, Token: at}
+	qualified := ast.IdentifierLiteral{Value: module.Qualify(module.ID(specifier), symbol), Token: at}
 	if p.GetLookahead() != nil && p.GetLookahead().GetTag().Id == token.O_PAREN {
 		return p.ParseCallee(qualified)
 	}

--- a/parser/module_test.go
+++ b/parser/module_test.go
@@ -110,9 +110,6 @@ func TestQualifiedNamesLeaveWithTheTree(t *testing.T) {
 		if got.Token == nil {
 			t.Errorf("reference %d carries no token, so nothing can point at it", i)
 		}
-		if got.Name() != want.Module+"."+want.Symbol {
-			t.Errorf("reference %d is called %q", i, got.Name())
-		}
 	}
 }
 

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -241,12 +241,6 @@ type Reference struct {
 	Token  token.Token `json:"-"`
 }
 
-// Name is what the reference is called in the program: the module in front of the symbol,
-// which is the same text the module itself writes when it binds it.
-func (r Reference) Name() string {
-	return r.Module + "." + r.Symbol
-}
-
 // StructDeclaration names the fields of a run of tapes: `struct Point { x, y };`.
 //
 // It declares a shape for whoever writes the source; it is not a value. The compiler reads it to

--- a/wire/module/module.go
+++ b/wire/module/module.go
@@ -31,6 +31,33 @@ func (m Module) IsEntry() bool {
 	return m.ID == ""
 }
 
+// Separator is what stands between a module and a name inside it: a/b/c.add.
+//
+// It is a character no identifier can hold — the lexer takes letters, digits and _ - ? ! > <
+// — so a qualified name is never something anyone could have typed, and reading one back is
+// unambiguous: exactly one of these, and neither side can contain another.
+const Separator = "."
+
+// Qualify writes a name as it is written inside a module. The parser is what calls it, when
+// it decides what an identifier is called.
+func Qualify(id ID, name string) string {
+	if id == "" {
+		return name
+	}
+	return string(id) + Separator + name
+}
+
+// Split reads a qualified name back: which module it belongs to, what it is called there, and
+// whether it belongs to one at all. The evaluator is what calls it, to find where to look
+// when a name is not in the chain.
+func Split(name string) (ID, string, bool) {
+	id, symbol, found := strings.Cut(name, Separator)
+	if !found {
+		return "", name, false
+	}
+	return ID(id), symbol, true
+}
+
 // Symbol is a name of this module as the file typed it, with the module taken off the front.
 // It is what somebody writing `x.add` asks for, and what an error about a missing name has to
 // say back to them.
@@ -38,5 +65,5 @@ func (m Module) Symbol(name string) string {
 	if m.IsEntry() {
 		return name
 	}
-	return strings.TrimPrefix(name, string(m.ID)+".")
+	return strings.TrimPrefix(name, string(m.ID)+Separator)
 }


### PR DESCRIPTION
Quarto do plano em [`rfcs/module_system.md`](https://github.com/guiferpa/aurora/blob/main/rfcs/module_system.md), **cortado em dois** no ponto que a própria RFC previu: aqui está o evaluator, e o loader montando o stream mais o CLI ficam no 4b. Junto, seriam ~800 linhas de diff no lugar mais quente do interpretador — mais do que alguém revisa direito em quarenta minutos.

**Empilhado sobre o #61**, que está sobre o #60. A base é `feat/modules-binding`.

## Os dois commits

**1. Como um nome qualificado é escrito muda de casa.** O parser era o único que sabia que um nome dentro de `a/b/c` se escreve `a/b/c.base`. O evaluator vira o segundo — para achar um nome que não está na cadeia ele precisa ler o módulo de volta de dentro dele —, e duas cópias de uma convenção é como convenções divergem. Vai para `wire/module`, que é para isso que um pacote wire existe.

**2. Um environ por módulo, e a busca de dois saltos.**

A **cadeia primeiro** — todo escopo aberto por aqui, que é o que um `defer` enxerga de quem o chamou. Isso não muda. Depois o **environ do módulo que o nome diz que é dele**, e é por isso que um nome dentro de um módulo carrega o módulo na frente: um escopo de outro arquivo, rodando na cadeia de outra pessoa, continua achando o que o próprio arquivo dele ligou.

É nisso que o desenho se apoia, e tem teste dizendo exatamente isso:

```
a/b/c.ar   ident base = 10;
           ident add  = defer { feed(0) + feed(1) + base; };

main.ar    use a/b/c as x;
           ident base = 3;
           printd x.add(base, 1);
```

Responde **14**. Responder 7 significaria que o escopo importado leu o `base` de quem chamou.

**A chamada agora procura o corpo onde achou o nome.** Um `defer` é um índice contado no environ que o criou, então o índice 0 de um módulo é um escopo diferente do índice 0 de outro — a colisão que a primeira versão da RFC usou como argumento contra dar environ a um módulo, e que desaparece quando a resolução para de subir a cadeia de quem chamou. Isso também deixa o caso de um arquivo só **mais estrito** do que era: um corpo só é achado onde o nome dele vive.

**O environ de um módulo não tem cadeia atrás dele**, então um módulo enxerga o que declarou e o que importou, e nada de quem o importou. Tem teste para isso também: um `defer` do módulo `m` que lê `n` não acha o `n` que a entrada ligou — acha erro.

## O que não muda

`EvaluateRange` manteve a forma e o `EvaluateModule` a embrulha. O nome vazio é o arquivo que você mandou rodar: sem environ próprio, o mesmo em que um programa sem módulo nenhum sempre rodou. **A suíte inteira passou sem nenhum teste existente precisar mudar.**

## Verificação

`make check` limpo, nada do código novo no `make complexity`. O primeiro commit foi verificado passando sozinho.

Os cinco testes de programa com vários módulos montam o stream em memória — compila cada módulo, põe um atrás do outro, roda cada um como faixa — que é o que o loader vai fazer no 4b.

🤖 Generated with [Claude Code](https://claude.com/claude-code)