### PR TITLE
feat: the editor says a module is a module

### DIFF
--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -1,0 +1,111 @@
+package textdoc
+
+import (
+	"slices"
+	"strings"
+
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// What the language server knows about the modules a document brings in, read straight from
+// the tokens for the same reason the structs are: a document being edited is broken most of
+// the time, and `x.` — the moment somebody wants to be told what is inside a module — never
+// parses.
+//
+// It is what one file says and nothing more. Which names a module actually has is a question
+// for whoever holds the other files, and this answers what it can without them: that a name
+// is a module rather than a value, and which module it is.
+
+// moduleAliases is what the use lines declared: the alias, and the module it names.
+type moduleAliases map[string]string
+
+// scanUses reads `use a/b/c as x;` out of a token chain.
+func scanUses(tokens []token.Token) moduleAliases {
+	found := make(moduleAliases)
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].GetTag().Id != token.USE {
+			continue
+		}
+		if alias, specifier, next := readUse(tokens, i); alias != "" {
+			found[alias] = specifier
+			i = next
+		}
+	}
+	return found
+}
+
+// readUse reads one declaration starting at the use token: the path it names, and the alias
+// it is reached by. A half-written line answers with nothing, which is the common case while
+// somebody is typing one.
+func readUse(tokens []token.Token, i int) (string, string, int) {
+	specifier := ""
+	for j := i + 1; j < len(tokens); j++ {
+		switch tokens[j].GetTag().Id {
+		case token.ID:
+			specifier += string(tokens[j].GetMatch())
+		case token.DIV:
+			specifier += "/"
+		case token.AS:
+			if specifier == "" || j+1 >= len(tokens) || tokens[j+1].GetTag().Id != token.ID {
+				return "", "", j
+			}
+			return string(tokens[j+1].GetMatch()), specifier, j + 1
+		default:
+			return "", "", j
+		}
+	}
+	return "", "", len(tokens) - 1
+}
+
+// moduleBefore answers the module a dot at this offset reaches into, when what sits in front
+// of it is an alias.
+func (m moduleAliases) moduleBefore(tokens []token.Token, offset int) (string, bool) {
+	owner := ownerBefore(tokens, offset)
+	if owner == nil {
+		return "", false
+	}
+	specifier, ok := m[string(owner.GetMatch())]
+	return specifier, ok
+}
+
+// describe answers what hover has to say about a token, when what it has to say is about a
+// module: the alias itself, or a name being reached through one.
+func (m moduleAliases) describe(tokens []token.Token, subject token.Token) string {
+	name := string(subject.GetMatch())
+	if specifier, ok := m[name]; ok {
+		return "module " + specifier + "\nreach what is inside it with " + name + ".name"
+	}
+
+	// Tokens are compared by where they start: the concrete type holds slices and cannot be
+	// compared with ==.
+	for i, t := range tokens {
+		if t.GetCursor() != subject.GetCursor() || i < 2 || tokens[i-1].GetTag().Id != token.DOT {
+			continue
+		}
+		owner := tokens[i-2]
+		if owner.GetTag().Id != token.ID {
+			continue
+		}
+		if specifier, ok := m[string(owner.GetMatch())]; ok {
+			return name + "\nof module " + specifier
+		}
+	}
+	return ""
+}
+
+// moduleCompletions offers the aliases a document declared, said to be modules rather than
+// values: what follows one is a dot, and never anything a value would take.
+func moduleCompletions(aliases moduleAliases) []CompletionItem {
+	items := make([]CompletionItem, 0, len(aliases))
+	for alias, specifier := range aliases {
+		items = append(items, CompletionItem{
+			Label:  alias,
+			Detail: "module " + specifier,
+			Kind:   Module,
+		})
+	}
+	slices.SortFunc(items, func(a, b CompletionItem) int {
+		return strings.Compare(a.Label, b.Label)
+	})
+	return items
+}

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -1,0 +1,130 @@
+package textdoc
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+)
+
+// What one file says about the modules it brings in, which is all the editor knows: that a
+// name is a module rather than a value, and which module it is. What is inside one lives in
+// another file, and nothing here has read it.
+
+const withModules = "use a/b as x;\nuse other as y;\nident n = 1;\nprintd x.area(n);\n"
+
+// A use line is read out of the tokens, so it is read while the document is broken too — and
+// a half-written one says nothing rather than something wrong.
+func TestScanUses(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   map[string]string
+	}{
+		{
+			name:   "one module",
+			source: "use a/b/c as x;",
+			want:   map[string]string{"x": "a/b/c"},
+		},
+		{
+			name:   "several, and a path of one segment",
+			source: "use a/b as x;\nuse other as y;",
+			want:   map[string]string{"x": "a/b", "y": "other"},
+		},
+		{
+			name:   "still being typed",
+			source: "use a/b",
+			want:   map[string]string{},
+		},
+		{
+			name:   "typed as far as the alias",
+			source: "use a/b as ",
+			want:   map[string]string{},
+		},
+		{
+			name:   "a document with none",
+			source: "ident a = 1;",
+			want:   map[string]string{},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := scanUses(session().Analyze(Document{Filename: "main.ar", Source: tc.source}).Tokens)
+			if len(got) != len(tc.want) {
+				t.Fatalf("read %v, want %v", got, tc.want)
+			}
+			for alias, specifier := range tc.want {
+				if got[alias] != specifier {
+					t.Errorf("alias %s means %q, want %q", alias, got[alias], specifier)
+				}
+			}
+		})
+	}
+}
+
+// An alias is a module, and saying "identifier" about it was the wrong answer it used to give.
+func TestHoverOnAModule(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		pos  lsp.Position
+		want string
+	}{
+		{name: "the alias", pos: lsp.Position{Line: 3, Character: 7}, want: "module a/b"},
+		{name: "a name reached through it", pos: lsp.Position{Line: 3, Character: 10}, want: "of module a/b"},
+		{name: "an ordinary name is untouched", pos: lsp.Position{Line: 3, Character: 14}, want: "identifier: n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := session().HoverInfo(Document{Filename: "main.ar", Source: withModules}, tc.pos)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("hover = %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// After a dot on a module, the editor has nothing to offer — and offering the keywords, which
+// is what it did, is offering the one thing that certainly cannot go there.
+func TestCompletionAfterAModuleDot(t *testing.T) {
+	source := "use a/b as x;\nprintd x.\n"
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 1, Character: 9}, false)
+
+	if len(items) != 0 {
+		t.Errorf("offered %d items after a module dot, want none: %+v", len(items), items)
+	}
+}
+
+// A struct still answers with its fields after a dot, which is the other reader of the same
+// question.
+func TestCompletionAfterAStructDotStillWorks(t *testing.T) {
+	source := "struct Point { x, y };\nident p = Point{1, 2};\nprintd p.\n"
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 9}, false)
+
+	if len(items) != 2 {
+		t.Fatalf("offered %d items, want the two fields: %+v", len(items), items)
+	}
+	if items[0].Label != "x" || items[1].Label != "y" {
+		t.Errorf("offered %q and %q, want x and y", items[0].Label, items[1].Label)
+	}
+}
+
+// And the aliases themselves are offered, as modules rather than as values.
+func TestCompletionOffersTheModules(t *testing.T) {
+	items := session().CompletionItemsFor(Document{Filename: "main.ar", Source: withModules}, lsp.Position{Line: 2, Character: 0}, false)
+
+	found := make(map[string]CompletionItem)
+	for _, item := range items {
+		found[item.Label] = item
+	}
+	for alias, specifier := range map[string]string{"x": "a/b", "y": "other"} {
+		item, ok := found[alias]
+		if !ok {
+			t.Errorf("the alias %s was not offered", alias)
+			continue
+		}
+		if item.Kind != Module {
+			t.Errorf("the alias %s is offered as kind %d, want a module", alias, item.Kind)
+		}
+		if !strings.Contains(item.Detail, specifier) {
+			t.Errorf("the alias %s is described as %q, want it to name %s", alias, item.Detail, specifier)
+		}
+	}
+}

--- a/hosting/lsp/textdoc/structs.go
+++ b/hosting/lsp/textdoc/structs.go
@@ -97,6 +97,17 @@ func readBinding(tokens []token.Token, i int) (string, string) {
 // cursor is a dot on a value whose shape is known. Anything else gives nothing, and the
 // caller falls back to the ordinary list.
 func (s structShapes) fieldsBefore(tokens []token.Token, offset int) []string {
+	owner := ownerBefore(tokens, offset)
+	if owner == nil {
+		return nil
+	}
+	return s.fields[s.shapes[string(owner.GetMatch())]]
+}
+
+// ownerBefore answers the name a dot at this offset hangs off, and nil when there is no dot
+// there. Both readers of a dot ask it — a struct to offer its fields, a module to say that
+// what follows is not a field at all.
+func ownerBefore(tokens []token.Token, offset int) token.Token {
 	// The token being typed may already have started, so walk back over it first.
 	i := len(tokens) - 1
 	for ; i >= 0; i-- {
@@ -119,7 +130,7 @@ func (s structShapes) fieldsBefore(tokens []token.Token, offset int) []string {
 	if owner.GetTag().Id != token.ID {
 		return nil
 	}
-	return s.fields[s.shapes[string(owner.GetMatch())]]
+	return owner
 }
 
 // structAt describes the struct a token belongs to, for hover: the declaration itself, or a

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -174,6 +174,10 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 	case token.TRUE, token.FALSE:
 		return "boolean: " + match
 	case token.ID:
+		// A module is not a value, so it is answered for before anything looks for one.
+		if info := scanUses(analysis.Tokens).describe(analysis.Tokens, tk); info != "" {
+			return info
+		}
 		// A struct name or a field read out of one: the declaration is what says these are
 		// anything other than a name, so it is what hover has to answer with.
 		if shape, fields, index := scanStructs(analysis.Tokens).structAt(analysis.Tokens, tk); shape != "" {
@@ -206,8 +210,17 @@ func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bo
 
 	// Right after a dot the fields are the answer, and the only one: nothing else can
 	// follow it.
-	if fields := shapes.fieldsBefore(analysis.Tokens, analysis.Mapper.Offset(pos)); len(fields) > 0 {
+	offset := analysis.Mapper.Offset(pos)
+	if fields := shapes.fieldsBefore(analysis.Tokens, offset); len(fields) > 0 {
 		return fieldCompletions(fields)
+	}
+
+	// After a dot on a module alias, what can follow is what that module declared — which is
+	// in another file, and nothing here has read it. Offering the keywords instead would be
+	// offering the one thing that certainly cannot go there.
+	aliases := scanUses(analysis.Tokens)
+	if _, isModule := aliases.moduleBefore(analysis.Tokens, offset); isModule {
+		return []CompletionItem{}
 	}
 
 	items := make([]CompletionItem, 0)
@@ -215,6 +228,7 @@ func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bo
 		items = append(items, keywordCompletion(tag, snippets))
 	}
 	items = append(items, structCompletions(shapes, snippets)...)
+	items = append(items, moduleCompletions(aliases)...)
 
 	if analysis.AST == nil {
 		return items


### PR DESCRIPTION
A camada 1 do que conversamos: **o que um arquivo já sabe sozinho**. Nenhum outro arquivo é lido aqui.

Três respostas do editor sobre módulos estavam **erradas**, não apenas faltando:

| Onde | Respondia | Responde |
|---|---|---|
| hover num alias | `identifier: x` | `module a/b` |
| hover num nome alcançado por ele | `identifier: add` | `add`, `of module a/b` |
| completar depois de `x.` | toda palavra-chave, todo struct, todo nome do arquivo | nada |

A do completar é a que mais incomodava: depois de um ponto num módulo, **o que pode vir é o que aquele módulo declarou** — e o editor oferecia justamente a única coisa que certamente não pode ir ali. Oferecer nada é honesto; oferecer `ident`, `if`, `defer` não é.

Os aliases também passam a ser oferecidos, como **módulos** e não como valores (`CompletionItemKind.Module`, que já existia e ninguém usava).

## Lido dos tokens, como os structs

Pelo mesmo motivo que `scanStructs` existe: um documento sendo editado está quebrado a maior parte do tempo, e `x.` — o exato momento em que alguém quer ser informado do que tem dentro de um módulo — **nunca parseia**. Uma linha `use` pela metade responde nada, em vez de responder algo errado.

## Uma simplificação que veio junto

"O que está antes do ponto" era uma caminhada de vinte linhas dentro de `fieldsBefore`. Agora é `ownerBefore`, uma função, com dois leitores: um struct que quer oferecer os campos dele, e um módulo que quer dizer que o que vem depois não é campo nenhum.

## O playground ganha tudo isso

Ele pergunta para a mesma `textdoc.Session` que o editor (`cmd/playground/analysis.go:76`), então hover e completar na página melhoram sem uma linha de JavaScript.

## O que continua precisando do resolver

O que precisa de outro arquivo: **que o módulo exista**, que ele **tenha mesmo o nome** que está sendo pedido, e **o que oferecer depois do ponto**. Isso é a camada 2, e continua sendo trabalho próprio — resolver a cada tecla significa ler e parsear todo dependente por análise, então pede cache com invalidação, e é a primeira vez que o language server olha para fora de um arquivo.

## Verificação

`make check` limpo. `make complexity` só acusa um teste que já era longo antes (`TestSemanticTokens`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)