### PR TITLE
feat: the REPL brings a module in

### DIFF
--- a/cmd/aurora/repl.go
+++ b/cmd/aurora/repl.go
@@ -8,6 +8,7 @@ import (
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/evaluator"
+	"github.com/guiferpa/aurora/hosting/cli"
 	"github.com/guiferpa/aurora/hosting/repl"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
@@ -46,6 +47,9 @@ var replCmd = &cobra.Command{
 			In:       os.Stdin,
 			Out:      out,
 			TapeSize: size,
+			// A use line resolves from where the session was started, which is the same
+			// answer the other commands give: the project you are standing in.
+			Resolver: newResolver(size, cli.ProjectSourceRoot("")),
 		}).Start()
 		return nil
 	},

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -186,7 +186,8 @@ never mentioned.
 
 - A `struct` cannot be exported.
 - There is no `private`: a module offers everything it binds at the top.
-- The REPL does not take `use`.
+- The REPL takes `use`, reading from where it was started, and brings a module in once per
+  session — a second `use` of the same one is a use of what is already there.
 - The editor follows an import — it underlines a module that is not there and a name a module
   does not have, and offers what a module declared after the dot — but it does not go to a
   definition in another file, and it only notices a change in a file you have open. Editing a

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -79,8 +79,6 @@ What it does not do yet:
   the parser, which is a different shape from the one that exists.
 - **There is no `private`.** A module offers everything it binds with `ident` at the top. The
   boundary exists now, so marking part of it later breaks nothing.
-- **The REPL does not take `use`.** It compiles one line at a time into one buffer, and a
-  module is a file — what a `use` would mean there is a question nobody has answered.
 - **The language server follows an import, and stops short of two things.** It reads what a
   document imports on every pass, from the editor's buffers before the disk, so a module that
   is not there and a name a module does not have are underlined where they were written, and

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -15,8 +15,12 @@ import (
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/evaluator"
 	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/ir"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // render prints the value of the line that was typed — the temp left by its last
@@ -114,6 +118,15 @@ type Session struct {
 	// defer recorded valid when it is called on a later line.
 	insts []ir.Instruction
 
+	// resolver finds the files a line imports. Nil is a session that takes no use line,
+	// which is what a REPL with nowhere to read from is.
+	resolver *resolver.Resolver
+	// loaded is every module this session has run, by name. A module is a program: running
+	// it twice would bind its names twice, and the second time is a conflict — so a use of
+	// something already here is a use of what is already here, the way it is in any REPL
+	// that imports.
+	loaded map[module.ID]module.Module
+
 	hist       *History
 	histWarned bool
 }
@@ -150,12 +163,83 @@ func (s *Session) compile(text string) (ir.Program, error) {
 		return ir.Program{}, err
 	}
 
+	// What the line imports is loaded before the line runs, since the line is about to use
+	// it. A line that imports nothing asks nothing of the world.
+	if err := s.load(tree); err != nil {
+		return ir.Program{}, err
+	}
+
 	program, err := s.emitter.EmitProgram(tree)
 	if err != nil {
 		return ir.Program{}, err
 	}
 
 	return program, nil
+}
+
+// imports reports whether a line names a module at all.
+func imports(tree ast.AST) bool {
+	for _, node := range tree.Nodes {
+		if _, ok := node.(ast.UseDeclaration); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// load brings in what a line imports, and checks the line against everything brought in.
+//
+// A module runs here the way it runs anywhere: its instructions go into the same buffer every
+// line goes into, and it is evaluated as a range of it under its own name, so what it bound
+// is in the environ that belongs to it. Being in the one buffer is what lets a scope from it
+// be called on a later line — a defer records where its body sits, and the buffer is what
+// those positions are into.
+func (s *Session) load(tree ast.AST) error {
+	if s.resolver == nil {
+		if imports(tree) {
+			return errors.New("this session has nowhere to read a module from")
+		}
+		return nil
+	}
+
+	// The entry has no path: a session is not a file. Nothing can import it either, which
+	// is what that would have been for.
+	modules, err := s.resolver.Dependencies("", tree)
+	if err != nil {
+		return err
+	}
+
+	fresh := make([]module.Module, 0, len(modules))
+	for _, each := range modules {
+		if _, done := s.loaded[each.ID]; !done {
+			fresh = append(fresh, each)
+		}
+	}
+
+	// The line is checked against everything this session knows, not only what arrived with
+	// it: a name reached on line ten belongs to a module imported on line one.
+	known := make([]module.Module, 0, len(s.loaded)+len(fresh)+1)
+	for _, each := range s.loaded {
+		known = append(known, each)
+	}
+	known = append(known, fresh...)
+	if err := loader.Check(append(known, module.Module{ID: "", Tree: tree})); err != nil {
+		return err
+	}
+
+	for _, each := range fresh {
+		program, err := s.emitter.EmitProgram(each.Tree)
+		if err != nil {
+			return err
+		}
+		from := uint64(len(s.insts))
+		s.insts = append(s.insts, program.Instructions...)
+		if _, err := s.ev.EvaluateModule(s.insts, from, uint64(len(s.insts)), string(each.ID)); err != nil {
+			return err
+		}
+		s.loaded[each.ID] = each
+	}
+	return nil
 }
 
 // evaluate runs the line's expressions one at a time, so a line holding several of them
@@ -196,6 +280,8 @@ type NewSessionOptions struct {
 	Out io.Writer
 	// TapeSize is the width in bytes of every value, the same one the phases were built with.
 	TapeSize int
+	// Resolver finds the files a use line names. Without one a session takes no imports.
+	Resolver *resolver.Resolver
 }
 
 // NewSession builds a session from what it was handed.
@@ -215,6 +301,8 @@ func NewSession(opts NewSessionOptions) *Session {
 		out:          opts.Out,
 		tapeSize:     tapeSize,
 		declarations: parser.NewDeclarations(),
+		resolver:     opts.Resolver,
+		loaded:       make(map[module.ID]module.Module),
 		hist:         hist,
 	}
 }

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -1,6 +1,8 @@
 package repl
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -9,7 +11,10 @@ import (
 	"github.com/guiferpa/aurora/evaluator"
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
 	"github.com/guiferpa/aurora/shared/printer"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 )
 
 // A session is one file typed a line at a time, and nothing could read one back until Start
@@ -147,5 +152,126 @@ func TestSessionSaysNothingForABlankLine(t *testing.T) {
 	}
 	if strings.Count(got, prompt) != 3 {
 		t.Errorf("session wrote %d prompts, want one per line and one for the end", strings.Count(got, prompt))
+	}
+}
+
+// typedIn is typed, in a project on disk: a use line reads a file, and where it reads from is
+// where the session was started.
+func typedIn(t *testing.T, dir, lines string, tapeSize int) string {
+	t.Helper()
+	t.Chdir(dir)
+
+	size := byteutil.TapeSize(tapeSize)
+	out := &strings.Builder{}
+	lx := lexer.New()
+	ps := parser.New()
+
+	NewSession(NewSessionOptions{
+		Lexer:   lx,
+		Parser:  ps,
+		Emitter: emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
+		Evaluator: evaluator.New(evaluator.NewEvaluatorOptions{
+			PrintBytes:   printer.Bytes(out, size),
+			PrintChars:   printer.Chars(out, size),
+			PrintDecimal: printer.Decimal(out, size),
+			TapeSize:     size,
+		}),
+		In:       strings.NewReader(lines),
+		Out:      out,
+		TapeSize: size,
+		Resolver: resolver.New(resolver.Options{
+			SourceRoot: "src",
+			Read:       os.ReadFile,
+			Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+				tokens, err := lx.GetFilledTokens(source)
+				if err != nil {
+					return ast.AST{}, err
+				}
+				return ps.Parse(parser.ParseInput{
+					Filename: filename,
+					Tokens:   tokens,
+					TapeSize: size,
+					Module:   string(id),
+				})
+			},
+		}),
+	}).Start()
+
+	return out.String()
+}
+
+// withModule writes a project with one module in it and answers where it is.
+func withModule(t *testing.T, source string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "src", "geometry.ar"), []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+const geometry = "ident area = defer { feed(0) * feed(1); };\nident base = 10;"
+
+// A use line brings the module in, and what is inside it answers on the lines after.
+func TestASessionImports(t *testing.T) {
+	got := typedIn(t, withModule(t, geometry), "use geometry as g;\nprintd g.area(3, 4);\nprintd g.base;\n", 0)
+
+	for _, want := range []string{"12", "10"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the session said %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// A module is a program, so it runs once: importing it again is a use of what is already
+// here, rather than binding its names a second time.
+func TestAModuleIsBroughtInOnce(t *testing.T) {
+	got := typedIn(t, withModule(t, "printd 1;\nident base = 10;"),
+		"use geometry as g;\nuse geometry as h;\nprintd h.base;\n", 0)
+
+	if strings.Count(got, "1\n") != 1 {
+		t.Errorf("the module ran more than once: %q", got)
+	}
+	if strings.Contains(got, "conflict") {
+		t.Errorf("importing twice bound its names twice: %q", got)
+	}
+	if !strings.Contains(got, "10") {
+		t.Errorf("the second alias does not reach it: %q", got)
+	}
+}
+
+// What is wrong is said when the line is read, not when it runs.
+func TestASessionSaysWhatIsWrongWithAnImport(t *testing.T) {
+	for _, tc := range []struct{ name, lines, want string }{
+		{
+			name:  "a module that is not there",
+			lines: "use gone as g;\n",
+			want:  "module gone is not there",
+		},
+		{
+			name:  "a name the module does not have",
+			lines: "use geometry as g;\nprintd g.volume;\n",
+			want:  "module geometry has no volume",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := typedIn(t, withModule(t, geometry), tc.lines, 0)
+			if !strings.Contains(got, tc.want) {
+				t.Errorf("the session said %q, want it to contain %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// A session with nowhere to read from takes no imports, and says so rather than accepting the
+// line and doing nothing with it.
+func TestASessionWithoutAResolverRefusesToPretend(t *testing.T) {
+	got := typed(t, "use geometry as g;\nprintd g.base;\n", 0)
+
+	if !strings.Contains(got, "nowhere to read a module from") {
+		t.Errorf("the session said %q, want it to say it cannot import", got)
 	}
 }


### PR DESCRIPTION
Você mostrou isto:

```
>> use geometry as g;
= [0 0 0 0 0 0 0 0]
>> g.area;
= identifier geometry.area not found
```

A linha era **aceita** e respondia com o valor neutro, como se algo tivesse acontecido, e depois todo uso falhava com o nome de um módulo que ninguém digitou — `geometry.area` é o compilador falando consigo mesmo.

Agora ela lê o arquivo:

```
>> use geometry as g;
= [0 0 0 0 0 0 0 0]
>> printd g.area(3, 4);
12
```

## Como

As instruções do módulo entram **no mesmo buffer** em que toda linha entra, e ele é avaliado como uma faixa dele sob o próprio nome — então o que ele ligou vive no environ que é dele. Estar no buffer único é o que permite chamar um escopo dele numa linha posterior: um `defer` grava onde o corpo está como posição naquele buffer.

**Roda uma vez.** Um módulo é um programa, então importar de novo é usar o que já está aqui, e não ligar os nomes dele uma segunda vez — o que o environ recusaria como conflito. É como qualquer REPL que importa se comporta.

**O que está errado é dito na leitura da linha**, não na execução: módulo ausente, ciclo e nome inexistente voltam antes de qualquer coisa rodar, porque a linha é conferida contra **todos os módulos que a sessão conhece** — um nome alcançado na linha dez pertence a um módulo importado na linha um.

**De onde lê** é de onde a sessão foi iniciada, que é a resposta que todo outro comando dá.

## E o caso sem resolver

Uma sessão montada sem lugar para ler **recusa a linha** em vez de aceitá-la e falhar depois. É exatamente o defeito que este PR conserta, então não fazia sentido deixá-lo de pé em outra porta.

## Documentação

`docs/modules.md` e o roadmap diziam que a REPL não aceita `use`. O roadmap perde o item; a referência passa a dizer o que ela faz, incluindo o "uma vez por sessão".

## Verificação

`make check` limpo, nada do código novo no `make complexity`. Os testes montam um projeto em disco e digitam linhas, que é como uma pessoa usa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)