### PR TITLE
feat: go to definition

### DIFF
--- a/cmd/aurorals/main.go
+++ b/cmd/aurorals/main.go
@@ -78,6 +78,7 @@ func (sv server) handlers() map[lsp.Method]lsp.MethodHandler {
 		"textDocument/didClose":            sv.didClose,
 		"textDocument/completion":          sv.completion,
 		"textDocument/hover":               sv.hover,
+		"textDocument/definition":          sv.definition,
 		"textDocument/semanticTokens/full": sv.semanticTokens,
 	}
 }

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -222,3 +222,52 @@ func TestSessionCompletionOffersKeywords(t *testing.T) {
 		}
 	}
 }
+
+// The whole round trip of a jump: a document opened, a position asked about, and a location
+// coming back — with the URI the client knows the file by, which is this side's half of the
+// answer.
+func TestSessionDefinitionAnswersWithALocation(t *testing.T) {
+	uri := "file:///tmp/main.ar"
+	replies := runSession(t,
+		didOpen(uri, "ident total = 1;\nprintd total;\n"),
+		request(5, "textDocument/definition", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 1, "character": 8},
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the definition reply, got %d", len(replies))
+	}
+	result := replies[1]["result"].(map[string]any)
+	if result["uri"] != uri {
+		t.Errorf("points at %v, want %s", result["uri"], uri)
+	}
+	start := result["range"].(map[string]any)["start"].(map[string]any)
+	if start["line"] != float64(0) || start["character"] != float64(6) {
+		t.Errorf("points at %v, want line 0 character 6", start)
+	}
+}
+
+// A position with no name under it is answered with null rather than with nothing. A request
+// carries an id and the client waits on it: silence is a client that waits forever.
+func TestSessionDefinitionOfNothingIsNull(t *testing.T) {
+	uri := "file:///tmp/main.ar"
+	replies := runSession(t,
+		didOpen(uri, "printd 42;\n"),
+		request(6, "textDocument/definition", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 0, "character": 8},
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the null reply, got %d replies: %v", len(replies), replies)
+	}
+	result, answered := replies[1]["result"]
+	if !answered || result != nil {
+		t.Errorf("answered %v, want a null result", replies[1])
+	}
+}

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -23,17 +25,41 @@ func frame(body string) string {
 	return fmt.Sprintf("Content-Length: %d\r\n\r\n%s", len(body), body)
 }
 
-// runSession feeds the messages to the server and returns every decoded reply.
+// runSession feeds the messages to a server that reads one document and nothing around it,
+// and returns every decoded reply.
 func runSession(t *testing.T, messages ...string) []map[string]any {
+	t.Helper()
+
+	return session(t, func(documents *state.State) textdoc.NewSessionOptions {
+		return textdoc.NewSessionOptions{Lexer: lexer.New(), Parser: parser.New()}
+	}, messages...)
+}
+
+// runSessionInProject feeds them to a server wired the way main wires it, which is the one
+// that reaches the files a document imports. The directory is the project it is run from,
+// because that is what module names resolve against.
+func runSessionInProject(t *testing.T, dir string, messages ...string) []map[string]any {
+	t.Helper()
+	t.Chdir(dir)
+
+	return session(t, func(documents *state.State) textdoc.NewSessionOptions {
+		return textdoc.NewSessionOptions{
+			Lexer:   lexer.New(),
+			Parser:  parser.New(),
+			Resolve: resolveModules(documents),
+		}
+	}, messages...)
+}
+
+// session runs one server over the messages and decodes what it wrote.
+func session(t *testing.T, options func(*state.State) textdoc.NewSessionOptions, messages ...string) []map[string]any {
 	t.Helper()
 
 	in := strings.NewReader(strings.Join(messages, ""))
 	out := bytes.NewBuffer(nil)
-	sv := server{textdoc: textdoc.NewSession(textdoc.NewSessionOptions{
-		Lexer:  lexer.New(),
-		Parser: parser.New(),
-	})}
-	lsp.Listen(log.New(io.Discard, "", 0), in, out, state.New(), sv.handlers())
+	documents := state.New()
+	sv := server{textdoc: textdoc.NewSession(options(documents))}
+	lsp.Listen(log.New(io.Discard, "", 0), in, out, documents, sv.handlers())
 
 	replies := make([]map[string]any, 0)
 	rest := out.Bytes()
@@ -269,5 +295,49 @@ func TestSessionDefinitionOfNothingIsNull(t *testing.T) {
 	result, answered := replies[1]["result"]
 	if !answered || result != nil {
 		t.Errorf("answered %v, want a null result", replies[1])
+	}
+}
+
+// The jump that crosses a file, through the server that reads the disk: the answer names the
+// module's file by the URI the client knows it as, which is the half of the answer this side
+// of the port is responsible for.
+func TestSessionDefinitionCrossesIntoAModule(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for name, source := range map[string]string{
+		// The manifest is what makes this a project, which is what makes src/ the root a
+		// module name resolves from.
+		"aurora.toml":     "[project]\n  name = \"jump\"\n\n[profiles]\n  [profiles.main]\n    source = \"src/main.ar\"\n    binary = \"bin/main\"\n",
+		"src/geometry.ar": "ident area = defer { feed(0) * feed(1); };\n",
+		"src/main.ar":     "use geometry as g;\nprintd g.area(2, 3);\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, filepath.FromSlash(name)), []byte(source), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	uri := "file://" + filepath.ToSlash(filepath.Join(dir, "src", "main.ar"))
+	replies := runSessionInProject(t, dir,
+		didOpen(uri, "use geometry as g;\nprintd g.area(2, 3);\n"),
+		request(7, "textDocument/definition", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 1, "character": 11},
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the definition reply, got %d: %v", len(replies), replies)
+	}
+	result := replies[1]["result"].(map[string]any)
+	want := "file://" + filepath.ToSlash(filepath.Join(dir, "src", "geometry.ar"))
+	if result["uri"] != want {
+		t.Errorf("points at %v, want %s", result["uri"], want)
+	}
+	start := result["range"].(map[string]any)["start"].(map[string]any)
+	if start["line"] != float64(0) || start["character"] != float64(6) {
+		t.Errorf("points at %v, want line 0 character 6", start)
 	}
 }

--- a/cmd/aurorals/textdoc.go
+++ b/cmd/aurorals/textdoc.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"log"
+	"path/filepath"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/hosting/lsp/state"
@@ -91,6 +92,39 @@ func (sv server) hover(l *log.Logger, s *state.State, contents []byte) any {
 	}
 
 	return textdoc.NewHoverResponse(req.ID, info)
+}
+
+// definition answers where the name under the cursor was declared.
+//
+// The path comes back from the session as a path, because which URI a file has is the
+// client's vocabulary and not the compiler's. Turning it back into one is this side's job,
+// and it is done from the absolute path so a module named from the source root — src/x.ar —
+// is the same file the editor already has open under its own URI.
+func (sv server) definition(l *log.Logger, s *state.State, contents []byte) any {
+	req, err := textdoc.ParseDefinitionRequest(contents)
+	if err != nil {
+		l.Println(err)
+		return nil
+	}
+
+	uri := req.Params.TextDocument.URI
+	found, ok := sv.textdoc.DefinitionFor(document(uri, s.GetDocument(string(uri))), req.Params.Position)
+	if !ok {
+		// A request is answered, always. Nothing under the cursor is a null result rather
+		// than silence: silence leaves the client waiting for a reply that never comes.
+		return lsp.NewNullResponse(&req.ID)
+	}
+
+	return textdoc.NewDefinitionResponse(req.ID, lsp.Location{URI: uriOf(found.Filename), Range: found.Range})
+}
+
+// uriOf turns a path into the URI the client knows the file by.
+func uriOf(path string) lsp.URI {
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		absolute = path
+	}
+	return lsp.URI("file://" + filepath.ToSlash(absolute))
 }
 
 func (sv server) semanticTokens(l *log.Logger, s *state.State, contents []byte) any {

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -12,6 +12,7 @@
 | **Diagnostics** | `textDocument/publishDiagnostics` | Lexer and parser errors underlined where they happen, republished on every change |
 | **Hover** | `textDocument/hover` | The description of the keyword under the cursor, what an identifier was bound to, a shape's fields, or which tape a field reads |
 | **Completion** | `textDocument/completion` | Keywords as snippets, the identifiers and shapes declared in the document, and — right after a `.` — the fields of a shape or what a module offers |
+| **Go to definition** | `textDocument/definition` | Where the name under the cursor was declared, in this file or in the module it came from |
 
 Document sync is **full** (`textDocumentSync: 1`): the client resends the whole file on each change.
 
@@ -64,12 +65,45 @@ Snippets are offered **only to a client that said it expands them** (`snippetSup
 initialize). To anyone else the placeholders would land in the buffer as the literal text
 they are, so that client gets the bare keyword.
 
+### Go to definition
+
+Four things are names, and each one answers with where it was written:
+
+| Under the cursor | Lands on |
+|---|---|
+| a value | the `ident` that binds it |
+| a shape | the `shape` that declares it |
+| a field | the field's name inside that declaration |
+| an alias, or anywhere in a `use` line | the top of the module's file |
+
+A name reached through an alias — `g.area`, `g.Square` — is declared in that module's file and
+never in this one, so the jump goes there. So does a field of a value whose shape came from a
+module: `s.width` lands inside `shape Square { width, height };`, in the file that declared it.
+The module's own source is lexed and asked exactly what the open document is asked, which is
+why a value, a shape and a field all cross without a rule of their own.
+
+Asking about a name where it is declared answers with itself. That is what "declared here"
+looks like, and it reads differently from "not declared at all", which answers with nothing.
+
+The binding that answers is **the one above the cursor**, so a name bound twice lands on the
+one the language itself would find. A binding that only appears further down is answered with
+anyway: a deferred scope runs when it is called, so its body can name something written under
+it.
+
+A module that is not there, and a name a module does not have, are jumps that do not happen.
+The diagnostic already says what is wrong, and an editor that opens nothing is better than one
+that opens the wrong file.
+
 **Scope:** the server lexes and parses the open document and the files it imports, and never evaluates. The imported files arrive through a port the host fills in — the command line reads a disk, the playground reads a map it already holds, since a browser has no files — so the same package answers wherever it is put. An imported file that is open in the editor is read as it is on screen, not as it is on disk: a name just typed resolves, and one just deleted stops resolving. See [modules.md](modules.md) for what a module is.
 
 **Known limitations**
 
 - The parser stops at the first error, so **one diagnostic per pass**. Fix it and the next one appears.
-- No go-to-definition, no code actions, no formatting, no incremental sync.
+- Go to definition lands on a declaration, never on every place a name is used: there is no
+  `textDocument/references`, and no rename that follows from it.
+- Scope is read as the file is written, so a name declared inside a deferred scope and one
+  declared at the top are told apart by which comes first, not by which is visible.
+- No code actions, no formatting, no incremental sync.
 - Semantic token types are decided lexically. A call is anything followed by `(`, a shape anything after `shape` or `as`, a field anything after `.`.
 
 ---

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -77,16 +77,18 @@ What it does not do yet:
   as `m.Point`, the same way everything it binds is. Marking part of it later breaks nothing.
 - **There is no `private`.** A module offers everything it binds with `ident` at the top. The
   boundary exists now, so marking part of it later breaks nothing.
-- **The language server follows an import, and stops short of two things.** It reads what a
+- **The language server follows an import, and stops short of one thing.** It reads what a
   document imports on every pass, from the editor's buffers before the disk, so a module that
   is not there and a name a module does not have are underlined where they were written, and
   what a module declared is offered after the dot — its shapes included, and the fields of a
   name whose shape came from another file, because what the imports offer is written down
-  before the document is read. What it does not do is go to a definition
-  in another file — no `textDocument/definition` exists for anything yet — and it does not
-  watch a file nobody has open, so editing a module outside the editor updates what depends
-  on it only when that file is touched. Neither needs the resolver; both need a capability
-  the server does not have.
+  before the document is read. A name jumps to where it was declared, here or in the module
+  it came from. What it does not do is watch a file nobody has open, so editing a module
+  outside the editor updates what depends on it only when that file is touched. It does not
+  need the resolver; it needs a capability the server does not have.
+- **A jump lands on a declaration and nothing else.** There is no
+  `textDocument/references` — every place a name is used — and so no rename either, which is
+  the same walk with an edit at the end of it.
 - **Nothing measures what following an import costs.** Every pass reads and parses every
   module the document imports, with no cache, which is the honest place to start: a cache has
   invalidation, and invalidation is a bug that reads as the editor lying. The shape to copy

--- a/hosting/lsp/initialize/initialize.go
+++ b/hosting/lsp/initialize/initialize.go
@@ -66,6 +66,9 @@ func NewResponse(id int) InitializeResponse {
 				// 1 = full sync: the client resends the whole document on each change.
 				TextDocumentSync: 1,
 				HoverProvider:    true,
+				// Where a name was declared. Every name in Aurora is declared in the file
+				// that uses it or in a module it named, so the answer is always one place.
+				DefinitionProvider: true,
 				// The dot is declared as a trigger so a client asks for completion the
 				// moment someone types it — which is when the fields of a shape are
 				// what they want, and the only moment the document does not parse.

--- a/hosting/lsp/message.go
+++ b/hosting/lsp/message.go
@@ -79,6 +79,7 @@ type SemanticTokensOptions struct {
 type ServerCapabilities struct {
 	TextDocumentSync       int                    `json:"textDocumentSync"`
 	HoverProvider          bool                   `json:"hoverProvider"`
+	DefinitionProvider     bool                   `json:"definitionProvider"`
 	CompletionProvider     map[string]any         `json:"completionProvider"`
 	SemanticTokensProvider *SemanticTokensOptions `json:"semanticTokensProvider,omitempty"`
 }

--- a/hosting/lsp/textdoc/definition.go
+++ b/hosting/lsp/textdoc/definition.go
@@ -2,6 +2,7 @@ package textdoc
 
 import (
 	"encoding/json"
+	"strings"
 
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/parser"
@@ -62,33 +63,147 @@ type Definition struct {
 // bound with `ident`, a shape declared with `shape`, a field inside a shape's declaration,
 // and the declaration itself — asking about a name where it was written answers with itself,
 // which is what tells "declared here" from "not declared at all".
+//
+// The file it lands in is this one or a module's, and the question does not change between
+// them: the other file is lexed and asked the same thing.
 func (s *Session) DefinitionFor(doc Document, pos lsp.Position) (Definition, bool) {
 	analysis := s.Analyze(doc)
 	subject := analysis.TokenAt(pos)
 	if subject == nil || subject.GetTag().Id != token.ID {
 		return Definition{}, false
 	}
+	aliases := aliasesOf(parser.ScanUses(analysis.Tokens))
 
-	found := declaredIn(analysis.Tokens, subject, shapesOf(analysis, aliasesOf(parser.ScanUses(analysis.Tokens))))
+	// A use line is about a module wherever the cursor sits in it — on the keyword, on the
+	// path or on the alias — and so is an alias anywhere else. The module is a file, so the
+	// answer is its top.
+	if alias, declared := aliasOfUse(analysis.Tokens, subject); declared {
+		return s.inModule(analysis, aliases[alias], "")
+	}
+	if specifier, isModule := aliases[string(subject.GetMatch())]; isModule {
+		return s.inModule(analysis, specifier, "")
+	}
+	// A name reached through an alias is declared in that module's file, and never here.
+	if specifier, reached := moduleOfSubject(analysis, subject); reached {
+		return s.inModule(analysis, specifier, string(subject.GetMatch()))
+	}
+
+	shapes := shapesOf(analysis, aliases)
+	if owner := ownerOf(analysis.Tokens, subject); owner != nil {
+		return s.fieldOf(analysis, aliases, doc.Filename, shapes.reads[string(owner.GetMatch())], string(subject.GetMatch()))
+	}
+	found := bindingOf(analysis.Tokens, string(subject.GetMatch()), subject.GetCursor())
 	if found == nil {
 		return Definition{}, false
 	}
-	return Definition{
-		Filename: doc.Filename,
-		Range:    analysis.Mapper.Range(found.GetCursor(), len(found.GetMatch())),
-	}, true
+	return Definition{Filename: doc.Filename, Range: rangeOf(analysis.Mapper, found)}, true
 }
 
-// declaredIn answers the token that declares the subject, among the tokens of the file it was
-// written in.
-//
-// A field is looked for first because the same name may be both — `p.x` where an `ident x`
-// exists elsewhere is the field, and the dot is what says so.
-func declaredIn(tokens []token.Token, subject token.Token, shapes shapeTable) token.Token {
-	if owner := ownerOf(tokens, subject); owner != nil {
-		return fieldToken(tokens, shapes.reads[string(owner.GetMatch())], string(subject.GetMatch()))
+// fieldOf answers where a field was named, in the file that declares the shape it belongs to.
+// A shape reached through an alias carries it, and that is the only part the reader here has
+// to undo: `g.Square` is Square, over there.
+func (s *Session) fieldOf(analysis *Analysis, aliases moduleAliases, filename, shape, field string) (Definition, bool) {
+	if alias, name, qualified := strings.Cut(shape, "."); qualified {
+		specifier, isModule := aliases[alias]
+		if !isModule {
+			return Definition{}, false
+		}
+		tokens, mapper, filename, ok := s.readModule(analysis, specifier)
+		if !ok {
+			return Definition{}, false
+		}
+		return found(fieldToken(tokens, name, field), mapper, filename)
 	}
-	return bindingToken(tokens, subject)
+	return found(fieldToken(analysis.Tokens, shape, field), analysis.Mapper, filename)
+}
+
+// inModule answers where a name is declared in another file, or the file itself when the name
+// is empty — which is what an alias means: a module is a file, and there is nothing narrower
+// to point at.
+func (s *Session) inModule(analysis *Analysis, specifier, symbol string) (Definition, bool) {
+	tokens, mapper, filename, ok := s.readModule(analysis, specifier)
+	if !ok {
+		return Definition{}, false
+	}
+	if symbol == "" {
+		return Definition{Filename: filename, Range: lsp.LineRange(0, 0, 0)}, true
+	}
+	// From the top: what a module offers is bound at the top level of its file, and nothing
+	// in the file that imports it says where.
+	return found(bindingOf(tokens, symbol, 0), mapper, filename)
+}
+
+// readModule lexes a module's own file, so the same questions can be asked of it as of the
+// document being edited. It answers nothing for a module that was never resolved — the one
+// that is not there, and the whole file when there is no port to resolve through.
+func (s *Session) readModule(analysis *Analysis, specifier string) ([]token.Token, *lsp.Mapper, string, bool) {
+	module, imported := analysis.module(specifier)
+	if !imported {
+		return nil, nil, "", false
+	}
+	tokens, err := s.lexer.GetFilledTokens([]byte(module.Source))
+	if err != nil {
+		return nil, nil, "", false
+	}
+	return tokens, lsp.NewMapper(module.Source), module.Tree.Filename, true
+}
+
+// found turns a token into the answer, and a token nobody found into no answer.
+func found(declaration token.Token, mapper *lsp.Mapper, filename string) (Definition, bool) {
+	if declaration == nil {
+		return Definition{}, false
+	}
+	return Definition{Filename: filename, Range: rangeOf(mapper, declaration)}, true
+}
+
+// rangeOf is the range a token covers in the file it was read from.
+func rangeOf(mapper *lsp.Mapper, tk token.Token) lsp.Range {
+	return mapper.Range(tk.GetCursor(), len(tk.GetMatch()))
+}
+
+// aliasOfUse answers the alias of the use declaration the subject sits inside, and false when
+// it sits anywhere else.
+//
+// It reads the statement rather than the line: two declarations on one line are two
+// statements, and the answer has to be about the one the cursor is in.
+func aliasOfUse(tokens []token.Token, subject token.Token) (string, bool) {
+	i := indexOf(tokens, subject)
+	if i < 0 {
+		return "", false
+	}
+	for ; i >= 0; i-- {
+		if tokens[i].GetTag().Id == token.SEMICOLON {
+			return "", false
+		}
+		if tokens[i].GetTag().Id == token.USE {
+			break
+		}
+	}
+	if i < 0 {
+		return "", false
+	}
+	// `use a/b/c as x;`: the alias is the name after `as`, and it is the last thing the
+	// declaration holds.
+	for ; i < len(tokens)-1; i++ {
+		if tokens[i].GetTag().Id == token.AS && tokens[i+1].GetTag().Id == token.ID {
+			return string(tokens[i+1].GetMatch()), true
+		}
+		if tokens[i].GetTag().Id == token.SEMICOLON {
+			break
+		}
+	}
+	return "", false
+}
+
+// indexOf answers where a token sits in the stream it came from. Tokens are compared by where
+// they start: the concrete type holds slices and cannot be compared with ==.
+func indexOf(tokens []token.Token, subject token.Token) int {
+	for i, tk := range tokens {
+		if tk.GetCursor() == subject.GetCursor() {
+			return i
+		}
+	}
+	return -1
 }
 
 // ownerOf answers the name a token is read out of — the `p` of `p.x` — and nil when the token
@@ -110,17 +225,15 @@ func ownerOf(tokens []token.Token, subject token.Token) token.Token {
 	return nil
 }
 
-// bindingToken answers where a plain name was declared: `shape Point`, or the nearest
-// `ident name` written before it.
+// bindingOf answers where a plain name was declared: `shape Point`, or the nearest
+// `ident name` written before the cursor it is asked about.
 //
 // Nearest before, because that is the one the language would find: a name is bound before it
 // is used, and a second binding of the same name shadows the first from where it is written.
 // A binding that only appears later is answered with anyway — a deferred scope runs when it
 // is called, so a body can name something written under it, and a jump to the wrong end of a
 // file is a better answer than none.
-func bindingToken(tokens []token.Token, subject token.Token) token.Token {
-	name := string(subject.GetMatch())
-
+func bindingOf(tokens []token.Token, name string, at int) token.Token {
 	var before, after token.Token
 	for i := 1; i < len(tokens); i++ {
 		if string(tokens[i].GetMatch()) != name || tokens[i].GetTag().Id != token.ID {
@@ -129,7 +242,7 @@ func bindingToken(tokens []token.Token, subject token.Token) token.Token {
 		if declares := tokens[i-1].GetTag().Id; declares != token.IDENT && declares != token.SHAPE {
 			continue
 		}
-		if tokens[i].GetCursor() <= subject.GetCursor() {
+		if tokens[i].GetCursor() <= at {
 			before = tokens[i]
 			continue
 		}

--- a/hosting/lsp/textdoc/definition.go
+++ b/hosting/lsp/textdoc/definition.go
@@ -1,0 +1,163 @@
+package textdoc
+
+import (
+	"encoding/json"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Where a name was declared, and how the editor is told.
+//
+// It is read from the tokens, like everything else here. A definition is asked for while
+// somebody is reading rather than typing, so the document usually parses — but the tree is
+// the wrong place to look anyway: what is wanted is where a name was *written*, and the tree
+// keeps what a name means. The token stream keeps where.
+
+type DefinitionParams struct {
+	PositionParams
+}
+
+type DefinitionRequest struct {
+	lsp.Request
+	Params DefinitionParams `json:"params"`
+}
+
+// DefinitionResponse answers with one location, which is one of the three forms the protocol
+// allows. A name is declared in one place in Aurora, so the list form would always hold one.
+type DefinitionResponse struct {
+	lsp.Response
+	Result lsp.Location `json:"result"`
+}
+
+func ParseDefinitionRequest(contents []byte) (*DefinitionRequest, error) {
+	var req DefinitionRequest
+	if err := json.Unmarshal(contents, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func NewDefinitionResponse(id int, location lsp.Location) DefinitionResponse {
+	return DefinitionResponse{
+		Response: lsp.Response{RPC: "2.0", ID: &id},
+		Result:   location,
+	}
+}
+
+// A Definition is where a name was declared: which file, and the range of the name inside it.
+//
+// The file is a path rather than a URI because this package answers with values and never
+// touches the world — which URI a path is depends on the host, and only the host knows.
+type Definition struct {
+	Filename string
+	Range    lsp.Range
+}
+
+// DefinitionFor answers where the name under the cursor was declared, and false when nothing
+// under it is a name or nothing declares it.
+//
+// Four things are names here, and each is declared somewhere a token can be found: a value
+// bound with `ident`, a shape declared with `shape`, a field inside a shape's declaration,
+// and the declaration itself — asking about a name where it was written answers with itself,
+// which is what tells "declared here" from "not declared at all".
+func (s *Session) DefinitionFor(doc Document, pos lsp.Position) (Definition, bool) {
+	analysis := s.Analyze(doc)
+	subject := analysis.TokenAt(pos)
+	if subject == nil || subject.GetTag().Id != token.ID {
+		return Definition{}, false
+	}
+
+	found := declaredIn(analysis.Tokens, subject, shapesOf(analysis, aliasesOf(parser.ScanUses(analysis.Tokens))))
+	if found == nil {
+		return Definition{}, false
+	}
+	return Definition{
+		Filename: doc.Filename,
+		Range:    analysis.Mapper.Range(found.GetCursor(), len(found.GetMatch())),
+	}, true
+}
+
+// declaredIn answers the token that declares the subject, among the tokens of the file it was
+// written in.
+//
+// A field is looked for first because the same name may be both — `p.x` where an `ident x`
+// exists elsewhere is the field, and the dot is what says so.
+func declaredIn(tokens []token.Token, subject token.Token, shapes shapeTable) token.Token {
+	if owner := ownerOf(tokens, subject); owner != nil {
+		return fieldToken(tokens, shapes.reads[string(owner.GetMatch())], string(subject.GetMatch()))
+	}
+	return bindingToken(tokens, subject)
+}
+
+// ownerOf answers the name a token is read out of — the `p` of `p.x` — and nil when the token
+// does not follow a dot.
+//
+// It is the same question ownerBefore asks of a cursor, from the other end: that one is for a
+// dot somebody just typed, this one for a name already there.
+func ownerOf(tokens []token.Token, subject token.Token) token.Token {
+	for i, tk := range tokens {
+		// Tokens are compared by where they start: the concrete type holds slices and cannot
+		// be compared with ==.
+		if tk.GetCursor() != subject.GetCursor() || i < 2 || tokens[i-1].GetTag().Id != token.DOT {
+			continue
+		}
+		if owner := tokens[i-2]; owner.GetTag().Id == token.ID {
+			return owner
+		}
+	}
+	return nil
+}
+
+// bindingToken answers where a plain name was declared: `shape Point`, or the nearest
+// `ident name` written before it.
+//
+// Nearest before, because that is the one the language would find: a name is bound before it
+// is used, and a second binding of the same name shadows the first from where it is written.
+// A binding that only appears later is answered with anyway — a deferred scope runs when it
+// is called, so a body can name something written under it, and a jump to the wrong end of a
+// file is a better answer than none.
+func bindingToken(tokens []token.Token, subject token.Token) token.Token {
+	name := string(subject.GetMatch())
+
+	var before, after token.Token
+	for i := 1; i < len(tokens); i++ {
+		if string(tokens[i].GetMatch()) != name || tokens[i].GetTag().Id != token.ID {
+			continue
+		}
+		if declares := tokens[i-1].GetTag().Id; declares != token.IDENT && declares != token.SHAPE {
+			continue
+		}
+		if tokens[i].GetCursor() <= subject.GetCursor() {
+			before = tokens[i]
+			continue
+		}
+		if after == nil {
+			after = tokens[i]
+		}
+	}
+	if before != nil {
+		return before
+	}
+	return after
+}
+
+// fieldToken answers where a field was named, which is inside the declaration of the shape it
+// belongs to: the `y` of `shape Point { x, y }`.
+func fieldToken(tokens []token.Token, shape, field string) token.Token {
+	for i := 1; i < len(tokens); i++ {
+		if tokens[i-1].GetTag().Id != token.SHAPE || string(tokens[i].GetMatch()) != shape {
+			continue
+		}
+		for j := i + 1; j < len(tokens); j++ {
+			if tokens[j].GetTag().Id == token.C_CUR_BRK {
+				return nil
+			}
+			if tokens[j].GetTag().Id == token.ID && string(tokens[j].GetMatch()) == field {
+				return tokens[j]
+			}
+		}
+	}
+	return nil
+}

--- a/hosting/lsp/textdoc/definition_test.go
+++ b/hosting/lsp/textdoc/definition_test.go
@@ -1,0 +1,142 @@
+package textdoc
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+)
+
+// Where a name was declared, inside the file that uses it. The cursor goes on the name being
+// asked about, and the answer is the range of the name where it was written.
+func TestDefinitionInTheSameFile(t *testing.T) {
+	const source = "ident width = 10;\n" +
+		"shape Point { x, y };\n" +
+		"ident p = Point{width, 2};\n" +
+		"printd p.y;\n"
+
+	for _, tc := range []struct {
+		name string
+		at   lsp.Position
+		want lsp.Range
+	}{
+		{
+			name: "a value, from where it is used",
+			at:   lsp.Position{Line: 2, Character: 16},
+			want: lsp.LineRange(0, 6, 11),
+		},
+		{
+			name: "a shape, from a construction",
+			at:   lsp.Position{Line: 2, Character: 11},
+			want: lsp.LineRange(1, 6, 11),
+		},
+		{
+			name: "a field, from where it is read",
+			at:   lsp.Position{Line: 3, Character: 9},
+			want: lsp.LineRange(1, 17, 18),
+		},
+		{
+			name: "a name asked about where it is declared answers with itself",
+			at:   lsp.Position{Line: 0, Character: 6},
+			want: lsp.LineRange(0, 6, 11),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			found, ok := session().DefinitionFor(Document{Filename: "main.ar", Source: source}, tc.at)
+			if !ok {
+				t.Fatal("nothing was found")
+			}
+			if found.Filename != "main.ar" {
+				t.Errorf("points at %s, want the file itself", found.Filename)
+			}
+			if found.Range != tc.want {
+				t.Errorf("points at %+v, want %+v", found.Range, tc.want)
+			}
+		})
+	}
+}
+
+// Nothing is answered rather than something wrong. A jump the editor cannot make is a jump
+// that does not happen; a jump to the wrong line is one somebody has to undo.
+func TestDefinitionOfWhatIsNotDeclared(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		at     lsp.Position
+	}{
+		{
+			name:   "a name nothing declares",
+			source: "printd nope;\n",
+			at:     lsp.Position{Line: 0, Character: 8},
+		},
+		{
+			name:   "a number",
+			source: "printd 42;\n",
+			at:     lsp.Position{Line: 0, Character: 8},
+		},
+		{
+			name:   "a keyword",
+			source: "printd 42;\n",
+			at:     lsp.Position{Line: 0, Character: 2},
+		},
+		{
+			name:   "past the end of the document",
+			source: "printd 42;\n",
+			at:     lsp.Position{Line: 9, Character: 0},
+		},
+		{
+			name:   "a field of a shape that has no such field",
+			source: "shape Point { x, y };\nident p = Point{1, 2};\nprintd p.z;\n",
+			at:     lsp.Position{Line: 2, Character: 9},
+		},
+		{
+			name:   "a field of a value with no shape",
+			source: "ident p = 1;\nprintd p.x;\n",
+			at:     lsp.Position{Line: 1, Character: 9},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if found, ok := session().DefinitionFor(Document{Filename: "main.ar", Source: tc.source}, tc.at); ok {
+				t.Errorf("answered %+v, want nothing", found)
+			}
+		})
+	}
+}
+
+// A name bound twice is two names, and the one that answers is the one the language would
+// find: the binding above the cursor, not the first in the file.
+func TestDefinitionOfAShadowedName(t *testing.T) {
+	const source = "ident n = 1;\n" +
+		"printd n;\n" +
+		"ident n = 2;\n" +
+		"printd n;\n"
+
+	first, ok := session().DefinitionFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 1, Character: 7})
+	if !ok {
+		t.Fatal("the first reading found nothing")
+	}
+	if first.Range != lsp.LineRange(0, 6, 7) {
+		t.Errorf("the first reading points at %+v, want the binding above it", first.Range)
+	}
+
+	second, ok := session().DefinitionFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 3, Character: 7})
+	if !ok {
+		t.Fatal("the second reading found nothing")
+	}
+	if second.Range != lsp.LineRange(2, 6, 7) {
+		t.Errorf("the second reading points at %+v, want the binding above it", second.Range)
+	}
+}
+
+// A deferred scope runs when it is called, so its body can name something written under it.
+// The binding below is a better answer than none.
+func TestDefinitionOfANameBoundFurtherDown(t *testing.T) {
+	const source = "ident show = defer { later; };\nident later = 5;\nprintd show();\n"
+
+	found, ok := session().DefinitionFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 0, Character: 22})
+	if !ok {
+		t.Fatal("nothing was found")
+	}
+	if found.Range != lsp.LineRange(1, 6, 11) {
+		t.Errorf("points at %+v, want the binding below it", found.Range)
+	}
+}

--- a/hosting/lsp/textdoc/definition_test.go
+++ b/hosting/lsp/textdoc/definition_test.go
@@ -140,3 +140,120 @@ func TestDefinitionOfANameBoundFurtherDown(t *testing.T) {
 		t.Errorf("points at %+v, want the binding below it", found.Range)
 	}
 }
+
+// Across a module: the answer is in the other file, and the other file is the one the editor
+// is told to open.
+func TestDefinitionInsideAModule(t *testing.T) {
+	const geometry = "shape Square { width, height };\n" +
+		"ident new_square = defer { Square{feed(0), feed(1)}; } returns Square;\n" +
+		"ident area = defer { feed(0) * feed(1); };\n"
+	const main = "use geometry as g;\n" +
+		"ident s = g.new_square(30, 20);\n" +
+		"printd g.area(s.width, s.height);\n"
+
+	for _, tc := range []struct {
+		name string
+		at   lsp.Position
+		want lsp.Range
+	}{
+		{
+			name: "a scope the module binds",
+			at:   lsp.Position{Line: 1, Character: 14},
+			want: lsp.LineRange(1, 6, 16),
+		},
+		{
+			name: "a shape the module declares, through a name that reads as one",
+			at:   lsp.Position{Line: 2, Character: 17},
+			want: lsp.LineRange(0, 15, 20),
+		},
+		{
+			name: "the alias, from where it is used",
+			at:   lsp.Position{Line: 2, Character: 7},
+			want: lsp.LineRange(0, 0, 0),
+		},
+		{
+			name: "the path in the use line",
+			at:   lsp.Position{Line: 0, Character: 6},
+			want: lsp.LineRange(0, 0, 0),
+		},
+		{
+			name: "the alias in the use line",
+			at:   lsp.Position{Line: 0, Character: 16},
+			want: lsp.LineRange(0, 0, 0),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			session := withModuleFiles(map[string]string{"src/geometry.ar": geometry})
+			found, ok := session.DefinitionFor(Document{Filename: "src/main.ar", Source: main}, tc.at)
+			if !ok {
+				t.Fatal("nothing was found")
+			}
+			if found.Filename != "src/geometry.ar" {
+				t.Errorf("points at %s, want the module's file", found.Filename)
+			}
+			if found.Range != tc.want {
+				t.Errorf("points at %+v, want %+v", found.Range, tc.want)
+			}
+		})
+	}
+}
+
+// A shape written as the module's — built, claimed or promised — is declared over there too.
+func TestDefinitionOfAShapeNamedThroughItsModule(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "shape Square { width, height };\n"})
+	found, ok := session.DefinitionFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nident s = g.Square{4, 5};\n",
+	}, lsp.Position{Line: 1, Character: 14})
+
+	if !ok {
+		t.Fatal("nothing was found")
+	}
+	if found.Filename != "src/geometry.ar" || found.Range != lsp.LineRange(0, 6, 12) {
+		t.Errorf("points at %s %+v, want the declaration in the module", found.Filename, found.Range)
+	}
+}
+
+// A module that is not there is a jump that does not happen. The diagnostic already says it
+// is missing, and an editor that opens nothing is better than one that opens the wrong file.
+func TestDefinitionIntoAModuleThatIsNotThere(t *testing.T) {
+	session := withModuleFiles(map[string]string{})
+	for _, at := range []lsp.Position{{Line: 0, Character: 6}, {Line: 1, Character: 9}} {
+		if found, ok := session.DefinitionFor(Document{
+			Filename: "src/main.ar",
+			Source:   "use gone as g;\nprintd g.area(1, 2);\n",
+		}, at); ok {
+			t.Errorf("answered %+v for a module that is not there", found)
+		}
+	}
+}
+
+// A name a module does not have is refused the same way, and the file is not opened at its
+// top as a consolation: the question was about a name.
+func TestDefinitionOfANameTheModuleDoesNotHave(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "ident area = defer { feed(0); };\n"})
+	if found, ok := session.DefinitionFor(Document{
+		Filename: "src/main.ar",
+		Source:   "use geometry as g;\nprintd g.volume(1, 2);\n",
+	}, lsp.Position{Line: 1, Character: 11}); ok {
+		t.Errorf("answered %+v, want nothing", found)
+	}
+}
+
+// Without the port nothing is resolved, so a name reached through a module has nowhere to
+// land — and the document is still answered for on its own.
+func TestDefinitionWithoutThePort(t *testing.T) {
+	const source = "use a/b as x;\nident here = 1;\nprintd x.there(here);\n"
+	doc := Document{Filename: "main.ar", Source: source}
+
+	if found, ok := session().DefinitionFor(doc, lsp.Position{Line: 2, Character: 11}); ok {
+		t.Errorf("answered %+v for a module nobody looked for", found)
+	}
+	found, ok := session().DefinitionFor(doc, lsp.Position{Line: 2, Character: 16})
+	if !ok {
+		t.Fatal("a name of this file was not found")
+	}
+	if found.Range != lsp.LineRange(1, 6, 10) {
+		t.Errorf("points at %+v, want the binding in this file", found.Range)
+	}
+}

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -102,7 +102,7 @@ func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(modules, module.Module{ID: "", Tree: tree}), nil
+	return append(modules, module.Module{ID: "", Tree: tree, Source: string(source)}), nil
 }
 
 // OffersOf is what a set of modules offer, by the name they are imported under.
@@ -209,7 +209,7 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 
 	// Appended after everything it needs, which is what makes the order topological.
 	state.found[id] = true
-	state.order = append(state.order, module.Module{ID: id, Tree: tree})
+	state.order = append(state.order, module.Module{ID: id, Tree: tree, Source: string(source)})
 	return nil
 }
 

--- a/wire/module/module.go
+++ b/wire/module/module.go
@@ -24,6 +24,11 @@ type ID string
 type Module struct {
 	ID   ID
 	Tree ast.AST
+	// Source is the text the tree was read from, which the resolver had in its hands anyway.
+	// It is here for whoever has to point at a place in a file it never opened: an editor
+	// jumping to where a name was declared needs the line and column of a token in another
+	// file, and a position is counted in text.
+	Source string
 }
 
 // IsEntry reports whether this is the file that was asked for rather than one it needed.


### PR DESCRIPTION
`textDocument/definition`, dentro do arquivo e atravessando módulo.

| Sob o cursor | Cai em |
|---|---|
| um valor | o `ident` que liga ele |
| uma shape | o `shape` que declara ela |
| um campo | o nome do campo dentro daquela declaração |
| um alias, ou qualquer lugar de uma linha `use` | o topo do arquivo do módulo |

`g.area` cai no `ident area` de `src/geometry.ar`; `g.Square` na shape que declara ela; `s.width` no campo lá dentro.

## Como

Lido dos **tokens**, como todo o resto do pacote. Uma definição é pedida enquanto alguém está lendo, não digitando, então o documento normalmente parseia — mas a árvore é o lugar errado de qualquer jeito: o que se quer é onde um nome foi **escrito**, e a árvore guarda o que ele significa.

Atravessar arquivo não mudou a pergunta: o source do módulo é lexado e recebe exatamente a mesma pergunta que o documento aberto. É por isso que valor, shape e campo atravessam sem um caso cada um.

Isso precisou de um campo: **um módulo passa a carregar o texto de onde foi parseado**, que o resolver já tinha na mão e jogava fora. Posição se conta em texto, e apontar para dentro de um arquivo que você nunca abriu precisa do texto para contar.

## Duas regras que valem saber

- **A ligação que responde é a de cima do cursor**, então um nome ligado duas vezes cai na que a própria linguagem acharia. Uma ligação que só aparece mais abaixo é respondida mesmo assim: um `defer` roda quando é chamado, então o corpo dele pode nomear algo escrito embaixo.
- **Perguntar sobre um nome onde ele é declarado responde com ele mesmo.** É assim que "declarado aqui" se lê diferente de "não declarado", que responde com nada.

Um módulo que não está lá, e um nome que o módulo não tem, são pulos que não acontecem. O diagnóstico já diz o que está errado, e um editor que não abre nada é melhor que um que abre o arquivo errado.

## Uma coisa que corrigi de passagem

O handler responde **null** quando não acha nada, em vez de não responder. Um request carrega um id e o cliente espera nele — silêncio é um cliente esperando para sempre.

O `hover` faz isso hoje (`return nil` quando não tem o que dizer) e eu **não** mexi, para manter o PR no assunto. Vale um PR de uma linha se você quiser.

## Verificação

`make check` limpo, `make complexity` sem nada novo. Testes: a tabela de casos no arquivo, os casos que não respondem nada (número, keyword, nome não declarado, campo que a shape não tem, fora do documento), sombra, ligação mais abaixo, os cinco casos que atravessam módulo — e dois testes de sessão de verdade em `cmd/aurorals`, um deles com dois arquivos em disco e manifesto, conferindo a URI que volta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)