### PR TITLE
fix: hover answers with null, and the example stops saying a shape cannot be named

### DIFF
--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -341,3 +341,25 @@ func TestSessionDefinitionCrossesIntoAModule(t *testing.T) {
 		t.Errorf("points at %v, want line 0 character 6", start)
 	}
 }
+
+// Hover over something with nothing to say — a semicolon — answers null, not silence: a
+// request is answered whatever the answer is.
+func TestSessionHoverOfNothingIsNull(t *testing.T) {
+	uri := "file:///tmp/main.ar"
+	replies := runSession(t,
+		didOpen(uri, "printd 42;\n"),
+		request(8, "textDocument/hover", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 0, "character": 9},
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the null reply, got %d replies: %v", len(replies), replies)
+	}
+	result, answered := replies[1]["result"]
+	if !answered || result != nil {
+		t.Errorf("answered %v, want a null result", replies[1])
+	}
+}

--- a/cmd/aurorals/textdoc.go
+++ b/cmd/aurorals/textdoc.go
@@ -88,7 +88,9 @@ func (sv server) hover(l *log.Logger, s *state.State, contents []byte) any {
 	uri := req.Params.TextDocument.URI
 	info := sv.textdoc.HoverInfo(document(uri, s.GetDocument(string(uri))), req.Params.Position)
 	if info == "" {
-		return nil
+		// Nothing to say is a null result rather than silence, for the same reason a jump
+		// that lands nowhere is: the request carries an id and the client waits on it.
+		return lsp.NewNullResponse(&req.ID)
 	}
 
 	return textdoc.NewHoverResponse(req.ID, info)

--- a/examples/project/src/geometry.ar
+++ b/examples/project/src/geometry.ar
@@ -3,10 +3,13 @@
 #- Its name is the path it has from src/, so this one is "geometry" — nothing in here says
 #- so, because what a module is called is decided by where it sits and not by what it holds.
 #-
-#- What it offers is what it binds with ident at the top: new_square and area. Names bound
-#- anywhere deeper belong to the scope that binds them, and the shape's name stays here — a
-#- file that imports this one cannot write Square, and does not have to: new_square promises
-#- it, and a promise carries the shape.
+#- What it offers is what it binds with ident at the top: new_square and area, and the shape
+#- Square. Names bound anywhere deeper belong to the scope that binds them.
+#-
+#- A file that imports this one writes the shape as g.Square, never as Square: the name of a
+#- shape carries the module it was declared in, so a Square here and a Square there are two
+#- shapes. It does not have to write it at all — new_square promises one, and a promise
+#- carries the fields with it.
 #-
 #- It prints nothing on its own, so it declares no output: a module of declarations does its
 #- work when somebody imports it.

--- a/examples/project/src/main.ar
+++ b/examples/project/src/main.ar
@@ -4,9 +4,12 @@
 #- What it multiplies comes from a module: "use geometry as g;" reads src/geometry.ar, and g
 #- is the only way to reach what is inside it. The alias is this file's alone.
 #-
-#- Nothing here names Square, and nothing can: a shape's name stays in the file that declared
-#- it. What crossed is the promise — new_square says it answers with a Square, and the fields
-#- of it came along, which is what lets s.width be read as the first tape of the run.
+#- Nothing here names Square, and nothing has to: what crossed is the promise — new_square
+#- says it answers with a Square, and the fields came along with it, which is what lets
+#- s.width be read as the first tape of the run.
+#-
+#- Naming it is possible too, through the alias and only through it: g.Square{30, 20} builds
+#- one, as g.Square claims one, returns g.Square promises one.
 #-
 #- Modules resolve from src/ under the directory the command was run in, so this one is run
 #- from the project root.


### PR DESCRIPTION
As duas pontas soltas que sobraram do #83.

## O hover responde

Passar o mouse sobre um ponto e vírgula não devolvia **nada** — nem um reply. Um request carrega um id e o cliente espera nele, então "não tenho o que dizer" é um resultado `null`, não silêncio. Silêncio é um cliente esperando para sempre.

É o que o pulo já faz desde que foi escrito; esse é o handler mais velho se acertando.

## O exemplo para de mentir

Os comentários de `examples/project/src/` diziam que o nome de uma shape fica no arquivo que declarou e que ninguém que importa consegue escrever `Square`. Era verdade quando foi escrito e deixou de ser quando a nomeação entrou (#80).

O que continua verdade é a parte que interessa, e ela fica: **este arquivo não nomeia nada**, porque `new_square` prometeu um `Square` e a promessa carregou os campos. O lado do módulo passa a dizer a outra metade — que o nome carrega o módulo, então um `Square` aqui e um `Square` lá são duas shapes.

## Verificação

`make check` limpo. O `TestSessionHoverOfNothingIsNull` é novo e roda a sessão de verdade; os exemplos já eram executados e conferidos contra o bloco `Output:` que eles declaram, então os comentários novos foram lidos por um teste que já existia.

🤖 Generated with [Claude Code](https://claude.com/claude-code)