### PR TITLE
feat: the editor follows an import

### DIFF
--- a/cmd/aurorals/main.go
+++ b/cmd/aurorals/main.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/hosting/lsp/state"
 	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
@@ -44,12 +45,18 @@ func main() {
 	// The phases are built here, once, and the session that holds them answers every request.
 	// A document carries the width of the project it belongs to, which is why one session
 	// serves whatever the editor opens.
+	//
+	// What a client has open is made here too, because the module resolution needs it: a
+	// file it has to read may be one the person is editing, and the version that counts is
+	// theirs rather than the disk's.
+	documents := state.New()
 	sv := server{textdoc: textdoc.NewSession(textdoc.NewSessionOptions{
-		Lexer:  lexer.New(),
-		Parser: parser.New(),
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
+		Resolve: resolveModules(documents),
 	})}
 
-	lsp.Listen(logger, os.Stdin, os.Stdout, sv.handlers())
+	lsp.Listen(logger, os.Stdin, os.Stdout, documents, sv.handlers())
 
 	logger.Println("Server stopped")
 }

--- a/cmd/aurorals/modules.go
+++ b/cmd/aurorals/modules.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/hosting/lsp/state"
+	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
+)
+
+// How the language server reaches the files a document imports.
+//
+// This is the third reader of the same port. The command line reads a disk; the playground
+// reads a map it already holds, since there is no file system in a browser; and this one
+// reads the editor's buffers first and the disk only for what is not open. An editor
+// answering from the disk would be answering about a version the person editing has already
+// moved past — a name they just wrote would be underlined as missing, and one they just
+// deleted would go on resolving.
+
+// resolveModules answers with the modules a document imports, for a tree the server already
+// parsed. It is the port textdoc is handed: everything about the world is on this side of it.
+func resolveModules(s *state.State) textdoc.Resolve {
+	lx := lexer.New()
+	ps := parser.New()
+
+	return func(doc textdoc.Document, uses []ast.UseDeclaration) ([]module.Module, error) {
+		return resolver.New(resolver.Options{
+			SourceRoot: sourceRootFor(doc.Filename),
+			Read:       readThroughBuffers(s),
+			Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+				tokens, err := lx.GetFilledTokens(source)
+				if err != nil {
+					return ast.AST{}, err
+				}
+				return ps.Parse(parser.ParseInput{
+					Filename: filename,
+					Tokens:   tokens,
+					TapeSize: doc.TapeSize,
+					Module:   string(id),
+				})
+			},
+		}).DependenciesOf(doc.Filename, uses)
+	}
+}
+
+// readThroughBuffers answers with what the editor is showing, and falls back to the disk.
+func readThroughBuffers(s *state.State) resolver.Read {
+	return func(path string) ([]byte, error) {
+		if text, open := openDocument(s, path); open {
+			return []byte(text), nil
+		}
+		return os.ReadFile(path)
+	}
+}
+
+// openDocument looks for a path among the documents the client has open.
+//
+// It walks them, which is a loop over how many files a person has open — a handful — rather
+// than a map lookup, because the keys are URIs and the question is asked with a path. Making
+// the state keep a second index would mean it knew what a URI means, which is the client's
+// business and not its own.
+func openDocument(s *state.State, path string) (string, bool) {
+	want, err := filepath.Abs(path)
+	if err != nil {
+		return "", false
+	}
+	for uri, text := range s.Documents() {
+		open, err := filepath.Abs(textdoc.PathFromURI(lsp.URI(uri)))
+		if err == nil && open == want {
+			return text, true
+		}
+	}
+	return "", false
+}

--- a/cmd/aurorals/modules_test.go
+++ b/cmd/aurorals/modules_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/guiferpa/aurora/hosting/lsp/state"
+)
+
+// The editor's buffer is what counts, not the file on disk.
+//
+// Somebody editing a module has not saved it, and a server answering from the disk would be
+// answering about a version they have already moved past: a name they just wrote would be
+// underlined as missing, and one they just deleted would go on resolving.
+func TestReadingPrefersTheOpenBuffer(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "geometry.ar")
+	if err := os.WriteFile(path, []byte("ident onDisk = 1;"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	documents := state.New()
+	read := readThroughBuffers(documents)
+
+	if got, err := read(path); err != nil || string(got) != "ident onDisk = 1;" {
+		t.Fatalf("read %q (%v), want what is on disk", got, err)
+	}
+
+	documents.UpdateDocument("file://"+path, "ident inTheEditor = 2;")
+	if got, err := read(path); err != nil || string(got) != "ident inTheEditor = 2;" {
+		t.Errorf("read %q (%v), want what the editor is showing", got, err)
+	}
+}
+
+// A file nobody has open is read from the disk, and one that is nowhere says so.
+func TestReadingFallsBackToTheDisk(t *testing.T) {
+	read := readThroughBuffers(state.New())
+
+	if _, err := read(filepath.Join(t.TempDir(), "gone.ar")); err == nil {
+		t.Error("a file that is nowhere was read")
+	}
+}
+
+// Where a module name resolves from is the project's, and src/ next to the file when there is
+// no project. It is absolute either way: a server has no working directory worth speaking of.
+func TestSourceRootFor(t *testing.T) {
+	dir := t.TempDir()
+	loose := filepath.Join(dir, "loose.ar")
+
+	if got, want := sourceRootFor(loose), filepath.Join(dir, "src"); got != want {
+		t.Errorf("source root is %q, want %q", got, want)
+	}
+
+	manifest := "[project]\nname = \"p\"\nsource_root = \"lib\"\n"
+	if err := os.WriteFile(filepath.Join(dir, "aurora.toml"), []byte(manifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got, want := sourceRootFor(loose), filepath.Join(dir, "lib"); got != want {
+		t.Errorf("source root is %q, want %q", got, want)
+	}
+}

--- a/cmd/aurorals/project.go
+++ b/cmd/aurorals/project.go
@@ -17,16 +17,23 @@ import (
 // The server has no notion of a profile — a document is a file, and the project it belongs
 // to is decided by where the file is. That is the same walk the CLI does.
 
-// projectWidth is what was found for one directory, and what says whether it still holds.
-type projectWidth struct {
+// projectSettings is what was found for one directory, and what says whether it still holds.
+//
+// Two things come out of the same walk — how wide a value is, and where a module name
+// resolves from — so they are read together and kept together.
+type projectSettings struct {
 	manifest string // path of the manifest that answered; empty when there is no project
 	modTime  time.Time
 	tapeSize int
+	// sourceRoot is absolute. A server has no working directory worth speaking of, so where
+	// a module name resolves from is the project's root joined with what the manifest says
+	// — which is what the command line arrives at too, whenever it is run from that root.
+	sourceRoot string
 }
 
 // stale reports whether the manifest changed or went away since it was read. The alternative
 // is a server answering with the width a project had when the editor was opened.
-func (w projectWidth) stale() bool {
+func (w projectSettings) stale() bool {
 	info, err := os.Stat(w.manifest)
 	if err != nil {
 		return true
@@ -35,47 +42,75 @@ func (w projectWidth) stale() bool {
 }
 
 var (
-	widthsMu sync.Mutex
+	projectsMu sync.Mutex
 	// Keyed by the directory the document sits in. Only a directory that resolved to a
 	// project is kept: a file with no project above it is cheap to answer for, and caching
 	// the absence would outlive someone running "aurora init" next to it.
-	widths = make(map[string]projectWidth)
+	projects = make(map[string]projectSettings)
 )
 
-// tapeSizeFor answers the width the project holding filename is written in, and zero — which
-// means the default — when there is no project or its manifest cannot be read.
+// settingsFor answers what the project holding filename says, and whether there is one.
 //
 // A manifest that does not load is not the editor's to complain about: the CLI says so out
 // loud, and a diagnostic about the source stays about the source.
-func tapeSizeFor(filename string) int {
+func settingsFor(filename string) (projectSettings, bool) {
 	dir, err := filepath.Abs(filepath.Dir(filename))
 	if err != nil {
-		return 0
+		return projectSettings{}, false
 	}
 
-	widthsMu.Lock()
-	defer widthsMu.Unlock()
+	projectsMu.Lock()
+	defer projectsMu.Unlock()
 
-	if width, ok := widths[dir]; ok && !width.stale() {
-		return width.tapeSize
+	if found, ok := projects[dir]; ok && !found.stale() {
+		return found, true
 	}
-	delete(widths, dir)
+	delete(projects, dir)
 
 	root, err := manifest.FindProjectRootFrom(dir)
 	if err != nil {
-		return 0
+		return projectSettings{}, false
 	}
 	m, err := manifest.Load(root)
 	if err != nil {
-		return 0
+		return projectSettings{}, false
+	}
+
+	found := projectSettings{
+		tapeSize:   m.Project.TapeSize,
+		sourceRoot: filepath.Join(root, m.SourceRoot()),
 	}
 
 	path := filepath.Join(root, manifest.Filename)
 	info, err := os.Stat(path)
 	if err != nil {
-		return m.Project.TapeSize
+		return found, true
 	}
-	widths[dir] = projectWidth{manifest: path, modTime: info.ModTime(), tapeSize: m.Project.TapeSize}
+	found.manifest = path
+	found.modTime = info.ModTime()
+	projects[dir] = found
 
-	return m.Project.TapeSize
+	return found, true
+}
+
+// tapeSizeFor answers the width the project holding filename is written in, and zero — which
+// means the default — when there is no project.
+func tapeSizeFor(filename string) int {
+	if found, ok := settingsFor(filename); ok {
+		return found.tapeSize
+	}
+	return 0
+}
+
+// sourceRootFor answers where a module name resolves from for this document: what the project
+// says, and src/ next to the file when it belongs to no project.
+func sourceRootFor(filename string) string {
+	if found, ok := settingsFor(filename); ok {
+		return found.sourceRoot
+	}
+	dir, err := filepath.Abs(filepath.Dir(filename))
+	if err != nil {
+		return manifest.DefaultSourceRoot
+	}
+	return filepath.Join(dir, manifest.DefaultSourceRoot)
 }

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/hosting/lsp/state"
 	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
@@ -32,7 +33,7 @@ func runSession(t *testing.T, messages ...string) []map[string]any {
 		Lexer:  lexer.New(),
 		Parser: parser.New(),
 	})}
-	lsp.Listen(log.New(io.Discard, "", 0), in, out, sv.handlers())
+	lsp.Listen(log.New(io.Discard, "", 0), in, out, state.New(), sv.handlers())
 
 	replies := make([]map[string]any, 0)
 	rest := out.Bytes()

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -187,8 +187,10 @@ never mentioned.
 - A `struct` cannot be exported.
 - There is no `private`: a module offers everything it binds at the top.
 - The REPL does not take `use`.
-- The language server does not follow imports yet, so it underlines what is wrong inside a
-  file and says nothing about a name that lives in another one.
+- The editor follows an import — it underlines a module that is not there and a name a module
+  does not have, and offers what a module declared after the dot — but it does not go to a
+  definition in another file, and it only notices a change in a file you have open. Editing a
+  module outside the editor updates what depends on it the next time you touch that file.
 - The manifest does not list dependencies of any kind. The file system is the whole story
   until third-party packages exist.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,9 +81,19 @@ What it does not do yet:
   boundary exists now, so marking part of it later breaks nothing.
 - **The REPL does not take `use`.** It compiles one line at a time into one buffer, and a
   module is a file — what a `use` would mean there is a question nobody has answered.
-- **The language server does not follow an import.** It parses a file on its own, which is
-  what it needs to answer fast, so it underlines what is wrong inside one and says nothing
-  about a name that lives in another. Going through the resolver would give it both.
+- **The language server follows an import, and stops short of two things.** It reads what a
+  document imports on every pass, from the editor's buffers before the disk, so a module that
+  is not there and a name a module does not have are underlined where they were written, and
+  what a module declared is offered after the dot. What it does not do is go to a definition
+  in another file — no `textDocument/definition` exists for anything yet — and it does not
+  watch a file nobody has open, so editing a module outside the editor updates what depends
+  on it only when that file is touched. Neither needs the resolver; both need a capability
+  the server does not have.
+- **Nothing measures what following an import costs.** Every pass reads and parses every
+  module the document imports, with no cache, which is the honest place to start: a cache has
+  invalidation, and invalidation is a bug that reads as the editor lying. The shape to copy
+  when it is measured and found wanting is next door — the width of a project is cached per
+  directory and invalidated by the manifest's mtime.
 - **Nothing lists a dependency but the file system.** There are no third-party packages, so
   there is nothing for the manifest to name yet.
 

--- a/hosting/lsp/listener.go
+++ b/hosting/lsp/listener.go
@@ -16,11 +16,15 @@ const maxMessageBytes = 16 << 20
 
 type MethodHandler func(l *log.Logger, s *state.State, contents []byte) any
 
-func Listen(l *log.Logger, r io.Reader, w io.Writer, handlers map[Method]MethodHandler) {
+// Listen reads messages and hands each to the handler for its method.
+//
+// The state arrives rather than being made here: what a client has open is the server's, and
+// the server has to reach it while putting itself together — the module resolution reads the
+// buffers of the files it needs before it reads a disk.
+func Listen(l *log.Logger, r io.Reader, w io.Writer, s *state.State, handlers map[Method]MethodHandler) {
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, 64*1024), maxMessageBytes)
 	scanner.Split(messenger.Split)
-	s := state.New()
 
 	for scanner.Scan() {
 		method, id, contents, err := messenger.Decode(scanner.Bytes())

--- a/hosting/lsp/listener_test.go
+++ b/hosting/lsp/listener_test.go
@@ -26,7 +26,7 @@ func TestListenDispatchesToHandler(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 
 	called := 0
-	Listen(discardLogger(), in, out, map[Method]MethodHandler{
+	Listen(discardLogger(), in, out, state.New(), map[Method]MethodHandler{
 		"initialize": func(l *log.Logger, s *state.State, contents []byte) any {
 			called++
 			return NullResponse{Response: Response{RPC: "2.0", ID: intPtr(1)}}
@@ -48,7 +48,7 @@ func TestListenAnswersUnknownRequest(t *testing.T) {
 		frame(`{"jsonrpc":"2.0","method":"exit"}`))
 	out := bytes.NewBuffer(nil)
 
-	Listen(discardLogger(), in, out, map[Method]MethodHandler{})
+	Listen(discardLogger(), in, out, state.New(), map[Method]MethodHandler{})
 
 	body := out.String()
 	if !strings.Contains(body, fmt.Sprint(CodeMethodNotFound)) {
@@ -64,7 +64,7 @@ func TestListenIgnoresUnknownNotification(t *testing.T) {
 		frame(`{"jsonrpc":"2.0","method":"exit"}`))
 	out := bytes.NewBuffer(nil)
 
-	Listen(discardLogger(), in, out, map[Method]MethodHandler{})
+	Listen(discardLogger(), in, out, state.New(), map[Method]MethodHandler{})
 
 	if out.Len() != 0 {
 		t.Errorf("a notification needs no answer, got %q", out.String())
@@ -78,7 +78,7 @@ func TestListenAnswersShutdownAndStopsOnExit(t *testing.T) {
 	out := bytes.NewBuffer(nil)
 
 	called := 0
-	Listen(discardLogger(), in, out, map[Method]MethodHandler{
+	Listen(discardLogger(), in, out, state.New(), map[Method]MethodHandler{
 		"initialize": func(l *log.Logger, s *state.State, contents []byte) any {
 			called++
 			return nil
@@ -112,7 +112,7 @@ func TestListenHandlesMessageLargerThan64KB(t *testing.T) {
 
 	in := strings.NewReader(frame(string(body)) + frame(`{"jsonrpc":"2.0","method":"exit"}`))
 	got := 0
-	Listen(discardLogger(), in, bytes.NewBuffer(nil), map[Method]MethodHandler{
+	Listen(discardLogger(), in, bytes.NewBuffer(nil), state.New(), map[Method]MethodHandler{
 		"textDocument/didChange": func(l *log.Logger, s *state.State, contents []byte) any {
 			got = len(contents)
 			return nil

--- a/hosting/lsp/state/state.go
+++ b/hosting/lsp/state/state.go
@@ -28,6 +28,21 @@ func (s *State) GetDocument(key string) string {
 	return s.docs[key]
 }
 
+// Documents answers every open document, keyed by the URI it arrived under.
+//
+// Whoever wants to find one by something other than that key does the translating: a URI is
+// the client's idea of a name, and this package keeps what it was handed. The one caller
+// today is the module resolution, which has a path and needs the buffer rather than the file
+// on disk — an editor that answered from the disk would be answering about a version the
+// person editing has already moved past.
+func (s *State) Documents() map[string]string {
+	open := make(map[string]string, len(s.docs))
+	for uri, text := range s.docs {
+		open[uri] = text
+	}
+	return open
+}
+
 // DeleteDocument drops a document the client closed.
 func (s *State) DeleteDocument(key string) {
 	delete(s.docs, key)

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -4,6 +4,9 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/guiferpa/aurora/loader"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -19,19 +22,29 @@ import (
 // moduleAliases is what the use lines declared: the alias, and the module it names.
 type moduleAliases map[string]string
 
-// scanUses reads `use a/b/c as x;` out of a token chain.
-func scanUses(tokens []token.Token) moduleAliases {
-	found := make(moduleAliases)
+// scanUses reads every `use a/b/c as x;` out of a token chain, with the token of each so
+// whatever goes wrong with one can be underlined where it was written.
+func scanUses(tokens []token.Token) []ast.UseDeclaration {
+	found := make([]ast.UseDeclaration, 0)
 	for i := 0; i < len(tokens); i++ {
 		if tokens[i].GetTag().Id != token.USE {
 			continue
 		}
 		if alias, specifier, next := readUse(tokens, i); alias != "" {
-			found[alias] = specifier
+			found = append(found, ast.UseDeclaration{Specifier: specifier, Alias: alias, Token: tokens[i]})
 			i = next
 		}
 	}
 	return found
+}
+
+// aliasesOf is what those declarations say about names: the alias, and what it means.
+func aliasesOf(uses []ast.UseDeclaration) moduleAliases {
+	aliases := make(moduleAliases, len(uses))
+	for _, declaration := range uses {
+		aliases[declaration.Alias] = declaration.Specifier
+	}
+	return aliases
 }
 
 // readUse reads one declaration starting at the use token: the path it names, and the alias
@@ -108,4 +121,70 @@ func moduleCompletions(aliases moduleAliases) []CompletionItem {
 		return strings.Compare(a.Label, b.Label)
 	})
 	return items
+}
+
+// exportCompletions offers what a module declared, which is read from the module's own tree.
+//
+// A module that could not be found offers nothing rather than everything: the diagnostic
+// already says it is missing, and a list of keywords would be the one answer that is
+// certainly wrong.
+func exportCompletions(analysis *Analysis, specifier string) []CompletionItem {
+	found, ok := analysis.module(specifier)
+	if !ok {
+		return []CompletionItem{}
+	}
+
+	names := loader.Exports(found)
+	items := make([]CompletionItem, 0, len(names))
+	for _, name := range names {
+		items = append(items, CompletionItem{
+			Label:  name,
+			Detail: describeNode(exportedValue(found, name)) + " of module " + specifier,
+			Kind:   Variable,
+		})
+	}
+	return items
+}
+
+// describeExport says what a name reached through a module is, when the module is there to
+// say — the same description an ordinary identifier gets, read from the other file.
+func describeExport(analysis *Analysis, subject token.Token) string {
+	specifier, ok := moduleOfSubject(analysis, subject)
+	if !ok {
+		return ""
+	}
+	found, loaded := analysis.module(specifier)
+	if !loaded {
+		return ""
+	}
+	value := exportedValue(found, string(subject.GetMatch()))
+	if value == nil {
+		return ""
+	}
+	return "\nvalue: " + describeNode(value)
+}
+
+// moduleOfSubject answers the module a token is reached through, when it follows a dot on an
+// alias.
+func moduleOfSubject(analysis *Analysis, subject token.Token) (string, bool) {
+	aliases := aliasesOf(scanUses(analysis.Tokens))
+	for i, t := range analysis.Tokens {
+		if t.GetCursor() != subject.GetCursor() || i < 2 || analysis.Tokens[i-1].GetTag().Id != token.DOT {
+			continue
+		}
+		specifier, ok := aliases[string(analysis.Tokens[i-2].GetMatch())]
+		return specifier, ok
+	}
+	return "", false
+}
+
+// exportedValue is what a module bound a name to, or nil when it bound no such name.
+func exportedValue(found module.Module, name string) ast.Node {
+	for _, node := range found.Tree.Nodes {
+		binding, ok := node.(ast.IdentLiteral)
+		if ok && found.Symbol(binding.Id) == name {
+			return binding.Value
+		}
+	}
+	return nil
 }

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -1,10 +1,16 @@
 package textdoc
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // What one file says about the modules it brings in, which is all the editor knows: that a
@@ -48,7 +54,7 @@ func TestScanUses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := scanUses(session().Analyze(Document{Filename: "main.ar", Source: tc.source}).Tokens)
+			got := aliasesOf(scanUses(session().Analyze(Document{Filename: "main.ar", Source: tc.source}).Tokens))
 			if len(got) != len(tc.want) {
 				t.Fatalf("read %v, want %v", got, tc.want)
 			}
@@ -126,5 +132,157 @@ func TestCompletionOffersTheModules(t *testing.T) {
 		if !strings.Contains(item.Detail, specifier) {
 			t.Errorf("the alias %s is described as %q, want it to name %s", alias, item.Detail, specifier)
 		}
+	}
+}
+
+// From here on the editor reads the other files too, through the port it is handed. These
+// hand it a project in memory: what is on a disk is the server's business, and this package
+// answers with values whatever the world it is put in.
+func withModuleFiles(files map[string]string) *Session {
+	lx := lexer.New()
+	ps := parser.New()
+
+	return NewSession(NewSessionOptions{
+		Lexer:  lx,
+		Parser: ps,
+		Resolve: func(doc Document, uses []ast.UseDeclaration) ([]module.Module, error) {
+			return resolver.New(resolver.Options{
+				SourceRoot: "src",
+				Read: func(path string) ([]byte, error) {
+					source, ok := files[path]
+					if !ok {
+						return nil, fmt.Errorf("no such file")
+					}
+					return []byte(source), nil
+				},
+				Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+					tokens, err := lx.GetFilledTokens(source)
+					if err != nil {
+						return ast.AST{}, err
+					}
+					return ps.Parse(parser.ParseInput{Filename: filename, Tokens: tokens, Module: string(id)})
+				},
+			}).DependenciesOf(doc.Filename, uses)
+		},
+	})
+}
+
+const geometry = "ident area = defer { feed(0) * feed(1); };\nident base = 10;"
+
+// What the imports say is underlined where it was written, and the message is the compiler's
+// own — the editor adds nothing to it.
+func TestModuleDiagnostics(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+		line   int
+	}{
+		{
+			name:   "a module that is not there",
+			source: "use a/b as x;\nprintd 1;",
+			want:   "module a/b is not there",
+			line:   0,
+		},
+		{
+			name:   "a name the module does not have",
+			source: "use geometry as g;\nprintd g.volume(1, 2);",
+			want:   "module geometry has no volume",
+			line:   1,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+			diagnostics := session.ValidateCode(Document{Filename: "src/main.ar", Source: tc.source})
+
+			if len(diagnostics) != 1 {
+				t.Fatalf("reported %d diagnostics, want 1: %+v", len(diagnostics), diagnostics)
+			}
+			if !strings.Contains(diagnostics[0].Message, tc.want) {
+				t.Errorf("said %q, want it to say %q", diagnostics[0].Message, tc.want)
+			}
+			if diagnostics[0].Range.Start.Line != tc.line {
+				t.Errorf("underlined line %d, want %d", diagnostics[0].Range.Start.Line, tc.line)
+			}
+		})
+	}
+}
+
+// A program whose imports are all there says nothing, which is the case that matters most.
+func TestNoDiagnosticWhenTheModulesAreThere(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+	diagnostics := session.ValidateCode(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nprintd g.area(2, 3);",
+	})
+
+	if len(diagnostics) != 0 {
+		t.Errorf("reported %+v, want nothing", diagnostics)
+	}
+}
+
+// After the dot, what the module declared — and only that.
+func TestCompletionOffersWhatTheModuleDeclared(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+	items := session.CompletionItemsFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nprintd g.\n",
+	}, lsp.Position{Line: 1, Character: 9}, false)
+
+	if len(items) != 2 {
+		t.Fatalf("offered %d items, want the two the module declared: %+v", len(items), items)
+	}
+	for i, want := range []string{"area", "base"} {
+		if items[i].Label != want {
+			t.Errorf("offered %q, want %q", items[i].Label, want)
+		}
+		if !strings.Contains(items[i].Detail, "geometry") {
+			t.Errorf("described %q as %q, want it to name the module", items[i].Label, items[i].Detail)
+		}
+	}
+	if !strings.Contains(items[0].Detail, "deferred scope") {
+		t.Errorf("area is described as %q, want it to say what it is", items[0].Detail)
+	}
+}
+
+// A module that could not be found offers nothing rather than everything: the diagnostic
+// already says it is missing.
+func TestCompletionAfterAMissingModule(t *testing.T) {
+	session := withModuleFiles(map[string]string{})
+	items := session.CompletionItemsFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use gone as g;\nprintd g.\n",
+	}, lsp.Position{Line: 1, Character: 9}, false)
+
+	if len(items) != 0 {
+		t.Errorf("offered %d items for a module that is not there", len(items))
+	}
+}
+
+// Hover reads the other file too, so a name reached through a module says what it is.
+func TestHoverReadsTheModule(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+	got := session.HoverInfo(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nprintd g.area(2, 3);",
+	}, lsp.Position{Line: 1, Character: 10})
+
+	for _, want := range []string{"of module geometry", "deferred scope"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hover = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// Without the port a document is read on its own, which is what a page with one editor in it
+// is: nothing is missing, because nothing could have been imported.
+func TestWithoutThePortNothingIsResolved(t *testing.T) {
+	diagnostics := session().ValidateCode(Document{
+		Filename: "main.ar",
+		Source:   "use a/b as x;\nprintd 1;",
+	})
+
+	if len(diagnostics) != 0 {
+		t.Errorf("reported %+v, want nothing said about a module nobody looked for", diagnostics)
 	}
 }

--- a/hosting/lsp/textdoc/session.go
+++ b/hosting/lsp/textdoc/session.go
@@ -3,6 +3,8 @@ package textdoc
 import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // A Session is one editor session: the phases it was handed, and the questions an editor asks
@@ -13,15 +15,31 @@ import (
 // from the project the file belongs to and travels with each Document, since one session
 // answers for files of any project the editor opens.
 type Session struct {
-	lexer  *lexer.Lexer
-	parser parser.Parser
+	lexer   *lexer.Lexer
+	parser  parser.Parser
+	resolve Resolve
 }
+
+// Resolve answers with the modules a document imports, given the use lines it opens with.
+//
+// It takes the declarations rather than a tree because a document being edited does not
+// parse, and what is inside a module is wanted exactly then — the moment a dot is typed.
+// They are the top of the file and readable from the tokens alone.
+//
+// It is a port because finding those files is the host's business and each host does it
+// differently: the server reads the editor's buffers and falls back to the disk, and the
+// playground has no file system at all — it passes nothing, and a document there imports
+// nothing, which is the truth about a page with one editor in it.
+type Resolve func(doc Document, uses []ast.UseDeclaration) ([]module.Module, error)
 
 type NewSessionOptions struct {
 	Lexer  *lexer.Lexer
 	Parser parser.Parser
+	// Resolve is optional. Without it a document is analysed on its own, which is what it
+	// was before modules existed.
+	Resolve Resolve
 }
 
 func NewSession(opts NewSessionOptions) *Session {
-	return &Session{lexer: opts.Lexer, parser: opts.Parser}
+	return &Session{lexer: opts.Lexer, parser: opts.Parser, resolve: opts.Resolve}
 }

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -8,8 +8,10 @@ import (
 	"strings"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -22,16 +24,33 @@ const (
 )
 
 // Analysis is one pass of the compiler front end over a single document: the tk
-// stream, the parsed namespace (nil when parsing failed) and a position mapper.
+// stream, the parsed tree (nil when parsing failed), a position mapper, and the modules the
+// document imports.
 //
-// The server analyses the open document alone, which is also the compiler's unit: there is
-// no module system yet (see docs/module_system_design.md).
+// The modules are read only when the document parses, because until it does there is no list
+// of imports to read. They are the one thing here that comes from outside the document, and
+// they arrive through a port: see Resolve.
 type Analysis struct {
-	Source string
-	Mapper *lsp.Mapper
-	Tokens []token.Token
-	AST    *ast.AST
-	Err    error
+	Source  string
+	Mapper  *lsp.Mapper
+	Tokens  []token.Token
+	AST     *ast.AST
+	Err     error
+	Modules []module.Module
+	// ModuleErr is what the imports had to say: a module that is not there, a circle, or a
+	// name a module does not have. It is kept apart from Err because it is found after the
+	// parse and only when the parse worked.
+	ModuleErr error
+}
+
+// module answers the module of a specifier among the ones this document imports.
+func (a *Analysis) module(specifier string) (module.Module, bool) {
+	for _, each := range a.Modules {
+		if string(each.ID) == specifier {
+			return each, true
+		}
+	}
+	return module.Module{}, false
 }
 
 // Document is what an analysis reads: the source, the path behind the URI — which decides
@@ -61,6 +80,14 @@ func (s *Session) Analyze(doc Document) *Analysis {
 		return analysis
 	}
 
+	// What the document imports is read from the tokens, before anything is parsed: a
+	// document being edited is broken most of the time, and what is inside a module is
+	// wanted exactly then. What that costs is one read of each imported file.
+	if s.resolve != nil {
+		modules, err := s.resolve(doc, scanUses(tokens))
+		analysis.Modules, analysis.ModuleErr = modules, err
+	}
+
 	// How wide a value is decides what fits in one, so the document is read in the dialect it
 	// belongs to rather than in the default.
 	tree, err := s.parser.Parse(parser.ParseInput{
@@ -74,6 +101,11 @@ func (s *Session) Analyze(doc Document) *Analysis {
 	}
 	analysis.AST = &tree
 
+	// The names have to be there too, and only a parsed document has names to check.
+	if analysis.ModuleErr == nil && s.resolve != nil {
+		analysis.ModuleErr = loader.Check(append(analysis.Modules, module.Module{ID: "", Tree: tree}))
+	}
+
 	return analysis
 }
 
@@ -83,7 +115,15 @@ func (s *Session) Analyze(doc Document) *Analysis {
 // fixing it reveals the next one.
 func (a *Analysis) Diagnostics() Diagnostics {
 	diagnostics := Diagnostics{}
-	if a.Err == nil {
+
+	// The parse comes first: a document that does not parse has no imports to be wrong
+	// about, and saying both at once would be saying the second about a tree that is not
+	// there.
+	failure := a.Err
+	if failure == nil {
+		failure = a.ModuleErr
+	}
+	if failure == nil {
 		return diagnostics
 	}
 
@@ -93,7 +133,7 @@ func (a *Analysis) Diagnostics() Diagnostics {
 	// Position comes from the structured error carried by the lexer and the parser,
 	// so the underline covers the offending tk instead of guessing from the message.
 	var perr *token.Error
-	if errors.As(a.Err, &perr) {
+	if errors.As(failure, &perr) {
 		rng = a.rangeFor(perr.Offset, perr.Length)
 	}
 
@@ -101,7 +141,7 @@ func (a *Analysis) Diagnostics() Diagnostics {
 		Range:    rng,
 		Severity: SeverityError,
 		Source:   source,
-		Message:  a.Err.Error(),
+		Message:  failure.Error(),
 	})
 }
 
@@ -175,8 +215,8 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 		return "boolean: " + match
 	case token.ID:
 		// A module is not a value, so it is answered for before anything looks for one.
-		if info := scanUses(analysis.Tokens).describe(analysis.Tokens, tk); info != "" {
-			return info
+		if info := aliasesOf(scanUses(analysis.Tokens)).describe(analysis.Tokens, tk); info != "" {
+			return info + describeExport(analysis, tk)
 		}
 		// A struct name or a field read out of one: the declaration is what says these are
 		// anything other than a name, so it is what hover has to answer with.
@@ -215,12 +255,11 @@ func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bo
 		return fieldCompletions(fields)
 	}
 
-	// After a dot on a module alias, what can follow is what that module declared — which is
-	// in another file, and nothing here has read it. Offering the keywords instead would be
-	// offering the one thing that certainly cannot go there.
-	aliases := scanUses(analysis.Tokens)
-	if _, isModule := aliases.moduleBefore(analysis.Tokens, offset); isModule {
-		return []CompletionItem{}
+	// After a dot on a module alias, what can follow is what that module declared, and
+	// nothing else — the same rule as a struct's fields, answered from another file.
+	aliases := aliasesOf(scanUses(analysis.Tokens))
+	if specifier, isModule := aliases.moduleBefore(analysis.Tokens, offset); isModule {
+		return exportCompletions(analysis, specifier)
 	}
 
 	items := make([]CompletionItem, 0)

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -91,30 +91,39 @@ func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
 // written in two files, neither of which the resolver would have read on its own. Both are
 // asked what they need, because a test names the modules it uses like any other file.
 func (r *Resolver) Dependencies(entry string, trees ...ast.AST) ([]module.Module, error) {
-	state := &resolution{found: make(map[module.ID]bool), entry: path.Clean(entry)}
+	uses := make([]ast.UseDeclaration, 0)
 	for _, tree := range trees {
-		if err := r.dependencies(state, tree); err != nil {
+		uses = append(uses, declarationsOf(tree)...)
+	}
+	return r.DependenciesOf(entry, uses)
+}
+
+// DependenciesOf answers the same, for a caller that has the declarations without a tree.
+//
+// An editor is that caller. A document is too broken to parse most of the time somebody is
+// looking at it — the moment a dot is typed there is no name after it yet — and what is
+// inside a module is exactly what is wanted then. The declarations are the top of the file
+// and readable from the tokens alone, so they arrive that way.
+func (r *Resolver) DependenciesOf(entry string, uses []ast.UseDeclaration) ([]module.Module, error) {
+	state := &resolution{found: make(map[module.ID]bool), entry: path.Clean(entry)}
+	for _, declaration := range uses {
+		if err := r.resolveOne(state, declaration); err != nil {
 			return nil, err
 		}
 	}
 	return state.order, nil
 }
 
-// dependencies resolves every module a tree names, in the order the file names them.
-//
-// The declarations are top-level nodes, so this reads the list a file opens with rather than
-// walking anything.
-func (r *Resolver) dependencies(state *resolution, tree ast.AST) error {
+// declarationsOf reads the imports out of a tree. They are top-level nodes, so this reads the
+// list a file opens with rather than walking anything.
+func declarationsOf(tree ast.AST) []ast.UseDeclaration {
+	uses := make([]ast.UseDeclaration, 0)
 	for _, node := range tree.Nodes {
-		declaration, ok := node.(ast.UseDeclaration)
-		if !ok {
-			continue
-		}
-		if err := r.resolveOne(state, declaration); err != nil {
-			return err
+		if declaration, ok := node.(ast.UseDeclaration); ok {
+			uses = append(uses, declaration)
 		}
 	}
-	return nil
+	return uses
 }
 
 // resolveOne finds one module, everything under it, and adds it to the order.
@@ -148,8 +157,10 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 	}
 
 	state.open = append(state.open, id)
-	if err := r.dependencies(state, tree); err != nil {
-		return err
+	for _, declaration := range declarationsOf(tree) {
+		if err := r.resolveOne(state, declaration); err != nil {
+			return err
+		}
 	}
 	state.open = state.open[:len(state.open)-1]
 


### PR DESCRIPTION
A camada 2, como combinado: a porta lendo buffers, sem cache, e o recorte de diagnóstico + completar.

## O que o editor passa a responder

| | |
|---|---|
| `use naoexiste as x;` | sublinhado, dizendo o arquivo que procurou |
| ciclo entre módulos | sublinhado, com a cadeia inteira |
| `x.naoexiste` | sublinhado, dizendo o que o módulo tem |
| `x.` | completa com os nomes do módulo, descritos |
| hover em `x.area` | diz de que módulo é **e o que é** |

As mensagens são as do compilador e as posições vêm junto com elas, então **o caminho de diagnóstico não precisou aprender nada** — `token.Error` já virava range.

## O furo do meu desenho, achado escrevendo

Eu tinha amarrado a resolução ao parse ter dado certo. Aí o teste de completar falhou, e o motivo é o desenho inteiro em uma frase: **completar é pedido no instante em que o documento não parseia** (`printd g.` não fecha nada). Uma resolução que espera um parse bom está ausente exatamente quando é chamada.

É a mesma lição do `scanStructs`, que já lia dos tokens por isso. Então os imports passam a ser lidos **dos tokens, antes do parse** — e o resolver ganhou uma porta de entrada que aceita as declarações em vez de uma árvore, mantendo o token de cada uma, que é o que permite sublinhar onde foi escrito. O que precisa de árvore é só a conferência de que o nome existe, e essa roda quando existe árvore.

## A porta lendo buffers

**Terceiro leitor da mesma porta**: a linha de comando lê disco, o playground lê um mapa em memória, o editor lê os buffers e cai para o disco. É a melhor justificativa que o desenho da porta recebeu — um servidor respondendo do disco responderia sobre uma versão que a pessoa já passou.

Para isso o `state` subiu para o `main` e o `Listen` passou a recebê-lo: o que o cliente tem aberto é do servidor, e o servidor precisa alcançar isso enquanto se monta.

## Sem cache, de propósito

Cada passada lê e parseia o que o documento importa. É o lugar honesto de começar: cache tem invalidação, e invalidação é bug que aparece como "o editor está mentindo". Quando alguém medir e doer, o molde está do lado — a largura do projeto já é cacheada por diretório e invalidada pelo mtime do manifesto, e agora a raiz de módulos sai da **mesma caminhada**, lida e cacheada junto.

## O que continua de fora

Ir para a definição em outro arquivo (`textDocument/definition` não existe para nada hoje) e reagir a mudança em arquivo fechado (`didChangeWatchedFiles`). Os dois são capability nova, não extensão desta. Estão escritos no roadmap e em `docs/modules.md`, que diziam que o editor não seguia import — agora dizem o que ele faz e onde para.

O playground não passa a porta e continua igual: numa página com um editor só, não há o que importar.

## Verificação

`make check` limpo, nada do código novo no `make complexity`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)