### PR TITLE
feat: a shape crosses a module with the promise that names it

### DIFF
--- a/cmd/aurora/resolver.go
+++ b/cmd/aurora/resolver.go
@@ -24,7 +24,7 @@ func newResolver(tapeSize int, sourceRoot string) *resolver.Resolver {
 	return resolver.New(resolver.Options{
 		SourceRoot: sourceRoot,
 		Read:       os.ReadFile,
-		Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+		Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 			tokens, err := lx.GetFilledTokens(source)
 			if err != nil {
 				return ast.AST{}, err
@@ -34,7 +34,17 @@ func newResolver(tapeSize int, sourceRoot string) *resolver.Resolver {
 				Tokens:   tokens,
 				TapeSize: tapeSize,
 				Module:   string(id),
+				Imports:  imports,
 			})
+		},
+		// What a file imports is read from the top of it, without a parse: a module has to be
+		// read before whoever imports it, and knowing what to read cannot itself need one.
+		Header: func(source []byte) ([]ast.UseDeclaration, error) {
+			tokens, err := lx.GetFilledTokens(source)
+			if err != nil {
+				return nil, err
+			}
+			return parser.ScanUses(tokens), nil
 		},
 	})
 }

--- a/cmd/aurorals/modules.go
+++ b/cmd/aurorals/modules.go
@@ -33,7 +33,7 @@ func resolveModules(s *state.State) textdoc.Resolve {
 		return resolver.New(resolver.Options{
 			SourceRoot: sourceRootFor(doc.Filename),
 			Read:       readThroughBuffers(s),
-			Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+			Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 				tokens, err := lx.GetFilledTokens(source)
 				if err != nil {
 					return ast.AST{}, err
@@ -43,7 +43,15 @@ func resolveModules(s *state.State) textdoc.Resolve {
 					Tokens:   tokens,
 					TapeSize: doc.TapeSize,
 					Module:   string(id),
+					Imports:  imports,
 				})
+			},
+			Header: func(source []byte) ([]ast.UseDeclaration, error) {
+				tokens, err := lx.GetFilledTokens(source)
+				if err != nil {
+					return nil, err
+				}
+				return parser.ScanUses(tokens), nil
 			},
 		}).DependenciesOf(doc.Filename, uses)
 	}

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -382,9 +382,9 @@ ident make = defer { Result{1, 42}; };
 printd make() as Result.value;   #- 42
 ```
 
-A struct does not cross a **module**, though — it is a way of naming the tapes of a run while
-one file is compiled, and it stays in the file that declared it. A scope imported from another
-module can answer with a run of tapes, and the file reading it has no name for their shape.
+A struct's **name** does not cross a module — it is a way of naming the tapes of a run while
+one file is compiled, and it stays in the file that declared it. What crosses is the shape,
+and only where a promise names it: see below.
 
 ### Promising a shape with `returns`
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -80,30 +80,42 @@ The alias belongs to the file that wrote it. It is not a name the module chose, 
 nothing in any other file — two files may reach the same module under two different names, and
 one file may not use the same name twice.
 
-It is a name in the file's scope like any other, so it cannot also be a value:
+It is a name in the file's scope like any other, so it cannot also be a value. These are
+refused while compiling — shown rather than run, because a module is read before the file that
+imports it, so a block on its own would be refused for the module missing before it got this
+far:
 
-```aurora
-#- fails: x is the module geometry
+```
 use geometry as x;
 
 printd x;
 ```
 
-```aurora
-#- fails: x is already the alias of geometry
+```
+x is the module geometry at line 3 and column 8: reach something inside it with x.name
+```
+
+```
 use geometry as x;
 
 ident x = 1;
 ```
 
+```
+x is already the alias of geometry at line 3 and column 7
+```
+
 And `use` belongs above everything else, so what a file depends on is known before anything
 happens in it:
 
-```aurora
-#- fails: use belongs to the top of the file
+```
 ident n = 1;
 
 use geometry as g;
+```
+
+```
+use belongs to the top of the file at line 3 and column 1: put it above everything else
 ```
 
 ---
@@ -115,8 +127,8 @@ which is the same thing since a scope's value is its index. Nothing else:
 
 - a name bound inside a block or a deferred body belongs to the scope that binds it, and is
   gone when that scope is;
-- a `struct` does not cross a module. It is a way of naming the fields of a run of tapes while
-  a file is compiled, and it stays in the file that declared it;
+- a `struct`'s **name** does not cross a module, and cannot be written in another file. What
+  does cross is the shape of one a scope promised — see below;
 - an import is not passed on. If `main` uses `a` and `a` uses `b`, then `main` does not reach
   `b` — it writes its own `use b as ...;`. Every file declares what it needs, and a name used
   in a file has its origin declared in that file.
@@ -140,6 +152,36 @@ use geometry as g;
 
 printd g.area(1, 2);
 ```
+
+### A shape crosses with the promise that names it
+
+A scope that says what it answers with hands the shape over, so whoever imports it reads the
+fields without naming anything:
+
+```
+#- src/os.ar
+struct Env { found, value };
+
+ident lookup = defer {
+  Env{1, 42};
+} returns Env;
+```
+
+```
+#- src/main.ar
+use os as o;
+
+ident r = o.lookup("HOME");
+printd r.found;
+printd r.value;
+```
+
+Nothing in `main.ar` mentions `Env`, and nothing can: a struct's name stays in the file that
+declared it. What crossed is the promise — the struct and the fields it is made of — which is
+what turns `found` into the first tape of the run.
+
+A scope that promised nothing hands over a run of tapes and no shape, exactly as it did
+before: the file reading it has to name one, and there is nothing to name.
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -73,10 +73,10 @@ is why it has that shape.
 
 What it does not do yet:
 
-- **A `struct` does not cross a module.** Exporting one would mean knowing another module's
-  struct table while parsing, which is exactly the dependency the design removed — the parse
-  of a file needs nothing from any other file. It would come back as a table the loader hands
-  the parser, which is a different shape from the one that exists.
+- **A `struct`'s name cannot be written in another file.** `as m.Point` and `m.Point{1, 2}`
+  are not syntax, so a shape is reached only through a promise, and a module that declares one
+  without promising with it offers nothing. Naming is the half of
+  [rfcs/crossing_shapes.md](../rfcs/crossing_shapes.md) that is not built yet.
 - **There is no `private`.** A module offers everything it binds with `ident` at the top. The
   boundary exists now, so marking part of it later breaks nothing.
 - **The language server follows an import, and stops short of two things.** It reads what a

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -239,3 +239,81 @@ func TestAStructValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
 		}
 	})
 }
+
+// A shape crosses a module with the promise that names it.
+//
+// The struct is declared in one file and read in another, and nothing in the reading file
+// names it: what crossed is the promise the scope made, with the fields of the struct it
+// answers with — which is what turns a field name into the index of a tape.
+func TestAPromisedShapeCrossesAModule(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/os.ar": "struct Env { found, value };\n" +
+			"ident lookup = defer {\n" +
+			"  if feed(0) equals 0 { Env{0, 0}; } else { Env{1, 42}; };\n" +
+			"} returns Env;",
+		"src/main.ar": "use os as o;\n" +
+			"ident r = o.lookup(1);\n" +
+			"printd r.found;\nprintd r.value;\n" +
+			"printd o.lookup(0).found;",
+	})
+
+	printed, err := run(t, "src/main.ar")
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if got := strings.Fields(printed); len(got) != 3 || got[0] != "1" || got[1] != "42" || got[2] != "0" {
+		t.Errorf("printed %q, want 1 42 0", printed)
+	}
+}
+
+// A field the promised struct does not have is refused where it was written, naming what the
+// struct is made of — the same refusal a local struct gets.
+func TestAFieldThePromiseDoesNotHave(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/os.ar":   "struct Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;",
+		"src/main.ar": "use os as o;\nident r = o.lookup(1);\nprintd r.missing;",
+	})
+
+	_, err := run(t, "src/main.ar")
+	if err == nil {
+		t.Fatal("a field nobody declared was read")
+	}
+	if !strings.Contains(err.Error(), "has no field named missing") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+// A scope that promised nothing hands over a run of tapes and no shape, which is what it did
+// before any of this: the reading file has to name one, and there is nothing to name.
+func TestAScopeThatPromisedNothingCrossesNothing(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/os.ar":   "struct Env { found, value };\nident lookup = defer { Env{1, 42}; };",
+		"src/main.ar": "use os as o;\nident r = o.lookup(1);\nprintd r.found;",
+	})
+
+	_, err := run(t, "src/main.ar")
+	if err == nil {
+		t.Fatal("a field was read off a scope that promised nothing")
+	}
+	if !strings.Contains(err.Error(), "nothing says which struct this value is") {
+		t.Errorf("error = %q", err)
+	}
+}
+
+// A test reads a promised shape too, since the file it belongs to and the file testing it are
+// one module, and what they import is read before either of them is parsed.
+func TestATestReadsAPromisedShape(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/os.ar":        "struct Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;",
+		"src/main.ar":      "use os as o;\nident r = o.lookup(0);",
+		"src/main.test.ar": "assert(r.value equals 42, \"the field is read through the promise\");",
+	})
+
+	report, err := tested(t, "", sessionOpts{asserts: true})
+	if err != nil {
+		t.Fatalf("testing: %v", err)
+	}
+	if !report.OK() {
+		t.Errorf("the run did not pass: %+v", report.Files)
+	}
+}

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -41,7 +41,7 @@ func newTestResolver(tapeSize int) *resolver.Resolver {
 	return resolver.New(resolver.Options{
 		SourceRoot: manifest.DefaultSourceRoot,
 		Read:       os.ReadFile,
-		Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+		Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 			tokens, err := lx.GetFilledTokens(source)
 			if err != nil {
 				return ast.AST{}, err
@@ -51,7 +51,15 @@ func newTestResolver(tapeSize int) *resolver.Resolver {
 				Tokens:   tokens,
 				TapeSize: tapeSize,
 				Module:   string(id),
+				Imports:  imports,
 			})
+		},
+		Header: func(source []byte) ([]ast.UseDeclaration, error) {
+			tokens, err := lx.GetFilledTokens(source)
+			if err != nil {
+				return nil, err
+			}
+			return parser.ScanUses(tokens), nil
 		},
 	})
 }

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -14,11 +14,14 @@ import (
 	"github.com/fatih/color"
 
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/evaluator"
 	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/eval"
 	"github.com/guiferpa/aurora/wire/module"
+	"github.com/guiferpa/aurora/wire/token"
 )
 
 // TestExtension marks a test file. A test belongs to the source file of the same name:
@@ -167,23 +170,83 @@ func failedAt(file, source string, err error) error {
 	return fmt.Errorf("%s: %w", filepath.Base(source), err)
 }
 
-// parseFile reads one file and parses it as part of the module somebody asked to run, which
-// is the one with no name of its own.
-func (s *Session) parseFile(file string, declarations *parser.Declarations) (ast.AST, error) {
+// failure is which file went wrong and what went wrong with it, so the report can say the
+// first and the reader the second.
+type failure struct {
+	file string
+	err  error
+}
+
+// readAll reads and lexes every file of the module, and collects what they import.
+//
+// Reading and parsing are two steps because what a file imports has to be parsed before the
+// file itself: a shape is resolved while parsing, and a struct's name never leaves the file
+// that declared it.
+func (s *Session) readAll(files []string) ([][]token.Token, []ast.UseDeclaration, *failure) {
+	chains := make([][]token.Token, 0, len(files))
+	uses := make([]ast.UseDeclaration, 0)
+
+	for _, file := range files {
+		tokens, err := s.tokensOf(file)
+		if err != nil {
+			return nil, nil, &failure{file: file, err: err}
+		}
+		chains = append(chains, tokens)
+		uses = append(uses, parser.ScanUses(tokens)...)
+	}
+	return chains, uses, nil
+}
+
+// runRanges runs every range in order, and the last one is the test.
+//
+// A failure before it is a failure of the code being checked rather than of the check, so it
+// says which file it came from.
+func runRanges(ev *evaluator.Evaluator, program loader.Program) error {
+	for i, each := range program.Ranges {
+		_, err := ev.EvaluateModule(program.Instructions, each.From, each.To, string(each.Module))
+		if err == nil {
+			continue
+		}
+		if i < len(program.Ranges)-1 {
+			return fmt.Errorf("%s: %w", each.Filename, err)
+		}
+		return err
+	}
+	return nil
+}
+
+// parseAll parses every file of the module, with what they import in hand.
+//
+// They share one set of declarations, because they are one module written in two files: a
+// struct declared in the source is known in the test, and so is a module it brought in.
+func (s *Session) parseAll(files []string, chains [][]token.Token, imports map[string][]ast.Promise) ([]ast.AST, *failure) {
+	declarations := parser.NewDeclarations()
+	trees := make([]ast.AST, 0, len(files))
+
+	for i, file := range files {
+		tree, err := s.parser.Parse(parser.ParseInput{
+			Filename:     file,
+			Tokens:       chains[i],
+			Declarations: declarations,
+			TapeSize:     s.tapeSize,
+			Imports:      imports,
+		})
+		if err != nil {
+			return nil, &failure{file: file, err: err}
+		}
+		trees = append(trees, tree)
+	}
+	return trees, nil
+}
+
+// tokensOf reads one file and lexes it. Reading and parsing are two steps here because what
+// a file imports is read from its tokens, before anything is parsed.
+func (s *Session) tokensOf(file string) ([]token.Token, error) {
 	bs, err := os.ReadFile(file)
 	if err != nil {
-		return ast.AST{}, err
+		return nil, err
 	}
-	tokens, err := s.lexer.GetFilledTokens(bs)
-	if err != nil {
-		return ast.AST{}, err
-	}
-	return s.parser.Parse(parser.ParseInput{
-		Filename:     file,
-		Tokens:       tokens,
-		Declarations: declarations,
-		TapeSize:     s.tapeSize,
-	})
+	return s.lexer.GetFilledTokens(bs)
 }
 
 // SourceForTest returns the file a test belongs to: greeting.test.ar -> greeting.ar.
@@ -217,26 +280,27 @@ func (s *Session) runTestFile(path string) FileReport {
 	//
 	// They are also read here rather than by the resolver, which reads the modules: these
 	// two are the file somebody asked for, and there is no name to look them up by.
-	declarations := parser.NewDeclarations()
-	trees := make([]ast.AST, 0, 2)
-	for _, file := range []string{source, path} {
-		tree, err := s.parseFile(file, declarations)
-		if err != nil {
-			report.Err = failedAt(file, source, err)
-			return report
-		}
-		trees = append(trees, tree)
-	}
-
-	// What the two of them import, and then the two of them: one program, with the modules
-	// before what needs them and the test last.
 	if s.resolver == nil {
 		report.Err = errors.New("no resolver was given to this session")
 		return report
 	}
-	modules, err := s.resolver.Dependencies(source, trees...)
-	if err != nil {
-		report.Err = err
+
+	files := []string{source, path}
+	chains, uses, broken := s.readAll(files)
+	if broken != nil {
+		report.Err = failedAt(broken.file, source, broken.err)
+		return report
+	}
+
+	modules, resolveErr := s.resolver.DependenciesOf(source, uses)
+	if resolveErr != nil {
+		report.Err = resolveErr
+		return report
+	}
+
+	trees, broken := s.parseAll(files, chains, resolver.PromisesOf(modules))
+	if broken != nil {
+		report.Err = failedAt(broken.file, source, broken.err)
 		return report
 	}
 	for _, tree := range trees {
@@ -255,18 +319,8 @@ func (s *Session) runTestFile(path string) FileReport {
 		return report
 	}
 
-	// Every range runs, in order, and the last one is the test. A failure before it is a
-	// failure of the code being checked rather than of the check, so it says which file.
-	for i, each := range program.Ranges {
-		_, err := ev.EvaluateModule(program.Instructions, each.From, each.To, string(each.Module))
-		if err == nil {
-			continue
-		}
-		if i < len(program.Ranges)-1 {
-			report.Err = fmt.Errorf("%s: %w", each.Filename, err)
-		} else {
-			report.Err = err
-		}
+	if err := runRanges(ev, program); err != nil {
+		report.Err = err
 		return report
 	}
 

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/guiferpa/aurora/loader"
+	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
@@ -22,22 +23,6 @@ import (
 // moduleAliases is what the use lines declared: the alias, and the module it names.
 type moduleAliases map[string]string
 
-// scanUses reads every `use a/b/c as x;` out of a token chain, with the token of each so
-// whatever goes wrong with one can be underlined where it was written.
-func scanUses(tokens []token.Token) []ast.UseDeclaration {
-	found := make([]ast.UseDeclaration, 0)
-	for i := 0; i < len(tokens); i++ {
-		if tokens[i].GetTag().Id != token.USE {
-			continue
-		}
-		if alias, specifier, next := readUse(tokens, i); alias != "" {
-			found = append(found, ast.UseDeclaration{Specifier: specifier, Alias: alias, Token: tokens[i]})
-			i = next
-		}
-	}
-	return found
-}
-
 // aliasesOf is what those declarations say about names: the alias, and what it means.
 func aliasesOf(uses []ast.UseDeclaration) moduleAliases {
 	aliases := make(moduleAliases, len(uses))
@@ -45,29 +30,6 @@ func aliasesOf(uses []ast.UseDeclaration) moduleAliases {
 		aliases[declaration.Alias] = declaration.Specifier
 	}
 	return aliases
-}
-
-// readUse reads one declaration starting at the use token: the path it names, and the alias
-// it is reached by. A half-written line answers with nothing, which is the common case while
-// somebody is typing one.
-func readUse(tokens []token.Token, i int) (string, string, int) {
-	specifier := ""
-	for j := i + 1; j < len(tokens); j++ {
-		switch tokens[j].GetTag().Id {
-		case token.ID:
-			specifier += string(tokens[j].GetMatch())
-		case token.DIV:
-			specifier += "/"
-		case token.AS:
-			if specifier == "" || j+1 >= len(tokens) || tokens[j+1].GetTag().Id != token.ID {
-				return "", "", j
-			}
-			return string(tokens[j+1].GetMatch()), specifier, j + 1
-		default:
-			return "", "", j
-		}
-	}
-	return "", "", len(tokens) - 1
 }
 
 // moduleBefore answers the module a dot at this offset reaches into, when what sits in front
@@ -167,7 +129,7 @@ func describeExport(analysis *Analysis, subject token.Token) string {
 // moduleOfSubject answers the module a token is reached through, when it follows a dot on an
 // alias.
 func moduleOfSubject(analysis *Analysis, subject token.Token) (string, bool) {
-	aliases := aliasesOf(scanUses(analysis.Tokens))
+	aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
 	for i, t := range analysis.Tokens {
 		if t.GetCursor() != subject.GetCursor() || i < 2 || analysis.Tokens[i-1].GetTag().Id != token.DOT {
 			continue

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -54,7 +54,7 @@ func TestScanUses(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := aliasesOf(scanUses(session().Analyze(Document{Filename: "main.ar", Source: tc.source}).Tokens))
+			got := aliasesOf(parser.ScanUses(session().Analyze(Document{Filename: "main.ar", Source: tc.source}).Tokens))
 			if len(got) != len(tc.want) {
 				t.Fatalf("read %v, want %v", got, tc.want)
 			}
@@ -155,12 +155,19 @@ func withModuleFiles(files map[string]string) *Session {
 					}
 					return []byte(source), nil
 				},
-				Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+				Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 					tokens, err := lx.GetFilledTokens(source)
 					if err != nil {
 						return ast.AST{}, err
 					}
-					return ps.Parse(parser.ParseInput{Filename: filename, Tokens: tokens, Module: string(id)})
+					return ps.Parse(parser.ParseInput{Filename: filename, Tokens: tokens, Module: string(id), Imports: imports})
+				},
+				Header: func(source []byte) ([]ast.UseDeclaration, error) {
+					tokens, err := lx.GetFilledTokens(source)
+					if err != nil {
+						return nil, err
+					}
+					return parser.ScanUses(tokens), nil
 				},
 			}).DependenciesOf(doc.Filename, uses)
 		},

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -10,6 +10,7 @@ import (
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/resolver"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
@@ -84,7 +85,7 @@ func (s *Session) Analyze(doc Document) *Analysis {
 	// document being edited is broken most of the time, and what is inside a module is
 	// wanted exactly then. What that costs is one read of each imported file.
 	if s.resolve != nil {
-		modules, err := s.resolve(doc, scanUses(tokens))
+		modules, err := s.resolve(doc, parser.ScanUses(tokens))
 		analysis.Modules, analysis.ModuleErr = modules, err
 	}
 
@@ -94,6 +95,9 @@ func (s *Session) Analyze(doc Document) *Analysis {
 		Filename: doc.Filename,
 		Tokens:   tokens,
 		TapeSize: doc.TapeSize,
+		// What the modules it imports promised, which the resolution above just found: a
+		// shape is resolved while parsing, so it has to be in hand by now.
+		Imports: resolver.PromisesOf(analysis.Modules),
 	})
 	if err != nil {
 		analysis.Err = err
@@ -215,7 +219,7 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 		return "boolean: " + match
 	case token.ID:
 		// A module is not a value, so it is answered for before anything looks for one.
-		if info := aliasesOf(scanUses(analysis.Tokens)).describe(analysis.Tokens, tk); info != "" {
+		if info := aliasesOf(parser.ScanUses(analysis.Tokens)).describe(analysis.Tokens, tk); info != "" {
 			return info + describeExport(analysis, tk)
 		}
 		// A struct name or a field read out of one: the declaration is what says these are
@@ -257,7 +261,7 @@ func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bo
 
 	// After a dot on a module alias, what can follow is what that module declared, and
 	// nothing else — the same rule as a struct's fields, answered from another file.
-	aliases := aliasesOf(scanUses(analysis.Tokens))
+	aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
 	if specifier, isModule := aliases.moduleBefore(analysis.Tokens, offset); isModule {
 		return exportCompletions(analysis, specifier)
 	}

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -238,6 +238,9 @@ func (s *Session) load(tree ast.AST) error {
 			return err
 		}
 		s.loaded[each.ID] = each
+		// What it answers with is written down for the lines after this one: a session is a
+		// file typed slowly, and the use line was already read when this module arrived.
+		s.declarations.Import(string(each.ID), each.Tree.Promises)
 	}
 	return nil
 }

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -182,7 +182,7 @@ func typedIn(t *testing.T, dir, lines string, tapeSize int) string {
 		Resolver: resolver.New(resolver.Options{
 			SourceRoot: "src",
 			Read:       os.ReadFile,
-			Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+			Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 				tokens, err := lx.GetFilledTokens(source)
 				if err != nil {
 					return ast.AST{}, err
@@ -192,7 +192,15 @@ func typedIn(t *testing.T, dir, lines string, tapeSize int) string {
 					Tokens:   tokens,
 					TapeSize: size,
 					Module:   string(id),
+					Imports:  imports,
 				})
+			},
+			Header: func(source []byte) ([]ast.UseDeclaration, error) {
+				tokens, err := lx.GetFilledTokens(source)
+				if err != nil {
+					return nil, err
+				}
+				return parser.ScanUses(tokens), nil
 			},
 		}),
 	}).Start()
@@ -273,5 +281,16 @@ func TestASessionWithoutAResolverRefusesToPretend(t *testing.T) {
 
 	if !strings.Contains(got, "nowhere to read a module from") {
 		t.Errorf("the session said %q, want it to say it cannot import", got)
+	}
+}
+
+// A shape crosses into a session with the promise that names it, so a field is read off an
+// imported scope without anybody naming the struct.
+func TestASessionReadsAPromisedShape(t *testing.T) {
+	dir := withModule(t, "struct Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;")
+	got := typedIn(t, dir, "use geometry as g;\nident r = g.lookup(0);\nprintd r.value;\n", 0)
+
+	if !strings.Contains(got, "42") {
+		t.Errorf("the session said %q, want it to contain 42", got)
 	}
 }

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -30,7 +30,7 @@ func load(t *testing.T, sources map[string]string) ([]module.Module, error) {
 			}
 			return []byte(source), nil
 		},
-		Parse: func(filename string, id module.ID, source []byte) (ast.AST, error) {
+		Parse: func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 			tokens, err := lexer.New().GetFilledTokens(source)
 			if err != nil {
 				return ast.AST{}, err
@@ -39,8 +39,10 @@ func load(t *testing.T, sources map[string]string) ([]module.Module, error) {
 				Filename: filename,
 				Tokens:   tokens,
 				Module:   string(id),
+				Imports:  imports,
 			})
 		},
+		Header: header,
 	}).Resolve("src/main.ar")
 }
 
@@ -249,4 +251,14 @@ func TestLoadRefusesBeforeItEmits(t *testing.T) {
 	if emitted != 0 {
 		t.Errorf("emitted %d modules before refusing, want none", emitted)
 	}
+}
+
+// header reads what a source imports without parsing it, which is what lets a module be read
+// before whoever imports it.
+func header(source []byte) ([]ast.UseDeclaration, error) {
+	tokens, err := lexer.New().GetFilledTokens(source)
+	if err != nil {
+		return nil, err
+	}
+	return parser.ScanUses(tokens), nil
 }

--- a/parser/header.go
+++ b/parser/header.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Reading the top of a file without parsing it.
+//
+// What a file imports is the first thing in it, and two callers need it before a parse can
+// happen: the resolver, which has to read a module's dependencies before reading the module,
+// and the editor, which is asked what is inside a module while the document is too broken to
+// parse. Both ask here.
+
+// scanUses reads every `use a/b/c as x;` out of a token chain, with the token of each so
+// whatever goes wrong with one can be underlined where it was written.
+func ScanUses(tokens []token.Token) []ast.UseDeclaration {
+	found := make([]ast.UseDeclaration, 0)
+	for i := 0; i < len(tokens); i++ {
+		if tokens[i].GetTag().Id != token.USE {
+			continue
+		}
+		if alias, specifier, next := readUse(tokens, i); alias != "" {
+			found = append(found, ast.UseDeclaration{Specifier: specifier, Alias: alias, Token: tokens[i]})
+			i = next
+		}
+	}
+	return found
+}
+
+// readUse reads one declaration starting at the use token: the path it names, and the alias
+// it is reached by. A half-written line answers with nothing, which is the common case while
+// somebody is typing one.
+func readUse(tokens []token.Token, i int) (string, string, int) {
+	specifier := ""
+	for j := i + 1; j < len(tokens); j++ {
+		switch tokens[j].GetTag().Id {
+		case token.ID:
+			specifier += string(tokens[j].GetMatch())
+		case token.DIV:
+			specifier += "/"
+		case token.AS:
+			if specifier == "" || j+1 >= len(tokens) || tokens[j+1].GetTag().Id != token.ID {
+				return "", "", j
+			}
+			return string(tokens[j+1].GetMatch()), specifier, j + 1
+		default:
+			return "", "", j
+		}
+	}
+	return "", "", len(tokens) - 1
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -45,6 +45,14 @@ type ParseInput struct {
 	// written as they were typed — which is every file compiled on its own, the language
 	// server and the REPL included.
 	Module string
+	// Imports is what the modules this file names promised, by specifier: for each of their
+	// exported scopes that promised, the struct it answers with and the fields of it.
+	//
+	// It arrives because a shape is resolved while parsing and a struct's name never leaves
+	// the file that declared it — so a scope of another module answering with one has to hand
+	// the fields over. Empty is a file that imports nothing, or one whose imports promised
+	// nothing, and it reads exactly as it did before any of this.
+	Imports map[string][]ast.Promise
 	// Declarations carries what `struct` and `as` declared across parses of the same file.
 	// Nil starts empty, which is what compiling a file in one go wants; the REPL passes the
 	// same value every line so a struct declared earlier is still known.
@@ -65,6 +73,8 @@ type pr struct {
 	// and false from the first node that is not one, and inside every body.
 	useAllowed bool
 	module     string
+	// imports is what the modules this file names promised, by specifier.
+	imports map[string][]ast.Promise
 	// references is every qualified name this parse read. It leaves with the tree because
 	// only whoever holds the other modules can say whether the name is really there.
 	references []ast.Reference
@@ -1010,6 +1020,7 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 	p.cursor = 0
 	p.useAllowed = true
 	p.module = in.Module
+	p.imports = in.Imports
 	p.references = nil
 	p.declarations = in.Declarations
 	if p.declarations == nil {
@@ -1021,7 +1032,12 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 		return ast.AST{}, err
 	}
 
-	return ast.AST{Filename: p.filename, Nodes: nodes, References: p.references}, nil
+	return ast.AST{
+		Filename:   p.filename,
+		Nodes:      nodes,
+		References: p.references,
+		Promises:   p.promises(nodes),
+	}, nil
 }
 
 // New builds a parser. It takes nothing: a parser is the same whatever it is asked to read,

--- a/parser/structs.go
+++ b/parser/structs.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -45,6 +46,19 @@ func NewDeclarations() *Declarations {
 		Shapes:  make(map[string]string),
 		Modules: make(map[string]string),
 		Returns: make(map[string]string),
+	}
+}
+
+// Import writes down what a module answers with, under names nobody can type.
+//
+// A promise crossing a module is the shape and its fields together, and both are written the
+// way an identifier of that module is: with the module in front. So two modules answering with
+// an Env each are two shapes, and neither can be confused with an Env declared here.
+func (d *Declarations) Import(specifier string, promises []ast.Promise) {
+	for _, promise := range promises {
+		shape := module.Qualify(module.ID(specifier), promise.Struct)
+		d.Structs[shape] = promise.Fields
+		d.Returns[module.Qualify(module.ID(specifier), promise.Scope)] = shape
 	}
 }
 
@@ -277,6 +291,38 @@ func (p *pr) shapeOfLast(body []ast.Node) string {
 // the block says what it answers with, and this refuses the block that does not.
 //
 // The promise is worth what shapeOf can see through, which is why that is the part that grew.
+
+// promises is what the top-level scopes of this file said they answer with, with the fields
+// of each — the only thing about a struct that leaves the file that declared it.
+//
+// It is a join of two tables the parse already filled: which scope promised what, and what
+// each struct is made of. Whoever imports this file needs both halves, since a name is worth
+// nothing without the fields it stands for.
+func (p *pr) promises(nodes []ast.Node) []ast.Promise {
+	found := make([]ast.Promise, 0)
+	for _, node := range nodes {
+		binding, ok := node.(ast.IdentLiteral)
+		if !ok {
+			continue
+		}
+		promised, made := p.declarations.Returns[binding.Id]
+		if !made {
+			continue
+		}
+		found = append(found, ast.Promise{
+			Scope:  p.bare(binding.Id),
+			Struct: promised,
+			Fields: p.declarations.Structs[promised],
+		})
+	}
+	return found
+}
+
+// bare is a name of this file without the module in front of it, which is how the file that
+// wrote it reads it and how whoever imports it asks for it.
+func (p *pr) bare(name string) string {
+	return module.Module{ID: module.ID(p.module)}.Symbol(name)
+}
 
 // parseReturns reads `returns Person` after a block, and checks what the block ends with.
 func (p *pr) parseReturns(body []ast.Node, closing token.Token) (string, error) {

--- a/parser/use.go
+++ b/parser/use.go
@@ -55,6 +55,7 @@ func (p *pr) ParseUse() (ast.Node, error) {
 			alias, declared, name.GetLine(), name.GetColumn())
 	}
 	p.declarations.Modules[alias] = specifier
+	p.declarations.Import(specifier, p.imports[specifier])
 
 	return ast.UseDeclaration{Specifier: specifier, Alias: alias, Token: tok}, nil
 }

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -28,8 +28,17 @@ const Extension = ".ar"
 type Read func(path string) ([]byte, error)
 
 // Parse turns one module's source into a tree. Filename is where it came from, which is what
-// positions and file-scoped rules are about; ID is the module the names inside belong to.
-type Parse func(filename string, id module.ID, source []byte) (ast.AST, error)
+// positions and file-scoped rules are about; ID is the module the names inside belong to; and
+// imports is what the modules it names promised, which it needs while parsing because a shape
+// is resolved there and a struct's name never leaves the file that declared it.
+type Parse func(filename string, id module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error)
+
+// Header answers what a source imports, without parsing it.
+//
+// It exists because a module has to be read before whoever imports it — the parse of a file
+// needs what its dependencies promised — and knowing what to read first cannot itself require
+// a parse. The declarations are the top of the file, so reading the top is enough.
+type Header func(source []byte) ([]ast.UseDeclaration, error)
 
 // Options is what a resolver is built with.
 type Options struct {
@@ -38,16 +47,18 @@ type Options struct {
 	SourceRoot string
 	Read       Read
 	Parse      Parse
+	Header     Header
 }
 
 type Resolver struct {
 	sourceRoot string
 	read       Read
 	parse      Parse
+	header     Header
 }
 
 func New(opts Options) *Resolver {
-	return &Resolver{sourceRoot: opts.SourceRoot, read: opts.Read, parse: opts.Parse}
+	return &Resolver{sourceRoot: opts.SourceRoot, read: opts.Read, parse: opts.Parse, header: opts.Header}
 }
 
 // resolution is one call to Resolve: what has been found, what is being looked at right now,
@@ -67,21 +78,45 @@ type resolution struct {
 //
 // The entry is a path rather than a module name because it is the file somebody asked to
 // run, and it is the one module with no id.
+// Resolve answers with the entry and everything it needs, dependencies first.
+//
+// The entry is parsed last, which is the whole shape of this: a file is read before the file
+// that imports it, so by the time one is parsed, everything it named has been. Knowing what to
+// read first is what the header is for.
 func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
 	source, err := r.read(entry)
 	if err != nil {
 		return nil, fmt.Errorf("reading %s: %w", entry, err)
 	}
-	tree, err := r.parse(entry, "", source)
+	uses, err := r.header(source)
 	if err != nil {
 		return nil, err
 	}
 
-	modules, err := r.Dependencies(entry, tree)
+	modules, err := r.DependenciesOf(entry, uses)
+	if err != nil {
+		return nil, err
+	}
+
+	tree, err := r.parse(entry, "", source, PromisesOf(modules))
 	if err != nil {
 		return nil, err
 	}
 	return append(modules, module.Module{ID: "", Tree: tree}), nil
+}
+
+// PromisesOf is what a set of modules promised, by the name they are imported under.
+//
+// Everything found so far is handed over rather than only what one file names: a parse looks
+// up the specifiers it actually wrote, so an entry nobody asks for costs nothing.
+func PromisesOf(modules []module.Module) map[string][]ast.Promise {
+	promises := make(map[string][]ast.Promise, len(modules))
+	for _, each := range modules {
+		if len(each.Tree.Promises) > 0 {
+			promises[string(each.ID)] = each.Tree.Promises
+		}
+	}
+	return promises
 }
 
 // Dependencies answers with everything the given trees need, and nothing of the trees
@@ -151,18 +186,25 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 		return token.NewError(declaration.Token, "module %s is not there at line %d and column %d: no %s",
 			id, declaration.Token.GetLine(), declaration.Token.GetColumn(), filename)
 	}
-	tree, err := r.parse(filename, id, source)
+	uses, err := r.header(source)
 	if err != nil {
 		return err
 	}
 
+	// Everything this module names is read before it is, which is what lets its parse be
+	// handed what they promised.
 	state.open = append(state.open, id)
-	for _, declaration := range declarationsOf(tree) {
-		if err := r.resolveOne(state, declaration); err != nil {
+	for _, use := range uses {
+		if err := r.resolveOne(state, use); err != nil {
 			return err
 		}
 	}
 	state.open = state.open[:len(state.open)-1]
+
+	tree, err := r.parse(filename, id, source, PromisesOf(state.order))
+	if err != nil {
+		return err
+	}
 
 	// Appended after everything it needs, which is what makes the order topological.
 	state.found[id] = true

--- a/resolver/resolver_test.go
+++ b/resolver/resolver_test.go
@@ -35,13 +35,14 @@ func resolve(t *testing.T, root, entry string, sources files) ([]module.Module, 
 			}
 			return []byte(source), nil
 		},
-		Parse: func(filename string, _ module.ID, source []byte) (ast.AST, error) {
+		Parse: func(filename string, _ module.ID, source []byte, imports map[string][]ast.Promise) (ast.AST, error) {
 			tokens, err := lexer.New().GetFilledTokens(source)
 			if err != nil {
 				return ast.AST{}, err
 			}
-			return parser.New().Parse(parser.ParseInput{Filename: filename, Tokens: tokens})
+			return parser.New().Parse(parser.ParseInput{Filename: filename, Tokens: tokens, Imports: imports})
 		},
+		Header: header,
 	})
 
 	modules, err := resolver.Resolve(entry)
@@ -255,4 +256,14 @@ func equal(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+// header reads what a source imports without parsing it, which is what lets a module be read
+// before whoever imports it.
+func header(source []byte) ([]ast.UseDeclaration, error) {
+	tokens, err := lexer.New().GetFilledTokens(source)
+	if err != nil {
+		return nil, err
+	}
+	return parser.ScanUses(tokens), nil
 }

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -234,6 +234,23 @@ type AST struct {
 	// somewhere else. Only whoever holds the other modules can answer that, which is why the
 	// parse hands it over instead of deciding.
 	References []Reference `json:"references,omitempty"`
+	// Promises is what this file's top-level scopes said they answer with. It leaves with the
+	// tree for whoever imports this file: see Promise.
+	Promises []Promise `json:"promises,omitempty"`
+}
+
+// A Promise is what one exported scope said it answers with, and what that struct is made
+// of.
+//
+// It is the only thing about a struct that leaves the file that declared it. A struct's name
+// is read while a file is parsed and dropped, so a module that answers with one has to hand
+// over the fields as well — otherwise whoever imports it has a run of tapes and no way to
+// turn a name into an index.
+type Promise struct {
+	// Scope is the name the scope is bound to, as the module's own file typed it.
+	Scope  string   `json:"scope"`
+	Struct string   `json:"struct"`
+	Fields []string `json:"fields"`
 }
 
 // A Reference is one qualified name, and where it was written.


### PR DESCRIPTION
Primeira metade da RFC #78. **Isto compila agora:**

```
#- src/os.ar
struct Env { found, value };
ident lookup = defer { Env{1, 42}; } returns Env;
```

```
#- src/main.ar
use os as o;

ident r = o.lookup("HOME");
printd r.found;   #- 1
printd r.value;   #- 42
```

Nada em `main.ar` menciona `Env`, e nada pode. O que atravessou foi **a promessa** — a struct e os campos dela.

## Os três commits

**1. Ler o topo de um arquivo vira coisa do parser.** O editor já lia as linhas `use` dos tokens; o resolver passa a precisar do mesmo. A regra de onde os imports ficam passa a morar num lugar só.

**2. Um módulo é lido antes do arquivo que o importa.** A ordem rodava ao contrário: o arquivo era parseado primeiro e as dependências saíam da árvore pronta. Agora o topo é lido sozinho, o que ele nomeia é resolvido e parseado, e só então o arquivo.

É o que Go e Rust fazem, e **é o que o editor já fazia** — ele lê o cabeçalho, resolve, e parseia o documento aberto por último, porque completar é pedido enquanto o documento está quebrado. O compilador adota a ordem que o editor foi obrigado a descobrir primeiro.

**Nada é parseado duas vezes e nada é parseado que já não fosse.** Muda o *quando*.

**3. A forma atravessa com a promessa.** O módulo se descreve e não responde perguntas: ele diz que seu `lookup` responde um `Env` feito de `found` e `value`, sem saber quem vai ler. A lista inteira precisa viajar, porque índice é **posição** — saber que alguém lê `found` não diz se ele é a primeira tape ou a sexta.

Chega a todos os hosts que compilam: `run`, `build`, `test`, a REPL e o editor.

## Uma mudança que se vê

**Um módulo que não existe passa a ser reportado antes de um erro de sintaxe no arquivo que importa**, porque o import é resolvido primeiro. É o mais fundamental dos dois — e é por isso que três exemplos do `docs/modules.md` passaram a ser **mostrados em vez de executados**: um bloco solto nomeando um módulo seria recusado pelo módulo faltando antes de chegar na regra que ele ilustrava.

## O que não mudou

Nada no IR, emitter, evaluator ou builder. Nome de struct continua não chegando a instrução nenhuma. E um escopo que não prometeu continua entregando uma corrida de tapes sem forma — por isso nada que existe compila diferente.

## O que fica para o segundo PR

**Nomear struct importado**: `as m.Point`, `returns m.Point`, `m.Point{1, 2}`.

## Verificação

`make check` limpo, `make complexity` sem nada novo — o `runTestFile` cresceu com a inversão e foi cortado em três funções que dizem o que fazem.

🤖 Generated with [Claude Code](https://claude.com/claude-code)