### PR TITLE
feat: modules, PR 4c — aurora test runs what the test and its source import

### DIFF
--- a/cmd/aurora/test.go
+++ b/cmd/aurora/test.go
@@ -38,6 +38,15 @@ func init() {
 	testCmd.Flags().IntP("tape-size", "t", 0, "bytes per value (1-32, default 8; overrides tape_size from aurora.toml)")
 }
 
+// firstOf answers the file the project is found from, and nothing when there are none to run
+// — in which case no module is ever looked for.
+func firstOf(files []string) string {
+	if len(files) == 0 {
+		return ""
+	}
+	return files[0]
+}
+
 func runTest(cmd *cobra.Command, args []string) error {
 	var target string
 	if len(args) > 0 {
@@ -59,6 +68,9 @@ func runTest(cmd *cobra.Command, args []string) error {
 		Lexer:   lexer.New(),
 		Parser:  parser.New(),
 		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
+		// A test file belongs to a project, and the project says where module names resolve
+		// from — the same answer for the file it tests and for the modules the two import.
+		Resolver: newResolver(size, cli.ProjectSourceRoot(firstOf(files))),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{
 				// A test says what held and what did not; what the program printed on the

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -125,3 +125,67 @@ func TestWhatARefusalSays(t *testing.T) {
 		})
 	}
 }
+
+// A test runs against the source it belongs to and everything the two of them import.
+//
+// The two files are one module written twice, so the test calls what the source declared by
+// the name the source typed, and the module the source brought in answers under its alias.
+func TestATestSeesWhatItsSourceImports(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/geometry.ar":  "ident area = defer { feed(0) * feed(1); };",
+		"src/main.ar":      "use geometry as g;\nident box = defer { g.area(feed(0), feed(1)); };",
+		"src/main.test.ar": "assert(box(3, 4) equals 12, \"a box is its sides multiplied\");",
+	})
+
+	report, err := tested(t, "", sessionOpts{asserts: true})
+	if err != nil {
+		t.Fatalf("testing: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("the run did not pass: %+v", report.Files)
+	}
+	if report.Passed != 1 {
+		t.Errorf("%d assertions held, want 1", report.Passed)
+	}
+}
+
+// And a test names the modules it uses like any other file, including one its source never
+// mentioned.
+func TestATestImportsOnItsOwn(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/numbers.ar":   "ident double = defer { feed(0) * 2; };",
+		"src/main.ar":      "ident v = 21;",
+		"src/main.test.ar": "use numbers as n;\nassert(n.double(v) equals 42, \"doubling what the source bound\");",
+	})
+
+	report, err := tested(t, "", sessionOpts{asserts: true})
+	if err != nil {
+		t.Fatalf("testing: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("the run did not pass: %+v", report.Files)
+	}
+}
+
+// A module that is not there is reported against the file that runs, rather than crashing the
+// whole run.
+func TestATestWhoseModuleIsNotThere(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/main.ar":      "use missing as m;\nident v = 1;",
+		"src/main.test.ar": "assert(v equals 1, \"holds\");",
+	})
+
+	report, err := tested(t, "", sessionOpts{asserts: true})
+	if err != nil {
+		t.Fatalf("testing: %v", err)
+	}
+	if report.OK() {
+		t.Fatal("the run passed with a module that is not there")
+	}
+	if len(report.Files) != 1 || report.Files[0].Err == nil {
+		t.Fatalf("no file reported the refusal: %+v", report.Files)
+	}
+	if got := report.Files[0].Err.Error(); !strings.Contains(got, "module missing is not there") {
+		t.Errorf("the error says %q", got)
+	}
+}

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -13,9 +14,11 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/eval"
-	"github.com/guiferpa/aurora/wire/ir"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // TestExtension marks a test file. A test belongs to the source file of the same name:
@@ -164,16 +167,37 @@ func failedAt(file, source string, err error) error {
 	return fmt.Errorf("%s: %w", filepath.Base(source), err)
 }
 
+// parseFile reads one file and parses it as part of the module somebody asked to run, which
+// is the one with no name of its own.
+func (s *Session) parseFile(file string, declarations *parser.Declarations) (ast.AST, error) {
+	bs, err := os.ReadFile(file)
+	if err != nil {
+		return ast.AST{}, err
+	}
+	tokens, err := s.lexer.GetFilledTokens(bs)
+	if err != nil {
+		return ast.AST{}, err
+	}
+	return s.parser.Parse(parser.ParseInput{
+		Filename:     file,
+		Tokens:       tokens,
+		Declarations: declarations,
+		TapeSize:     s.tapeSize,
+	})
+}
+
 // SourceForTest returns the file a test belongs to: greeting.test.ar -> greeting.ar.
 func SourceForTest(path string) string {
 	return strings.TrimSuffix(path, TestExtension) + SourceExtension
 }
 
-// runTestFile evaluates a test together with the source it belongs to.
+// runTestFile evaluates a test together with the source it belongs to, and everything the
+// two of them import.
 //
-// Both run in one evaluator, so what the source declares is in scope for the test — its
-// bindings and its deferred scopes alike, since the defer counter belongs to the environ.
-// Whatever the source does at its top level happens too, prints included.
+// They are one module written in two files: what the source declares is in scope for the
+// test — its bindings and its deferred scopes alike, since the defer counter belongs to the
+// environ — and neither of them carries a module name, so the names in both are written as
+// they were typed. Whatever the source does at its top level happens too, prints included.
 func (s *Session) runTestFile(path string) FileReport {
 	report := FileReport{Path: path}
 
@@ -187,51 +211,42 @@ func (s *Session) runTestFile(path string) FileReport {
 	}
 
 	// The two files are one scope, so they are one set of declarations: a struct declared in
-	// the source is known in the test. They are parsed apart because each keeps its own name —
-	// which is what decides that assert belongs to the test file — and its own line numbers.
+	// the source is known in the test, and so is a module the source brought in. They are
+	// parsed apart because each keeps its own name — which is what decides that assert
+	// belongs to the test file — and its own line numbers.
+	//
+	// They are also read here rather than by the resolver, which reads the modules: these
+	// two are the file somebody asked for, and there is no name to look them up by.
 	declarations := parser.NewDeclarations()
-
-	// Both programs go into one instruction stream, and each is run as a range of it. A
-	// deferred scope records where its body sits as indexes into the stream, so handing
-	// the evaluator a different slice afterwards would point those indexes at unrelated
-	// instructions — a call would then run whatever happened to be there. The REPL keeps
-	// one buffer across lines for the same reason. Each range clears the temps first,
-	// since the two were emitted separately and both number their labels from zero.
-	instructions := make([]ir.Instruction, 0)
-	boundary := 0
-
+	trees := make([]ast.AST, 0, 2)
 	for _, file := range []string{source, path} {
-		bs, err := os.ReadFile(file)
-		if err != nil {
-			report.Err = err
-			return report
-		}
-
-		tokens, err := s.lexer.GetFilledTokens(bs)
+		tree, err := s.parseFile(file, declarations)
 		if err != nil {
 			report.Err = failedAt(file, source, err)
 			return report
 		}
+		trees = append(trees, tree)
+	}
 
-		tree, err := s.parser.Parse(parser.ParseInput{
-			Filename:     file,
-			Tokens:       tokens,
-			Declarations: declarations,
-			TapeSize:     s.tapeSize,
-		})
-		if err != nil {
-			report.Err = failedAt(file, source, err)
-			return report
-		}
+	// What the two of them import, and then the two of them: one program, with the modules
+	// before what needs them and the test last.
+	if s.resolver == nil {
+		report.Err = errors.New("no resolver was given to this session")
+		return report
+	}
+	modules, err := s.resolver.Dependencies(source, trees...)
+	if err != nil {
+		report.Err = err
+		return report
+	}
+	for _, tree := range trees {
+		modules = append(modules, module.Module{ID: "", Tree: tree})
+	}
 
-		program, err := s.emitter.EmitProgram(tree)
-		if err != nil {
-			report.Err = failedAt(file, source, err)
-			return report
-		}
-
-		boundary = len(instructions)
-		instructions = append(instructions, program.Instructions...)
+	program, err := loader.Load(modules, s.emitter.EmitProgram)
+	if err != nil {
+		report.Err = err
+		return report
 	}
 
 	ev, err := s.evaluator()
@@ -240,12 +255,18 @@ func (s *Session) runTestFile(path string) FileReport {
 		return report
 	}
 
-	if _, err := ev.EvaluateRange(instructions, 0, uint64(boundary)); err != nil {
-		report.Err = fmt.Errorf("%s: %w", source, err)
-		return report
-	}
-	if _, err := ev.EvaluateRange(instructions, uint64(boundary), uint64(len(instructions))); err != nil {
-		report.Err = err
+	// Every range runs, in order, and the last one is the test. A failure before it is a
+	// failure of the code being checked rather than of the check, so it says which file.
+	for i, each := range program.Ranges {
+		_, err := ev.EvaluateModule(program.Instructions, each.From, each.To, string(each.Module))
+		if err == nil {
+			continue
+		}
+		if i < len(program.Ranges)-1 {
+			report.Err = fmt.Errorf("%s: %w", each.Filename, err)
+		} else {
+			report.Err = err
+		}
 		return report
 	}
 

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -68,8 +68,6 @@ type resolution struct {
 // The entry is a path rather than a module name because it is the file somebody asked to
 // run, and it is the one module with no id.
 func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
-	state := &resolution{found: make(map[module.ID]bool), entry: path.Clean(entry)}
-
 	source, err := r.read(entry)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", entry, err)
@@ -78,11 +76,28 @@ func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := r.dependencies(state, tree); err != nil {
+
+	modules, err := r.Dependencies(entry, tree)
+	if err != nil {
 		return nil, err
 	}
+	return append(modules, module.Module{ID: "", Tree: tree}), nil
+}
 
-	return append(state.order, module.Module{ID: "", Tree: tree}), nil
+// Dependencies answers with everything the given trees need, and nothing of the trees
+// themselves.
+//
+// It is for a caller that already has them, which is what "aurora test" is: one module
+// written in two files, neither of which the resolver would have read on its own. Both are
+// asked what they need, because a test names the modules it uses like any other file.
+func (r *Resolver) Dependencies(entry string, trees ...ast.AST) ([]module.Module, error) {
+	state := &resolution{found: make(map[module.ID]bool), entry: path.Clean(entry)}
+	for _, tree := range trees {
+		if err := r.dependencies(state, tree); err != nil {
+			return nil, err
+		}
+	}
+	return state.order, nil
 }
 
 // dependencies resolves every module a tree names, in the order the file names them.


### PR DESCRIPTION
Última parte do PR 4 do plano em [`rfcs/module_system.md`](https://github.com/guiferpa/aurora/blob/main/rfcs/module_system.md). **Empilhado sobre o #63.** Com este, os três comandos que compilam Aurora passam pelo loader.

## O nó

Um teste e a fonte dele são **um módulo escrito em dois arquivos**. Eles dividem um conjunto de declarações — um `struct` ou um alias que a fonte escreveu é conhecido no teste —, e isso só acontece se o mesmo estado de parse atravessar os dois. O `Resolve` lê e parseia a entrada por dentro, então não tinha como.

## Os dois commits

**1. O resolver responde o que uma árvore precisa, para quem já tem uma.** `Dependencies` recebe árvores que alguém já parseou e devolve tudo que elas pedem, e nada delas próprias. `Resolve` passa a ser isso com a leitura e o parse na frente e a entrada anexada atrás — a mesma caminhada, de um ponto de partida diferente.

As **duas** árvores são perguntadas, porque um teste nomeia os módulos que usa como qualquer outro arquivo.

**2. `aurora test` roda o que o teste e a fonte importam.** O que os dois trouxerem é encontrado, carregado uma vez e rodado antes deles. Uma fonte que usa um módulo passa a ser testável, e um teste pode nomear um módulo que a fonte dele nunca mencionou.

Os dois arquivos continuam sendo lidos ali, e não pelo resolver: são os arquivos que **você pediu**, e não há nome de módulo por onde procurá-los — a mesma razão pela qual a entrada de um `run` é lida onde é.

## O que ficou mais simples

Era duas faixas escritas na mão e um `boundary`. Agora são as faixas do loader, e a fonte e o teste são simplesmente as duas últimas. A regra de atribuição de erro continua: uma falha antes da última faixa é falha do código sendo checado, não do check, e diz de que arquivo veio.

## Verificação

`make check` limpo, nada do código novo no `make complexity`.

Três testes novos: um teste chamando o que a fonte declarou, que por sua vez usa um módulo; um teste importando por conta própria um módulo que a fonte nunca citou; e um módulo ausente sendo reportado contra o arquivo que roda em vez de derrubar a execução inteira. O teste que já existia — um `struct` declarado na fonte sendo conhecido no teste — continua passando sem mudança, que é o que diz que a partilha de declarações sobreviveu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)