### PR TITLE
test: a struct value crosses a module and its declaration does not

### DIFF
--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -189,3 +189,40 @@ func TestATestWhoseModuleIsNotThere(t *testing.T) {
 		t.Errorf("the error says %q", got)
 	}
 }
+
+// What crosses a module and what does not, which is a sharper line than it looks.
+//
+// The value crosses whole: a struct is a run of tapes and nothing in it says a struct built
+// it, so a scope in another file answers with one and the bytes arrive intact. What does not
+// cross is the declaration — the table that turns a field name into an index — because it is
+// read while a file is parsed and belongs to that file.
+func TestAStructValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
+	files := map[string]string{
+		"src/a/b.ar":  "struct Result { failed, value };\nident make = defer { Result{1, 42}; };",
+		"src/main.ar": "use a/b as x;\nprintd x.make();",
+	}
+
+	t.Run("the value arrives whole", func(t *testing.T) {
+		projectOf(t, files)
+		printed, err := run(t, "src/main.ar")
+		if err != nil {
+			t.Fatalf("running: %v", err)
+		}
+		if strings.TrimSpace(printed) != "1 42" {
+			t.Errorf("printed %q, want the two tapes the module built", printed)
+		}
+	})
+
+	t.Run("and the field name has nowhere to be resolved", func(t *testing.T) {
+		reading := map[string]string{
+			"src/a/b.ar":  files["src/a/b.ar"],
+			"src/main.ar": "use a/b as x;\nident r = x.make();\nprintd r.value;",
+		}
+		projectOf(t, reading)
+		if _, err := run(t, "src/main.ar"); err == nil {
+			t.Fatal("the field was read without a shape")
+		} else if !strings.Contains(err.Error(), "nothing says which struct this value is") {
+			t.Errorf("error = %q", err)
+		}
+	})
+}

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -102,6 +102,19 @@ func TestWhatARefusalSays(t *testing.T) {
 			want: []string{"module a/b has no area", "it has base"},
 		},
 		{
+			// A struct's name is not something a module offers, and the refusal has to stay
+			// where it is. Adding struct declarations to the export list would make this
+			// compile — as a name being loaded, since that is what a qualified name is —
+			// and then fail while running, with a name nobody bound. A refusal that moves
+			// from the compiler to the run is the bug the whole design exists to prevent.
+			name: "a struct name is not offered by a module",
+			files: map[string]string{
+				"src/a/b.ar":  "struct Prime { p };\nident v = 1;",
+				"src/main.ar": "use a/b as x;\nprintd x.Prime;",
+			},
+			want: []string{"module a/b has no Prime", "it has v"},
+		},
+		{
 			name: "two modules in a circle",
 			files: map[string]string{
 				"src/one.ar":  "use two as t;\nident a = 1;",


### PR DESCRIPTION
Dois testes que fixam onde passa a fronteira, porque toda conversa de desenho sobre isso começa errando a linha — inclusive a minha.

**O valor atravessa inteiro.** Um módulo constrói `Result{1, 42}` e o `main.ar` imprime `1 42`. Uma corrida de tapes não tem nada dentro dizendo que um struct a construiu, então ela cruza qualquer fronteira sem esforço.

**A declaração não atravessa.** `r.value` falha com *"nothing says which struct this value is"*: a tabela que transforma nome de campo em índice é lida durante o parse e pertence ao arquivo que declarou.

É a evidência para o desenho que vem a seguir.

`make check` limpo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)