### PR TITLE
fix: use had no colour

### DIFF
--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -129,12 +129,17 @@ func collectSemanticTokens(mapper *lsp.Mapper, tokens []token.Token) []semanticT
 
 // semanticTypeOf maps a lexer tag to a tk type. Tags with no visual meaning
 // (whitespace, line breaks, EOF, punctuation) report false and are skipped.
+//
+// The list of keywords is written out rather than derived, because being a keyword is not
+// the same question as being coloured as one: and and or are keywords the lexer knows and
+// operators to whoever reads them. What a list like this drifts from is the lexer, so a test
+// asks the lexer for every keyword it knows and requires each to be coloured as something.
 func semanticTypeOf(tag string) (int, bool) {
 	switch tag {
 	case token.IDENT, token.IF, token.ELSE, token.BRANCH, token.DEFER,
 		token.PRINTB, token.PRINTC, token.PRINTD, token.ASSERT, token.FEED,
 		token.HEAD, token.TAIL, token.PUSH, token.PULL, token.TRUE, token.FALSE,
-		token.STRUCT, token.AS:
+		token.STRUCT, token.AS, token.USE:
 		return SemanticKeyword, true
 	case token.NUMBER:
 		return SemanticNumber, true

--- a/hosting/lsp/textdoc/semantic_tokens_test.go
+++ b/hosting/lsp/textdoc/semantic_tokens_test.go
@@ -1,6 +1,7 @@
 package textdoc
 
 import (
+	"github.com/guiferpa/aurora/lexer"
 	"reflect"
 	"testing"
 )
@@ -118,5 +119,20 @@ func TestSemanticTokensDataIsWellFormed(t *testing.T) {
 	data := session().SemanticTokensFor("ident a = 1;\n#- note\nprintb a;\n")
 	if len(data)%5 != 0 {
 		t.Fatalf("data length %d is not a multiple of 5", len(data))
+	}
+}
+
+// Every keyword the lexer knows is coloured as something.
+//
+// The list in semanticTypeOf is written by hand, so it drifts the moment the language gains a
+// word — which is exactly what happened when "use" arrived: it lexed as a keyword, hovered
+// with its description, and stayed the colour of ordinary text. Not every keyword is coloured
+// as a keyword, since "and" and "or" read as operators, but a word the language reserves is
+// never invisible.
+func TestEveryKeywordIsColoured(t *testing.T) {
+	for word, tag := range lexer.Keywords {
+		if _, ok := semanticTypeOf(tag.Id); !ok {
+			t.Errorf("the keyword %q (%s) has no colour", word, tag.Id)
+		}
 	}
 }


### PR DESCRIPTION
Reportado usando: a palavra `use` não fica colorida no editor nem no playground.

## O que era

`semanticTypeOf` (`hosting/lsp/textdoc/semantic_tokens.go:131`) tem uma **lista escrita à mão** das tags que são palavra-chave, e `use` não entrou nela quando a palavra foi reservada. Ela lexava como keyword, respondia hover com a descrição dela, e ficava da cor de texto comum. O playground mostra a mesma coisa porque pergunta para a mesma sessão.

## A lista continua escrita à mão

Ser palavra-chave e **ser colorida como uma** não são a mesma pergunta: `and` e `or` são palavras que o lexer reserva e operadores para quem lê. Derivar a lista da tabela do lexer teria que codificar essa exceção em outro lugar.

O que fecha o buraco é um teste que **pergunta ao lexer todas as palavras-chave que ele conhece e exige que cada uma tenha alguma cor** — não a de keyword, já que duas não têm, mas nunca invisível. Ele falha em `use` sem o conserto, que é a única razão para confiar nele.

## Verificação

`make check` limpo. Conferi o vermelho antes do verde: com o conserto revertido, o teste acusa `the keyword "use" (USE) has no colour`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)