### PR TITLE
docs: a struct comes out of a scope, and now it is written down

### DIFF
--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -347,6 +347,45 @@ printd area(Point{10, 20});   #- 200
 claim reads the wrong tapes, and reading past the end gives the neutral value rather than
 stopping the program — the same rule `head` and `feed` follow.
 
+### A shape coming back out
+
+The same crossing happens the other way. A scope that has to say two things — whether it
+worked and what it produced — says them as one run of tapes, and whoever called it names the
+shape to read them back:
+
+```aurora
+struct Result { failed, value };
+
+ident divide = defer {
+  if feed(1) equals 0 {
+    Result{1, 0};
+  } else {
+    Result{0, feed(0) / feed(1)};
+  };
+};
+
+ident r = divide(10, 2) as Result;
+printd r.failed;   #- 0
+printd r.value;    #- 5
+```
+
+Nothing about the scope says it answers with a `Result`, and nothing has to: the answer is a
+run of two tapes, and `as` names what they are. The claim is the caller's, the same way it is
+on the way in.
+
+The shape binds tighter than anything else, so a name in between is optional:
+
+```aurora
+struct Result { failed, value };
+ident make = defer { Result{1, 42}; };
+
+printd make() as Result.value;   #- 42
+```
+
+A struct does not cross a **module**, though — it is a way of naming the tapes of a run while
+one file is compiled, and it stays in the file that declared it. A scope imported from another
+module can answer with a run of tapes, and the file reading it has no name for their shape.
+
 ### What is an error
 
 Because the declaration exists to catch mistakes, these stop the compilation, with the line

--- a/hosting/cli/struct_test.go
+++ b/hosting/cli/struct_test.go
@@ -134,3 +134,60 @@ func TestAOneCharacterReelFitsAField(t *testing.T) {
 		t.Errorf("printed %s, want \"97 1\"", got)
 	}
 }
+
+// A struct crossing a deferred scope, which is what a composite answer is made of: a scope
+// that has to say two things — whether it worked and what it produced — says them as one run
+// of tapes, and whoever called it reads them back by naming the shape.
+func TestAStructComesOutOfAScope(t *testing.T) {
+	const declaration = "struct Result { failed, value };\n"
+
+	cases := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "built inside and read outside",
+			source: declaration + "ident make = defer { Result{1, 42}; };\nident r = make() as Result;\nprintd r.failed;\nprintd r.value;",
+			want:   []string{"1", "42"},
+		},
+		{
+			name: "chosen by a branch",
+			source: declaration +
+				"ident divide = defer { if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; }; };\n" +
+				"ident ok = divide(10, 2) as Result;\nident bad = divide(10, 0) as Result;\n" +
+				"printd ok.failed;\nprintd ok.value;\nprintd bad.failed;",
+			want: []string{"0", "5", "1"},
+		},
+		{
+			// The shape binds tighter than anything, so it can be named and read through in
+			// one expression, without a name in between.
+			name:   "shaped and read in one expression",
+			source: declaration + "ident make = defer { Result{1, 42}; };\nprintd make() as Result.value;",
+			want:   []string{"42"},
+		},
+		{
+			name: "fed into another scope",
+			source: declaration +
+				"ident make = defer { Result{0, 7}; };\n" +
+				"ident twice = defer { ident r = feed(0) as Result; r.value * 2; };\n" +
+				"printd twice(make());",
+			want: []string{"14"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := output(t, tc.source, 0)
+			if len(got) != len(tc.want) {
+				t.Fatalf("printed %v, want %v", got, tc.want)
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("printed %v, want %v", got, tc.want)
+					break
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Você pediu para um `defer` conseguir devolver struct, para dar valores compostos de erro e resultado. **Isso já funciona** — fui verificar com teste antes de desenhar qualquer coisa, e passou de primeira nas quatro formas.

```
struct Result { failed, value };

ident divide = defer {
  if feed(1) equals 0 {
    Result{1, 0};
  } else {
    Result{0, feed(0) / feed(1)};
  };
};

ident r = divide(10, 2) as Result;
printd r.failed;   #- 0
printd r.value;    #- 5
```

## Por que já funcionava

Um valor de struct é uma corrida de tapes e nada mais; o `feed` **entrega um valor mais largo inteiro** em vez de estreitá-lo (está escrito assim no `builtin/functions.go`); e o `return` carrega o que a última expressão produziu. Então um escopo respondendo duas tapes sempre foi possível, e o `as` sempre leu de volta.

## O que faltava era ninguém poder saber

A documentação mostra o cruzamento numa direção só — struct **entrando** num escopo pelo `feed` — e não diz nada sobre uma **saindo**, que é a direção que interessa quando um escopo precisa dizer se deu certo e o que produziu.

Então: testado nas quatro formas que valem (construída dentro e lida fora, escolhida por um `if`, nomeada e lida numa expressão só, e alimentada num segundo escopo), e escrito ao lado da direção que já estava.

## O limite que fecha a seção

**Um struct não atravessa módulo.** Um escopo importado de outro lugar pode responder uma corrida de tapes, e o arquivo que lê não tem nome para a forma delas.

É o mesmo muro em que a RFC do `syscall` (#72) esbarrou: `os.lookup_env` não pode responder `{found, value}` porque quem importa não consegue nomear `Result`. **Esse é o desenho que vale a pena fazer agora** — não "devolver struct de um defer", que existe, mas "struct atravessando módulo", que desbloqueia o padrão composto na biblioteca padrão e em qualquer projeto com mais de um arquivo.

## Verificação

`make check` limpo. O exemplo da documentação é executado pela suíte, como todo bloco `aurora` em `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)