### PR TITLE
feat: a field of an imported shape completes after the dot

### DIFF
--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -11,7 +11,7 @@
 | **Semantic tokens** | `textDocument/semanticTokens/full` | Coloring for keywords, numbers, text, comments, operators, identifiers, calls, structs and fields |
 | **Diagnostics** | `textDocument/publishDiagnostics` | Lexer and parser errors underlined where they happen, republished on every change |
 | **Hover** | `textDocument/hover` | The description of the keyword under the cursor, what an identifier was bound to, a struct's fields, or which tape a field reads |
-| **Completion** | `textDocument/completion` | Keywords as snippets, the identifiers and structs declared in the document, and — right after a `.` — the fields of that struct |
+| **Completion** | `textDocument/completion` | Keywords as snippets, the identifiers and structs declared in the document, and — right after a `.` — the fields of a struct or what a module offers |
 
 Document sync is **full** (`textDocumentSync: 1`): the client resends the whole file on each change.
 
@@ -19,11 +19,22 @@ Document sync is **full** (`textDocumentSync: 1`): the client resends the whole 
 
 Three things come back, depending on where the cursor is.
 
-**Right after a dot**, the fields of that struct and nothing else. The shape comes from what
-was declared — `ident p = Point{...}` or `... as Point` — read straight from the tokens rather
-than from the tree, because a document being edited hardly ever parses: the moment someone
-types `p.` there is no field name yet, and that is exactly when completion is wanted. The
-dot is declared as a trigger character, so the client asks on its own.
+**Right after a dot on a value**, the fields of that struct and nothing else. The shape comes
+from what was declared — `ident p = Point{...}`, `... as Point`, or a call to a scope that
+promised with `returns` — read straight from the tokens rather than from the tree, because a
+document being edited hardly ever parses: the moment someone types `p.` there is no field name
+yet, and that is exactly when completion is wanted. The dot is declared as a trigger character,
+so the client asks on its own.
+
+The struct does not have to be declared here. What the imported modules offer is written down
+first — their structs, and what their scopes promised — under the alias this file gave them, so
+`ident s = g.new_square(4, 5);` is enough for `s.` to answer with `width` and `height`. That is
+the same table the parser fills, read the same way.
+
+**Right after a dot on a module alias**, what that module offers: the names it binds with
+`ident`, each described by what it is, and the structs it declares, each with its fields. A
+module that could not be found offers nothing rather than everything — the diagnostic already
+says it is missing.
 
 **Everywhere else**, the keywords and whatever the document declares. A declared struct comes
 back as a way of building one, with its own field names as the places to fill in:
@@ -31,6 +42,9 @@ back as a way of building one, with its own field names as the places to fill in
 ```
 struct Point { x, y };   ->   Point{${1:x}, ${2:y}}
 ```
+
+A struct of an imported module comes back the same way, under the name this file has to write
+it with: `g.Square{${1:width}, ${2:height}}`.
 
 **Keywords expand into their shape**, for the forms that have one to get wrong:
 
@@ -50,7 +64,7 @@ Snippets are offered **only to a client that said it expands them** (`snippetSup
 initialize). To anyone else the placeholders would land in the buffer as the literal text
 they are, so that client gets the bare keyword.
 
-**Scope:** the server analyses the **open document alone** — it lexes and parses it, and never evaluates. That is what diagnostics and coloring need, and it stays within what the compiler can actually do: resolution of `use ns as alias` across files is not implemented yet (see [import_design.md](import_design.md)).
+**Scope:** the server lexes and parses the open document and the files it imports, and never evaluates. The imported files arrive through a port the host fills in — the command line reads a disk, the playground reads a map it already holds, since a browser has no files — so the same package answers wherever it is put. An imported file that is open in the editor is read as it is on screen, not as it is on disk: a name just typed resolves, and one just deleted stops resolving. See [modules.md](modules.md) for what a module is.
 
 **Known limitations**
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -80,7 +80,9 @@ What it does not do yet:
 - **The language server follows an import, and stops short of two things.** It reads what a
   document imports on every pass, from the editor's buffers before the disk, so a module that
   is not there and a name a module does not have are underlined where they were written, and
-  what a module declared is offered after the dot. What it does not do is go to a definition
+  what a module declared is offered after the dot — its structs included, and the fields of a
+  name whose shape came from another file, because what the imports offer is written down
+  before the document is read. What it does not do is go to a definition
   in another file — no `textDocument/definition` exists for anything yet — and it does not
   watch a file nobody has open, so editing a module outside the editor updates what depends
   on it only when that file is touched. Neither needs the resolver; both need a capability

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -159,3 +159,42 @@ func exportedValue(found module.Module, name string) ast.Node {
 	}
 	return nil
 }
+
+// shapesOf is everything the editor knows about structs while a document is being edited:
+// what the modules it imports offer, and then what the document itself says on top.
+//
+// The order is the point. A name bound here can be read as a shape declared over there —
+// `ident s = g.new_square(1, 2);` — and the reader of the tokens only knows what that call
+// answers with if the promise is already written down when it walks past the call.
+func shapesOf(analysis *Analysis, aliases moduleAliases) structShapes {
+	return importedShapes(analysis, aliases).scan(analysis.Tokens)
+}
+
+// importedShapes is what the modules a document imports offer, written the way this document
+// has to write it: `g.Square`, never `Square`, because a shape of another file is named
+// through the alias or not at all.
+//
+// It is the parser's own Import with the alias in front instead of the specifier — the same
+// two halves, read for the same reason. The structs say what a construction is made of; the
+// promises say what a call answers with, which is the only shape a name bound from another
+// module's scope ever has.
+func importedShapes(analysis *Analysis, aliases moduleAliases) structShapes {
+	shapes := newStructShapes()
+	for alias, specifier := range aliases {
+		found, imported := analysis.module(specifier)
+		if !imported {
+			continue
+		}
+		for _, shape := range found.Tree.Shapes {
+			shapes.fields[alias+"."+shape.Name] = shape.Fields
+		}
+		for _, promise := range found.Tree.Promises {
+			// A promise may name a shape of a third module, which this one never declared, so
+			// the fields come with it rather than being looked up.
+			named := alias + "." + promise.Struct
+			shapes.fields[named] = promise.Fields
+			shapes.promises[alias+"."+promise.Scope] = named
+		}
+	}
+	return shapes
+}

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -323,3 +323,109 @@ func TestTheEditorOffersAModuleStructs(t *testing.T) {
 		t.Error("the names it binds are no longer offered")
 	}
 }
+
+// And a name whose shape came from another file answers with its fields after the dot, which
+// is the whole point of the shape crossing: however the name got it — built here, claimed
+// with as, or promised by the scope that answered.
+func TestCompletionOnAShapeFromAnotherModule(t *testing.T) {
+	const geometry = "struct Square { width, height };\n" +
+		"ident new_square = defer { Square{feed(0), feed(1)}; } returns Square;\n" +
+		"ident area = defer { feed(0) * feed(1); };"
+
+	for _, tc := range []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "built here",
+			source: "use geometry as g;\nident s = g.Square{4, 5};\nprintd s.",
+		},
+		{
+			name:   "answered by a scope that promised",
+			source: "use geometry as g;\nident s = g.new_square(4, 5);\nprintd s.",
+		},
+		{
+			name:   "claimed with as",
+			source: "use geometry as g;\nident s = feed(0) as g.Square;\nprintd s.",
+		},
+		{
+			name:   "promised by a scope written here",
+			source: "use geometry as g;\nident make = defer { g.Square{1, 2}; } returns g.Square;\nident s = make();\nprintd s.",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+			lines := strings.Split(tc.source, "\n")
+			items := session.CompletionItemsFor(Document{Filename: "src/main.ar", Source: tc.source},
+				lsp.Position{Line: len(lines) - 1, Character: len(lines[len(lines)-1])}, false)
+
+			if len(items) != 2 {
+				t.Fatalf("offered %d items, want the two fields: %+v", len(items), items)
+			}
+			for i, want := range []string{"width", "height"} {
+				if items[i].Label != want {
+					t.Errorf("offered %q, want %q", items[i].Label, want)
+				}
+				if items[i].Kind != Field {
+					t.Errorf("%q is offered as kind %d, want a field", items[i].Label, items[i].Kind)
+				}
+			}
+			if !strings.Contains(items[1].Detail, "1") {
+				t.Errorf("height is described as %q, want it to say which tape it reads", items[1].Detail)
+			}
+		})
+	}
+}
+
+// A name with no shape offers the ordinary list, as it did before any of this: a module is
+// read to answer more, never to answer wrongly.
+func TestCompletionOnANameWithNoShape(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "struct Square { width, height };"})
+	items := session.CompletionItemsFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nident n = 1;\nprintd n.",
+	}, lsp.Position{Line: 2, Character: 9}, false)
+
+	for _, item := range items {
+		if item.Label == "width" {
+			t.Fatalf("offered the fields of a struct nothing said this name is: %+v", items)
+		}
+	}
+}
+
+// Hover reads the imported shape too, so a field of it says where it comes from and which
+// tape it reads.
+func TestHoverOnAFieldOfAnImportedShape(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "struct Square { width, height };"})
+	got := session.HoverInfo(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nident s = g.Square{4, 5};\nprintd s.height;",
+	}, lsp.Position{Line: 2, Character: 10})
+
+	for _, want := range []string{"field height", "g.Square", "tape 1"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("hover = %q, want it to contain %q", got, want)
+		}
+	}
+}
+
+// Away from any dot, a module's struct is offered as a way of building one — under the name
+// this file has to write it with, since that is the only name that would compile.
+func TestAModuleStructIsOfferedAsASnippet(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "struct Square { width, height };"})
+	items := session.CompletionItemsFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nident s = ",
+	}, lsp.Position{Line: 1, Character: 10}, true)
+
+	for _, item := range items {
+		if item.Label != "g.Square" {
+			continue
+		}
+		if item.InsertText != "g.Square{${1:width}, ${2:height}}" {
+			t.Errorf("inserts %q, want the construction with its fields", item.InsertText)
+		}
+		return
+	}
+	t.Errorf("the struct of the module was not offered: %+v", items)
+}

--- a/hosting/lsp/textdoc/structs.go
+++ b/hosting/lsp/textdoc/structs.go
@@ -22,15 +22,23 @@ type structShapes struct {
 	promises map[string]string
 }
 
-// scanStructs reads the declarations out of a token stream: `struct Point { x, y }` for the
-// fields, and `ident p = Point{...}` or `... as Point` for what a name is read as.
-func scanStructs(tokens []token.Token) structShapes {
-	found := structShapes{
+// newStructShapes is what nothing has been read into yet.
+func newStructShapes() structShapes {
+	return structShapes{
 		fields:   make(map[string][]string),
 		shapes:   make(map[string]string),
 		promises: make(map[string]string),
 	}
+}
 
+// scan reads the declarations out of a token stream, on top of whatever is already known:
+// `struct Point { x, y }` for the fields, and `ident p = Point{...}` or `... as Point` for
+// what a name is read as.
+//
+// It reads on top rather than from nothing because a document is not the only thing that
+// declares a shape. What its modules offer is written down first, and a name bound here from
+// a call over there is only read when both halves are in the same table.
+func (found structShapes) scan(tokens []token.Token) structShapes {
 	for i := 0; i < len(tokens); i++ {
 		switch tokens[i].GetTag().Id {
 		case token.STRUCT:
@@ -104,13 +112,13 @@ func readBinding(tokens []token.Token, i int) (name, shape, promised, called str
 				return name, shape, promised, called
 			}
 		case token.RETURNS:
-			if depth == 0 && j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.ID {
-				promised = string(tokens[j+1].GetMatch())
+			if claimed := claimedAt(tokens, j+1); depth == 0 && claimed != "" {
+				promised = claimed
 			}
 		case token.AS:
 			// The nearest `as` wins, which is the one the value ends up with.
-			if depth == 0 && j+1 < len(tokens) && tokens[j+1].GetTag().Id == token.ID {
-				shape = string(tokens[j+1].GetMatch())
+			if claimed := claimedAt(tokens, j+1); depth == 0 && claimed != "" {
+				shape = claimed
 			}
 		case token.ID:
 			if depth != 0 || j+1 >= len(tokens) {
@@ -119,14 +127,40 @@ func readBinding(tokens []token.Token, i int) (name, shape, promised, called str
 			switch tokens[j+1].GetTag().Id {
 			case token.O_CUR_BRK:
 				// A construction: the name of a struct in front of a brace.
-				shape = string(tokens[j].GetMatch())
+				shape = nameAt(tokens, j)
 			case token.O_PAREN:
 				// A call: what it answers with is known when that scope promised.
-				called = string(tokens[j].GetMatch())
+				called = nameAt(tokens, j)
 			}
 		}
 	}
 	return name, shape, promised, called
+}
+
+// nameAt reads the name at this position the way the document wrote it: `Square`, or
+// `g.Square` when it hangs off a dot on an alias.
+//
+// The alias comes along because it is part of the name. A shape of another module is never
+// written without one, and two files reached through two aliases may both call a struct
+// Square.
+func nameAt(tokens []token.Token, j int) string {
+	name := string(tokens[j].GetMatch())
+	if j >= 2 && tokens[j-1].GetTag().Id == token.DOT && tokens[j-2].GetTag().Id == token.ID {
+		return string(tokens[j-2].GetMatch()) + "." + name
+	}
+	return name
+}
+
+// claimedAt reads the struct name written after `as` or `returns`, and nothing when what
+// follows is not one yet.
+func claimedAt(tokens []token.Token, j int) string {
+	if j >= len(tokens) || tokens[j].GetTag().Id != token.ID {
+		return ""
+	}
+	if j+2 < len(tokens) && tokens[j+1].GetTag().Id == token.DOT && tokens[j+2].GetTag().Id == token.ID {
+		return nameAt(tokens, j+2)
+	}
+	return string(tokens[j].GetMatch())
 }
 
 // fieldsBefore answers the fields offered at a position, when what sits in front of the

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -218,13 +218,15 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 	case token.TRUE, token.FALSE:
 		return "boolean: " + match
 	case token.ID:
+		aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
 		// A module is not a value, so it is answered for before anything looks for one.
-		if info := aliasesOf(parser.ScanUses(analysis.Tokens)).describe(analysis.Tokens, tk); info != "" {
+		if info := aliases.describe(analysis.Tokens, tk); info != "" {
 			return info + describeExport(analysis, tk)
 		}
 		// A struct name or a field read out of one: the declaration is what says these are
-		// anything other than a name, so it is what hover has to answer with.
-		if shape, fields, index := scanStructs(analysis.Tokens).structAt(analysis.Tokens, tk); shape != "" {
+		// anything other than a name, so it is what hover has to answer with. The declaration
+		// may be in another file, which is why the imports are read here too.
+		if shape, fields, index := shapesOf(analysis, aliases).structAt(analysis.Tokens, tk); shape != "" {
 			if index < 0 {
 				return "struct " + shape + "\nfields: " + strings.Join(fields, ", ")
 			}
@@ -250,7 +252,8 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 // the cursor, and a document being edited usually does not parse.
 func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bool) []CompletionItem {
 	analysis := s.Analyze(doc)
-	shapes := scanStructs(analysis.Tokens)
+	aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
+	shapes := shapesOf(analysis, aliases)
 
 	// Right after a dot the fields are the answer, and the only one: nothing else can
 	// follow it.
@@ -261,7 +264,6 @@ func (s *Session) CompletionItemsFor(doc Document, pos lsp.Position, snippets bo
 
 	// After a dot on a module alias, what can follow is what that module declared, and
 	// nothing else — the same rule as a struct's fields, answered from another file.
-	aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
 	if specifier, isModule := aliases.moduleBefore(analysis.Tokens, offset); isModule {
 		return exportCompletions(analysis, specifier)
 	}


### PR DESCRIPTION
O que você reportou: em `main.ar`, com

```
use geometry as g;
ident s = g.new_square(30, 20);
printd g.area(s.width, s.height);
```

o `s.` não sugeria nada.

## Por quê

O leitor de tokens do editor só conhecia as structs escritas no arquivo à frente dele. O `s` **tem** forma — o escopo prometeu com `returns`, e o módulo entregou os campos junto com a promessa — mas essa metade estava do outro lado do porto e ninguém tinha ido buscar.

## O que mudou

O que os módulos oferecem é anotado **primeiro**, e o documento é lido por cima. São as mesmas duas metades que o `Declarations.Import` do parser escreve, com o alias no lugar do specifier:

- as structs do módulo → `g.Square` → os campos
- as promessas do módulo → chamar `g.new_square` responde `g.Square`

A ordem é o ponto: um nome ligado aqui a partir de uma chamada de lá só é lido se a promessa já estiver na tabela quando o leitor passa pela chamada.

O nome fica `g.Square` porque é o único que compilaria — e dois módulos com um `Square` cada continuam sendo duas formas.

## Os quatro caminhos, que são os que a linguagem já tinha

```
ident s = g.Square{4, 5};                                  #- construído
ident s = g.new_square(4, 5);                              #- prometido lá
ident s = feed(0) as g.Square;                             #- alegado
ident make = defer { g.Square{1,2}; } returns g.Square;    #- prometido aqui
```

Todos com teste, e o hover lê a mesma tabela: passar por cima de um campo de forma importada diz qual tape ele lê.

Um nome sobre o qual ninguém disse nada continua oferecendo a lista de sempre — tem teste disso também. **Ler outro arquivo é para responder mais, nunca para responder errado.**

De brinde, longe de qualquer ponto, a struct do módulo é oferecida como construção: `g.Square{${1:width}, ${2:height}}`.

## Documentação

`docs/lsp.md` ganhou as duas seções novas e perdeu um parágrafo que ficou para trás no trabalho de módulos: dizia que o servidor analisa **só** o documento aberto e que `use` entre arquivos ainda não existia, apontando para um `import_design.md` que não existe mais.

## Verificação

`make check` limpo, `make complexity` sem nada novo. Os testes novos foram rodados contra o código antigo antes: todos vermelhos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)