### PR TITLE
feat: a block can promise the shape it answers with

### DIFF
--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -386,6 +386,67 @@ A struct does not cross a **module**, though — it is a way of naming the tapes
 one file is compiled, and it stays in the file that declared it. A scope imported from another
 module can answer with a run of tapes, and the file reading it has no name for their shape.
 
+### Promising a shape with `returns`
+
+`as` is what whoever reads a value claims about it, and the compiler believes it. `returns` is
+the other end: what a block promises about itself, checked where it is written.
+
+```aurora
+struct Result { failed, value };
+
+ident divide = defer {
+  if feed(1) equals 0 {
+    Result{1, 0};
+  } else {
+    Result{0, feed(0) / feed(1)};
+  };
+} returns Result;
+
+ident r = divide(10, 2);
+printd r.failed;   #- 0
+printd r.value;    #- 5
+```
+
+The word comes after the brace that closes the block, and that is the only place it goes — a
+block, or a deferred scope, which is a block with a word in front of it. An `if` never takes
+one; it is looked *through*, which is why the example above compiles: both arms answer with a
+`Result`. A `branch` is nested ifs by the time anything reads it, and its last item is the
+innermost else, so its way out is always covered.
+
+A block that does not keep its promise does not compile:
+
+```aurora
+#- fails: answers with Person and ends with a number
+struct Person { name };
+
+{
+  ident p = Person{"Joana"};
+  10;
+} returns Person;
+```
+
+An `if` with no else promises nothing, since the path where the test fails answers with the
+neutral value:
+
+```aurora
+#- fails: its if has no else
+struct Person { name };
+
+{
+  if true { Person{"Joana"}; };
+} returns Person;
+```
+
+**What it buys is the other end.** A call to a scope that promised has a shape, so `as`
+disappears from the place it was repeated once per call — and it stops being a claim, since
+the promise was checked. A scope that promises nothing is unchanged: it answers with a run of
+tapes, and whoever reads its fields writes `as`.
+
+The promise is never required, and never will be. A scope has no signature — it does not
+declare how many values it receives or what they are — so requiring it to declare what it
+answers with would be declaring one end and not the other. `returns` is what you gain by
+promising, not a toll for writing a block.
+
 ### What is an error
 
 Because the declaration exists to catch mistakes, these stop the compilation, with the line

--- a/examples/structs.ar
+++ b/examples/structs.ar
@@ -21,6 +21,9 @@
 #-   1
 #-   24930 98
 #-   0
+#-   0
+#-   5
+#-   1
 
 struct Point { x, y };
 
@@ -62,3 +65,28 @@ printd Pair{"ab", 98};
 #- the way head saturates and feed wraps. A claim can be wrong.
 ident single = 7 as Point;
 printd single.y;
+
+
+#- "as" is what whoever reads a value claims about it. "returns" is what a block
+#- promises about itself, and the compiler refuses the block that does not keep
+#- it — so a scope that says it answers with a Result and ends with a number
+#- does not compile.
+#-
+#- What it buys is the other end: a call to a scope that promised has a shape,
+#- so nobody has to claim one at every call site.
+struct Result { failed, value };
+
+ident divide = defer {
+  if feed(1) equals 0 {
+    Result{1, 0};
+  } else {
+    Result{0, feed(0) / feed(1)};
+  };
+} returns Result;
+
+ident r = divide(10, 2);
+printd r.failed;
+printd r.value;
+
+#- And it reads straight off the call, since the shape came with it.
+printd divide(1, 0).failed;

--- a/hosting/cli/struct_test.go
+++ b/hosting/cli/struct_test.go
@@ -191,3 +191,25 @@ func TestAStructComesOutOfAScope(t *testing.T) {
 		})
 	}
 }
+
+// A promise, kept, and the claim gone from the call site: the shape is known because the
+// scope said so, and the compiler checked that it said the truth.
+func TestAPromisedShapeIsReadWithoutAClaim(t *testing.T) {
+	const source = "struct Result { failed, value };\n" +
+		"ident divide = defer {\n" +
+		"  if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; };\n" +
+		"} returns Result;\n" +
+		"ident r = divide(10, 2);\n" +
+		"printd r.failed;\nprintd r.value;\nprintd divide(1, 0).failed;"
+
+	got := output(t, source, 0)
+	want := []string{"0", "5", "1"}
+	if len(got) != len(want) {
+		t.Fatalf("printed %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("printed %v, want %v", got, want)
+		}
+	}
+}

--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -139,7 +139,7 @@ func semanticTypeOf(tag string) (int, bool) {
 	case token.IDENT, token.IF, token.ELSE, token.BRANCH, token.DEFER,
 		token.PRINTB, token.PRINTC, token.PRINTD, token.ASSERT, token.FEED,
 		token.HEAD, token.TAIL, token.PUSH, token.PULL, token.TRUE, token.FALSE,
-		token.STRUCT, token.AS, token.USE:
+		token.STRUCT, token.AS, token.USE, token.RETURNS:
 		return SemanticKeyword, true
 	case token.NUMBER:
 		return SemanticNumber, true

--- a/hosting/lsp/textdoc/snippets.go
+++ b/hosting/lsp/textdoc/snippets.go
@@ -16,17 +16,19 @@ import (
 //
 // A keyword with no entry is offered as itself.
 var keywordSnippets = map[string]string{
-	token.IDENT:  "ident ${1:name} = ${0:value};",
-	token.DEFER:  "defer {\n\t$0\n}",
-	token.IF:     "if ${1:condition} {\n\t$0\n}",
-	token.BRANCH: "branch {\n\t${1:test}: ${2:value},\n\t${0:fallback};\n}",
-	token.STRUCT: "struct ${1:Name} { ${0:field} };",
-	token.AS:     "as ${0:Struct}",
-	token.ASSERT: "assert(${1:condition}, \"${0:message}\");",
-	token.FEED:   "feed(${0:0})",
-	token.PRINTB: "printb ${0:value};",
-	token.PRINTC: "printc ${0:value};",
-	token.PRINTD: "printd ${0:value};",
+	token.IDENT:   "ident ${1:name} = ${0:value};",
+	token.DEFER:   "defer {\n\t$0\n}",
+	token.IF:      "if ${1:condition} {\n\t$0\n}",
+	token.BRANCH:  "branch {\n\t${1:test}: ${2:value},\n\t${0:fallback};\n}",
+	token.STRUCT:  "struct ${1:Name} { ${0:field} };",
+	token.AS:      "as ${0:Struct}",
+	token.RETURNS: "returns ${0:Struct}",
+	token.USE:     "use ${1:a/b/c} as ${0:alias};",
+	token.ASSERT:  "assert(${1:condition}, \"${0:message}\");",
+	token.FEED:    "feed(${0:0})",
+	token.PRINTB:  "printb ${0:value};",
+	token.PRINTC:  "printc ${0:value};",
+	token.PRINTD:  "printd ${0:value};",
 	// The tape operations take a target and then a value; for head and tail that value is
 	// an index, and it has to be written as a number.
 	token.PULL: "pull ${1:tape} ${0:value}",

--- a/hosting/lsp/textdoc/structs.go
+++ b/hosting/lsp/textdoc/structs.go
@@ -17,14 +17,18 @@ import (
 type structShapes struct {
 	fields map[string][]string // struct name -> its fields, in order
 	shapes map[string]string   // identifier name -> the struct it is read as
+	// promises is what `returns` said: the name of a scope -> the struct calling it answers
+	// with. A name bound from such a call is read as that struct without anybody claiming it.
+	promises map[string]string
 }
 
 // scanStructs reads the declarations out of a token stream: `struct Point { x, y }` for the
 // fields, and `ident p = Point{...}` or `... as Point` for what a name is read as.
 func scanStructs(tokens []token.Token) structShapes {
 	found := structShapes{
-		fields: make(map[string][]string),
-		shapes: make(map[string]string),
+		fields:   make(map[string][]string),
+		shapes:   make(map[string]string),
+		promises: make(map[string]string),
 	}
 
 	for i := 0; i < len(tokens); i++ {
@@ -35,8 +39,17 @@ func scanStructs(tokens []token.Token) structShapes {
 				i = next
 			}
 		case token.IDENT:
-			// `ident p = Point{` and `ident p = <anything> as Point` both say what p is.
-			if name, shape := readBinding(tokens, i); shape != "" {
+			// `ident p = Point{`, `ident p = <anything> as Point` and a call to a scope that
+			// promised all say what p is; `ident f = defer { ... } returns Point` says what
+			// calling f will.
+			name, shape, promised, called := readBinding(tokens, i)
+			if promised != "" {
+				found.promises[name] = promised
+			}
+			if shape == "" && called != "" {
+				shape = found.promises[called]
+			}
+			if shape != "" {
 				found.shapes[name] = shape
 			}
 		}
@@ -67,30 +80,53 @@ func readDeclaration(tokens []token.Token, i int) (string, []string, int) {
 	return name, fields, len(tokens) - 1
 }
 
-// readBinding reads what `ident name = ...` binds, up to the end of the statement.
-func readBinding(tokens []token.Token, i int) (string, string) {
+// readBinding reads what `ident name = ...` binds, up to the end of the statement: the struct
+// it is read as, the struct calling it will answer with, and the scope it was bound from.
+//
+// Only what sits at the top of the value is read. A body between braces is another scope's
+// business — the semicolons in it do not end this statement, and a construction inside it says
+// what that scope answers with rather than what this name is.
+func readBinding(tokens []token.Token, i int) (name, shape, promised, called string) {
 	if i+2 >= len(tokens) || tokens[i+1].GetTag().Id != token.ID || tokens[i+2].GetTag().Id != token.ASSIGN {
-		return "", ""
+		return "", "", "", ""
 	}
-	name := string(tokens[i+1].GetMatch())
+	name = string(tokens[i+1].GetMatch())
 
+	depth := 0
 	for j := i + 3; j < len(tokens); j++ {
 		switch tokens[j].GetTag().Id {
+		case token.O_CUR_BRK:
+			depth++
+		case token.C_CUR_BRK:
+			depth--
 		case token.SEMICOLON:
-			return name, ""
+			if depth <= 0 {
+				return name, shape, promised, called
+			}
+		case token.RETURNS:
+			if depth == 0 && j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.ID {
+				promised = string(tokens[j+1].GetMatch())
+			}
 		case token.AS:
 			// The nearest `as` wins, which is the one the value ends up with.
-			if j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.ID {
-				return name, string(tokens[j+1].GetMatch())
+			if depth == 0 && j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.ID {
+				shape = string(tokens[j+1].GetMatch())
 			}
 		case token.ID:
-			// A construction: the name of a struct in front of a brace.
-			if j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.O_CUR_BRK {
-				return name, string(tokens[j].GetMatch())
+			if depth != 0 || j+1 >= len(tokens) {
+				continue
+			}
+			switch tokens[j+1].GetTag().Id {
+			case token.O_CUR_BRK:
+				// A construction: the name of a struct in front of a brace.
+				shape = string(tokens[j].GetMatch())
+			case token.O_PAREN:
+				// A call: what it answers with is known when that scope promised.
+				called = string(tokens[j].GetMatch())
 			}
 		}
 	}
-	return name, ""
+	return name, shape, promised, called
 }
 
 // fieldsBefore answers the fields offered at a position, when what sits in front of the

--- a/hosting/lsp/textdoc/structs_test.go
+++ b/hosting/lsp/textdoc/structs_test.go
@@ -137,3 +137,62 @@ func TestSemanticTokensForStructs(t *testing.T) {
 		}
 	}
 }
+
+// A promise reaches the editor too, and it reaches it from the tokens: a document being
+// edited does not parse, and the moment somebody types a dot is the moment they want to be
+// told what is there.
+func TestTheEditorReadsAPromise(t *testing.T) {
+	const source = "struct Result { failed, value };\n" +
+		"ident divide = defer {\n" +
+		"  if feed(1) equals 0 { Result{1, 0}; } else { Result{0, 1}; };\n" +
+		"} returns Result;\n" +
+		"ident r = divide(10, 2);\n" +
+		"printd r."
+
+	document := Document{Filename: "main.ar", Source: source}
+	items := session().CompletionItemsFor(document, lsp.Position{Line: 5, Character: 9}, false)
+
+	if len(items) != 2 {
+		t.Fatalf("offered %d items after the dot, want the two fields: %+v", len(items), items)
+	}
+	for i, want := range []string{"failed", "value"} {
+		if items[i].Label != want {
+			t.Errorf("offered %q, want %q", items[i].Label, want)
+		}
+	}
+}
+
+// And a scope that promised nothing gives the editor nothing, the same way it gives the
+// compiler nothing.
+func TestTheEditorReadsNoPromiseWhereThereIsNone(t *testing.T) {
+	const source = "struct Result { failed, value };\n" +
+		"ident divide = defer { Result{1, 0}; };\n" +
+		"ident r = divide(10, 2);\n" +
+		"printd r."
+
+	document := Document{Filename: "main.ar", Source: source}
+	items := session().CompletionItemsFor(document, lsp.Position{Line: 3, Character: 9}, false)
+
+	for _, item := range items {
+		if item.Label == "failed" || item.Label == "value" {
+			t.Errorf("offered %q for a scope that promised nothing", item.Label)
+		}
+	}
+}
+
+// The body of a scope is another scope's business: a construction inside it says what that
+// scope answers with, not what the name being bound is.
+func TestABodyDoesNotShapeTheNameItIsBoundTo(t *testing.T) {
+	const source = "struct Result { failed, value };\n" +
+		"ident divide = defer { Result{1, 0}; };\n" +
+		"printd divide."
+
+	document := Document{Filename: "main.ar", Source: source}
+	items := session().CompletionItemsFor(document, lsp.Position{Line: 2, Character: 14}, false)
+
+	for _, item := range items {
+		if item.Label == "failed" || item.Label == "value" {
+			t.Errorf("offered %q: a deferred scope is not the struct its body builds", item.Label)
+		}
+	}
+}

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -28,6 +28,7 @@ var keywordTags = []token.Tag{
 	token.TagStruct,
 	token.TagAs,
 	token.TagUse,
+	token.TagReturns,
 }
 
 var Keywords = func() map[string]token.Tag {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -689,35 +689,46 @@ func (p *pr) ParseBranch() (ast.Node, error) {
 	return item, nil
 }
 
+// ParseBlockExpr reads a block where an expression is wanted.
 func (p *pr) ParseBlockExpr() (ast.Node, error) {
+	return p.parseBlock()
+}
+
+// parseBlock reads `{ ... }` and the promise that may follow it.
+//
+// A deferred scope is a block with a word in front of it, so it comes through here too — which
+// is what gives it the promise, and what keeps the braces from being read in two places.
+func (p *pr) parseBlock() (ast.BlockExpression, error) {
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
-		return nil, err
+		return ast.BlockExpression{}, err
 	}
 	exprs, err := p.ParseExprs(token.TagCCurBrk)
 	if err != nil {
-		return nil, err
+		return ast.BlockExpression{}, err
 	}
-	if _, err := p.EatToken(token.C_CUR_BRK); err != nil {
-		return nil, err
+	closing, err := p.EatToken(token.C_CUR_BRK)
+	if err != nil {
+		return ast.BlockExpression{}, err
 	}
-	return ast.BlockExpression{Body: exprs}, nil
+
+	// The promise is read here, which is the one place it is written. The body of an if is
+	// read straight rather than through here, so it never takes one.
+	promised, err := p.parseReturns(exprs, closing)
+	if err != nil {
+		return ast.BlockExpression{}, err
+	}
+
+	return ast.BlockExpression{Body: exprs, Returns: promised}, nil
 }
 
 func (p *pr) ParseDefer() (ast.Node, error) {
 	if _, err := p.EatToken(token.DEFER); err != nil {
 		return nil, err
 	}
-	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
-		return nil, err
-	}
-	exprs, err := p.ParseExprs(token.TagCCurBrk)
+	block, err := p.parseBlock()
 	if err != nil {
 		return nil, err
 	}
-	if _, err := p.EatToken(token.C_CUR_BRK); err != nil {
-		return nil, err
-	}
-	block := ast.BlockExpression{Body: exprs}
 	return ast.DeferExpression{Block: block}, nil
 }
 
@@ -793,6 +804,11 @@ func (p *pr) ParseIdent() (ast.Node, error) {
 	name := p.name(string(id.GetMatch()))
 	if shape := p.shapeOf(expr); shape != "" {
 		p.declarations.Shapes[name] = shape
+	}
+	// A scope that promised is not itself a struct — its value is an index — so what is
+	// written down is what calling it answers with.
+	if scope, ok := expr.(ast.DeferExpression); ok && scope.Block.Returns != "" {
+		p.declarations.Returns[name] = scope.Block.Returns
 	}
 	return ast.IdentLiteral{Id: name, Token: id, Value: expr}, nil
 }

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -1,0 +1,185 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// What a block promises, and what happens when it does not keep it.
+//
+// `as` is a claim the compiler believes; this is a promise it checks. The two live in one
+// program, and a block that promises nothing goes on answering with a run of tapes.
+
+const person = "struct Person { name };\n"
+const result = "struct Result { failed, value };\n"
+
+// The promise is read at the end of a block, and it is the same place for a deferred scope,
+// which is a block with a word in front of it.
+func TestABlockPromisesAShape(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "a block",
+			source: person + "{ ident p = Person{\"Joana\"};\np; } returns Person;",
+		},
+		{
+			name:   "a deferred scope",
+			source: person + "ident make = defer {\nPerson{\"Joana\"};\n} returns Person;",
+		},
+		{
+			name: "an if with both arms agreeing",
+			source: result + "ident divide = defer {\n" +
+				"if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; };\n" +
+				"} returns Result;",
+		},
+		{
+			// A branch is nested ifs by the time anything reads the tree, and its last item
+			// is the innermost else — so the way out is always covered.
+			name: "a branch",
+			source: result + "ident classify = defer {\n" +
+				"branch { feed(0) equals 0: Result{0, 100}, feed(0) equals 1: Result{0, 200}, Result{1, 0}; };\n" +
+				"} returns Result;",
+		},
+		{
+			// The promise is kept by a name whose shape was named, the same way a field read
+			// is allowed by one.
+			name:   "a name that was shaped",
+			source: person + "ident make = defer {\nident p = feed(0) as Person;\np;\n} returns Person;",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSource(t, tc.source, "main.ar"); err != nil {
+				t.Fatalf("parsing: %v", err)
+			}
+		})
+	}
+}
+
+// The promise reaches the tree, so whoever reads the block knows what it answers with.
+func TestThePromiseIsOnTheBlock(t *testing.T) {
+	nodes := parse(t, person+"{ Person{\"Joana\"}; } returns Person;")
+
+	block, ok := nodes[1].(ast.BlockExpression)
+	if !ok {
+		t.Fatalf("the second node is %T, want a block", nodes[1])
+	}
+	if block.Returns != "Person" {
+		t.Errorf("the block promises %q, want Person", block.Returns)
+	}
+}
+
+// A block that promises nothing is a block, and answers with a run of tapes as it always did.
+func TestABlockWithoutAPromiseIsUnchanged(t *testing.T) {
+	nodes := parse(t, person+"{ Person{\"Joana\"}; };")
+
+	if block := nodes[1].(ast.BlockExpression); block.Returns != "" {
+		t.Errorf("the block promises %q, want nothing", block.Returns)
+	}
+}
+
+// Every way of breaking the promise, and what it says.
+var brokenPromises = []struct {
+	name   string
+	source string
+	want   string
+}{
+	{
+		name:   "ends with a number",
+		source: person + "{ ident p = Person{\"Joana\"};\n10; } returns Person;",
+		want:   "answers with Person and ends with a number",
+	},
+	{
+		name:   "ends with another struct",
+		source: person + "struct Place { city };\n{ Place{\"Recife\"}; } returns Person;",
+		want:   "answers with Person and ends with a Place",
+	},
+	{
+		name:   "an if with no else",
+		source: person + "{ if true { Person{\"Joana\"}; }; } returns Person;",
+		want:   "its if has no else",
+	},
+	{
+		name:   "an else that answers with something else",
+		source: person + "{ if true { Person{\"Joana\"}; } else { 0; }; } returns Person;",
+		want:   "the else answers with a number",
+	},
+	{
+		name:   "an if arm that answers with something else",
+		source: person + "{ if true { 0; } else { Person{\"Joana\"}; }; } returns Person;",
+		want:   "the if answers with a number",
+	},
+	{
+		name:   "a shape nobody declared",
+		source: "{ 10; } returns Person;",
+		want:   "Person is not a declared struct",
+	},
+	{
+		name:   "an empty block",
+		source: person + "{ } returns Person;",
+		want:   "ends with nothing",
+	},
+}
+
+func TestABlockThatDoesNotKeepItsPromise(t *testing.T) {
+	for _, tc := range brokenPromises {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseSource(t, tc.source, "main.ar")
+			if err == nil {
+				t.Fatal("expected a compile error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q, want it to say %q", err, tc.want)
+			}
+			positioned, ok := err.(*token.Error)
+			if !ok || positioned.Line == 0 {
+				t.Errorf("error is %T and unpositioned", err)
+			}
+		})
+	}
+}
+
+// A scope that promised gives its callers a shape, so the claim disappears from the place it
+// used to be repeated once per call.
+func TestACallToAScopeThatPromisedHasAShape(t *testing.T) {
+	const source = result +
+		"ident divide = defer {\n" +
+		"if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; };\n" +
+		"} returns Result;\n"
+
+	for _, tc := range []struct{ name, read string }{
+		{name: "bound and then read", read: "ident r = divide(10, 2);\nprintd r.value;"},
+		{name: "read straight off the call", read: "printd divide(10, 2).value;"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := parseSource(t, source+tc.read, "main.ar"); err != nil {
+				t.Errorf("parsing: %v", err)
+			}
+		})
+	}
+}
+
+// A scope that promised nothing gives nothing away, and reading a field off it still asks for
+// the claim — which is the half of the rule that does not change.
+func TestACallToAScopeThatPromisedNothing(t *testing.T) {
+	const source = result + "ident divide = defer { Result{0, 5}; };\nident r = divide(10, 2);\nprintd r.value;"
+
+	_, err := parseSource(t, source, "main.ar")
+	if err == nil {
+		t.Fatal("expected a compile error")
+	}
+	if !strings.Contains(err.Error(), "nothing says which struct this value is") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+// A block bound to a name is the run of tapes itself, so the promise is the name's own shape.
+func TestABlockBoundToANameCarriesItsPromise(t *testing.T) {
+	if _, err := parseSource(t, person+"ident p = { Person{\"Joana\"}; } returns Person;\nprintc p.name;", "main.ar"); err != nil {
+		t.Errorf("parsing: %v", err)
+	}
+}

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -33,6 +33,10 @@ type Declarations struct {
 	// Modules is what `use` declared: alias -> specifier. It belongs to the file that wrote
 	// it and to no other, which is the whole point of the alias being mandatory.
 	Modules map[string]string
+	// Returns is what `returns` promised: the name of a scope -> the struct that calling it
+	// answers with. It is not the shape of the name itself — a deferred scope is an index —
+	// but the shape of what comes back from it.
+	Returns map[string]string
 }
 
 func NewDeclarations() *Declarations {
@@ -40,6 +44,7 @@ func NewDeclarations() *Declarations {
 		Structs: make(map[string][]string),
 		Shapes:  make(map[string]string),
 		Modules: make(map[string]string),
+		Returns: make(map[string]string),
 	}
 }
 
@@ -224,6 +229,10 @@ func (p *pr) parseShape(expr ast.Node) (ast.Node, error) {
 
 // shapeOf answers which struct a value is read as, or empty when nothing said. A field is
 // one tape wide, so reading a field of a field is never known.
+//
+// What it sees through is what a promise is worth: a block answers with its last expression,
+// and an if answers with whatever the arm that runs answers with — so both arms have to agree,
+// and an if with no else agrees with nothing.
 func (p *pr) shapeOf(node ast.Node) string {
 	switch n := node.(type) {
 	case ast.StructLiteral:
@@ -232,6 +241,134 @@ func (p *pr) shapeOf(node ast.Node) string {
 		return n.Struct
 	case ast.IdentifierLiteral:
 		return p.declarations.Shapes[n.Value]
+	case ast.BlockExpression:
+		if n.Returns != "" {
+			return n.Returns
+		}
+		return p.shapeOfLast(n.Body)
+	case ast.CalleeLiteral:
+		// Not the shape of the name, which is a deferred scope, but of what calling it
+		// answers with — which is only known because the scope promised.
+		return p.declarations.Returns[n.Id.Value]
+	case ast.IfExpression:
+		if n.Else == nil {
+			return ""
+		}
+		shape := p.shapeOfLast(n.Body)
+		if shape != "" && shape == p.shapeOfLast(n.Else.Body) {
+			return shape
+		}
 	}
 	return ""
+}
+
+// shapeOfLast answers for the expression a body ends with, which is what the body answers with.
+func (p *pr) shapeOfLast(body []ast.Node) string {
+	if len(body) == 0 {
+		return ""
+	}
+	return p.shapeOf(body[len(body)-1])
+}
+
+// What `returns` promises, and how the promise is kept.
+//
+// `as` is a claim: the compiler believes it and has nothing to check it against, which is why
+// a wrong one reads the wrong tape and the program carries on. `returns` is the other end —
+// the block says what it answers with, and this refuses the block that does not.
+//
+// The promise is worth what shapeOf can see through, which is why that is the part that grew.
+
+// parseReturns reads `returns Person` after a block, and checks what the block ends with.
+func (p *pr) parseReturns(body []ast.Node, closing token.Token) (string, error) {
+	if p.GetLookahead() == nil || p.GetLookahead().GetTag().Id != token.RETURNS {
+		return "", nil
+	}
+	if _, err := p.EatToken(token.RETURNS); err != nil {
+		return "", err
+	}
+	name, err := p.EatToken(token.ID)
+	if err != nil {
+		return "", err
+	}
+
+	promised := string(name.GetMatch())
+	if _, declared := p.declarations.Structs[promised]; !declared {
+		return "", token.NewError(name, "%s is not a declared struct at line %d and column %d",
+			promised, name.GetLine(), name.GetColumn())
+	}
+	if err := p.answersWith(body, promised, "", closing); err != nil {
+		return "", err
+	}
+	return promised, nil
+}
+
+// answersWith refuses a body that ends with something other than what was promised.
+//
+// A `where` names the arm being read, so a promise broken inside a branch says which one; the
+// block itself has no name and simply ends.
+func (p *pr) answersWith(body []ast.Node, promised, where string, at token.Token) error {
+	if len(body) == 0 {
+		return brokenPromise(at, promised, where, "nothing")
+	}
+
+	last := body[len(body)-1]
+	// An if is looked through rather than at: it answers with whatever the arm that runs
+	// answers with, so every arm has to keep the promise. A branch is nested ifs by the time
+	// anything reads the tree, so this covers it too.
+	if answer, ok := last.(ast.IfExpression); ok {
+		if answer.Else == nil {
+			return token.NewError(at, "this block answers with %s and its if has no else at line %d and column %d: one path answers with nothing",
+				promised, at.GetLine(), at.GetColumn())
+		}
+		if err := p.answersWith(answer.Body, promised, "the if", at); err != nil {
+			return err
+		}
+		return p.answersWith(answer.Else.Body, promised, "the else", at)
+	}
+
+	if p.shapeOf(last) == promised {
+		return nil
+	}
+	return brokenPromise(at, promised, where, describeAnswer(last))
+}
+
+// brokenPromise says what was promised and what is there instead.
+func brokenPromise(at token.Token, promised, where, answer string) error {
+	if where == "" {
+		return token.NewError(at, "this block answers with %s and ends with %s at line %d and column %d",
+			promised, answer, at.GetLine(), at.GetColumn())
+	}
+	return token.NewError(at, "this block answers with %s and %s answers with %s at line %d and column %d",
+		promised, where, answer, at.GetLine(), at.GetColumn())
+}
+
+// describeAnswer names what a node answers with, for the message of a promise that was not
+// kept. It is the reader's words rather than the tree's: somebody reading the error is looking
+// at what they wrote, not at a node type.
+func describeAnswer(node ast.Node) string {
+	switch n := node.(type) {
+	case ast.NumberLiteral:
+		return "a number"
+	case ast.TextLiteral:
+		return "text"
+	case ast.BooleanLiteral:
+		return "a boolean"
+	case ast.StructLiteral:
+		return "a " + n.Name
+	case ast.ShapedExpression:
+		return "a " + n.Struct
+	case ast.IdentifierLiteral:
+		return "the name " + n.Value
+	case ast.CalleeLiteral:
+		return "a call to " + n.Id.Value
+	case ast.DeferExpression:
+		return "a deferred scope"
+	case ast.TapeBracketExpression:
+		return "a tape"
+	case ast.BinaryExpression:
+		return "arithmetic"
+	case ast.RelativeExpression, ast.BooleanExpression:
+		return "a comparison"
+	}
+	return "something no shape was named for"
 }

--- a/wire/ast/equal.go
+++ b/wire/ast/equal.go
@@ -146,7 +146,7 @@ func ifEqual(a, b IfExpression) bool {
 }
 
 func blockEqual(a, b BlockExpression) bool {
-	return nodesEqual(a.Body, b.Body)
+	return a.Returns == b.Returns && nodesEqual(a.Body, b.Body)
 }
 
 func elseEqual(a, b ElseExpression) bool {

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -150,7 +150,11 @@ type BooleanExpression struct {
 
 type BlockExpression struct {
 	mark
-	Body []Node `json:"body"`
+	// Returns is the struct this block promised to answer with, and empty when it promised
+	// nothing. It is checked where it is written and never reaches an instruction: like the
+	// declaration it names, it is read while compiling and dropped.
+	Returns string `json:"returns,omitempty"`
+	Body    []Node `json:"body"`
 }
 
 // DeferExpression is "defer { ... }". It produces a value that is a pointer to the scope

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -39,6 +39,7 @@ const (
 	PRINTD       = "PRINTD"    // printd - a value as a decimal number
 	PULL         = "PULL"      // pull
 	PUSH         = "PUSH"      // push
+	RETURNS      = "RETURNS"   // returns - the shape a block answers with
 	SEMICOLON    = "SEMICOLON" // ;
 	SMALLER      = "SMALLER"   // smaller
 	STRING       = "STRING"    // text literal "text" - one more way of writing a tape
@@ -96,6 +97,7 @@ var (
 	TagOr         = Tag{OR, "or", ""}
 	TagPull       = Tag{PULL, "pull", "Pull item in right to left"}
 	TagPush       = Tag{PUSH, "push", "Push item in left to right"}
+	TagReturns    = Tag{RETURNS, "returns", "Name the struct a block answers with"}
 	TagSemicolon  = Tag{SEMICOLON, ";", ""}
 	TagSmaller    = Tag{SMALLER, "smaller", ""}
 	TagString     = Tag{STRING, "", ""} // Text literal: "text", the bytes it holds, in a tape
@@ -126,6 +128,7 @@ var processableTags = []Tag{
 	TagStruct,
 	TagAs,
 	TagUse,
+	TagReturns,
 }
 
 func GetProcessableTags() []Tag {


### PR DESCRIPTION
Implementa a RFC do #74, com o escopo de LSP inteiro junto.

```
struct Result { failed, value };

ident divide = defer {
  if feed(1) equals 0 {
    Result{1, 0};
  } else {
    Result{0, feed(0) / feed(1)};
  };
} returns Result;

ident r = divide(10, 2);
printd r.failed;   #- 0
printd r.value;    #- 5
```

`as` é alegação — o compilador acredita e não confere. `returns` é promessa: **o bloco que não a cumpre não compila.**

## Os três commits

**1. A palavra, a gramática e a promessa.** Uma produção só, no bloco. Um `if` nunca recebe a palavra — é olhado *através*, e cada ramo tem que cumprir; sem `else` não promete nada. `branch` não precisou de regra: é `if` aninhado quando alguém lê a árvore.

Junto vem o que a promessa compra: **uma chamada a quem prometeu tem forma**, então o `as` some do lugar onde era repetido uma vez por chamada — e deixa de ser alegação, porque foi conferido.

**2. O editor lê a promessa.** Depois de um ponto num nome ligado a uma chamada, os campos do struct prometido; nada quando não houve promessa, que é a mesma resposta do compilador. Lido dos **tokens**, como as formas de struct ao lado, pelo mesmo motivo: documento sendo editado não parseia.

**3. Documentação e exemplo**, com as duas recusas como blocos que dizem que falham — a suíte roda e confere as palavras.

## Três coisas que a implementação achou

**O `defer` lia as próprias chaves.** `ParseDefer` duplicava `{`, `ParseExprs`, `}` em vez de chamar `ParseBlockExpr` — por isso a palavra era invisível ali. Unifiquei em vez de escrever a terceira cópia.

**O scanner do editor parava no primeiro `;`.** Num `defer` isso é dentro do corpo, então tudo depois era invisível — inclusive a palavra no fim. Agora ele conta chaves.

**E isso destapou um segundo defeito**: uma construção dentro do corpo dava forma ao nome ligado. `ident f = defer { Result{1,0}; };` fazia o editor achar que `f` era um `Result` — `f` é um escopo. Tem teste para os dois.

**Bônus**: `use` estava sendo oferecido no completar **sem snippet** desde que módulos entraram. Ganhou um.

## Não é tipagem obrigatória

Um bloco sem `returns` continua como sempre foi, e sempre vai continuar — está escrito na documentação com o motivo: um escopo não tem assinatura, então exigir que ele declare o que responde seria declarar uma ponta e não a outra.

## Verificação

`make check` limpo. `make complexity` só acusa um teste que já era longo antes. Os exemplos da documentação são executados, e a saída declarada do `examples/structs.ar` é comparada com uma execução real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)