### PR TITLE
feat: rename

### DIFF
--- a/cmd/aurorals/main.go
+++ b/cmd/aurorals/main.go
@@ -79,6 +79,8 @@ func (sv server) handlers() map[lsp.Method]lsp.MethodHandler {
 		"textDocument/completion":          sv.completion,
 		"textDocument/hover":               sv.hover,
 		"textDocument/definition":          sv.definition,
+		"textDocument/prepareRename":       sv.prepareRename,
+		"textDocument/rename":              sv.rename,
 		"textDocument/semanticTokens/full": sv.semanticTokens,
 	}
 }

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -363,3 +363,59 @@ func TestSessionHoverOfNothingIsNull(t *testing.T) {
 		t.Errorf("answered %v, want a null result", replies[1])
 	}
 }
+
+// The round trip of a rename: every edit in one file, under the URI the client knows it by.
+func TestSessionRenameAnswersWithTheEdits(t *testing.T) {
+	uri := "file:///tmp/main.ar"
+	replies := runSession(t,
+		didOpen(uri, "ident area = defer {\n  ident side = feed(0);\n  side * side;\n};\n"),
+		request(9, "textDocument/rename", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 2, "character": 3},
+			"newName":      "edge",
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the rename reply, got %d: %v", len(replies), replies)
+	}
+	changes := replies[1]["result"].(map[string]any)["changes"].(map[string]any)
+	edits, touched := changes[uri]
+	if !touched || len(changes) != 1 {
+		t.Fatalf("changed %v, want the open file alone", changes)
+	}
+	if len(edits.([]any)) != 3 {
+		t.Errorf("made %d edits, want the declaration and its two readings", len(edits.([]any)))
+	}
+	for _, edit := range edits.([]any) {
+		if edit.(map[string]any)["newText"] != "edge" {
+			t.Errorf("an edit writes %v, want the new name", edit)
+		}
+	}
+}
+
+// A name that cannot be renamed is refused with the reason, which is what a client shows to
+// whoever asked — and it is refused at the prepare step, before the box opens.
+func TestSessionRenameIsRefusedWithAReason(t *testing.T) {
+	uri := "file:///tmp/main.ar"
+	replies := runSession(t,
+		didOpen(uri, "ident total = 1;\nprintd total;\n"),
+		request(10, "textDocument/prepareRename", map[string]any{
+			"textDocument": map[string]any{"uri": uri},
+			"position":     map[string]any{"line": 1, "character": 8},
+		}),
+		exitMessage,
+	)
+
+	if len(replies) != 2 {
+		t.Fatalf("expected diagnostics plus the refusal, got %d: %v", len(replies), replies)
+	}
+	failure, refused := replies[1]["error"].(map[string]any)
+	if !refused {
+		t.Fatalf("answered %v, want a refusal", replies[1])
+	}
+	if !strings.Contains(fmt.Sprint(failure["message"]), "another file may be importing it") {
+		t.Errorf("said %v, want it to say why", failure["message"])
+	}
+}

--- a/cmd/aurorals/textdoc.go
+++ b/cmd/aurorals/textdoc.go
@@ -129,6 +129,48 @@ func uriOf(path string) lsp.URI {
 	return lsp.URI("file://" + filepath.ToSlash(absolute))
 }
 
+// prepareRename answers the range about to be renamed, or the reason it cannot be.
+//
+// The reason travels as an error because that is what a client shows: a rename box that opens
+// and then fails is worse than one that never opens.
+func (sv server) prepareRename(l *log.Logger, s *state.State, contents []byte) any {
+	req, err := textdoc.ParsePrepareRenameRequest(contents)
+	if err != nil {
+		l.Println(err)
+		return nil
+	}
+
+	uri := req.Params.TextDocument.URI
+	at, err := sv.textdoc.PrepareRename(document(uri, s.GetDocument(string(uri))), req.Params.Position)
+	if err != nil {
+		return lsp.NewFailedResponse(req.ID, err.Error())
+	}
+	return textdoc.NewPrepareRenameResponse(req.ID, at)
+}
+
+// rename answers every edit the change is made of, in the one file it touches.
+func (sv server) rename(l *log.Logger, s *state.State, contents []byte) any {
+	req, err := textdoc.ParseRenameRequest(contents)
+	if err != nil {
+		l.Println(err)
+		return nil
+	}
+
+	uri := req.Params.TextDocument.URI
+	found, err := sv.textdoc.RenameFor(document(uri, s.GetDocument(string(uri))), req.Params.Position, req.Params.NewName)
+	if err != nil {
+		return lsp.NewFailedResponse(req.ID, err.Error())
+	}
+
+	edits := make([]textdoc.TextEdit, 0, len(found.Ranges))
+	for _, at := range found.Ranges {
+		edits = append(edits, textdoc.TextEdit{Range: at, NewText: req.Params.NewName})
+	}
+	return textdoc.NewRenameResponse(req.ID, textdoc.WorkspaceEdit{
+		Changes: map[lsp.URI][]textdoc.TextEdit{uriOf(found.Filename): edits},
+	})
+}
+
 func (sv server) semanticTokens(l *log.Logger, s *state.State, contents []byte) any {
 	req, err := textdoc.ParseSemanticTokensRequest(contents)
 	if err != nil {

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -13,6 +13,7 @@
 | **Hover** | `textDocument/hover` | The description of the keyword under the cursor, what an identifier was bound to, a shape's fields, or which tape a field reads |
 | **Completion** | `textDocument/completion` | Keywords as snippets, the identifiers and shapes declared in the document, and — right after a `.` — the fields of a shape or what a module offers |
 | **Go to definition** | `textDocument/definition` | Where the name under the cursor was declared, in this file or in the module it came from |
+| **Rename** | `textDocument/rename`, `textDocument/prepareRename` | A name changed everywhere it is written — for the names that cannot leave the file |
 
 Document sync is **full** (`textDocumentSync: 1`): the client resends the whole file on each change.
 
@@ -94,13 +95,46 @@ A module that is not there, and a name a module does not have, are jumps that do
 The diagnostic already says what is wrong, and an editor that opens nothing is better than one
 that opens the wrong file.
 
+### Rename
+
+A name is changed everywhere it is written, in one pass, and the editor is handed every edit
+at once.
+
+It refuses more than it accepts, and that is deliberate. An editor that offers a rename it
+cannot finish is worse than one that offers none: the half that was renamed compiles, the half
+that was not is in somebody else's file, and nothing on screen says which is which.
+
+| Under the cursor | |
+|---|---|
+| a name bound inside a scope | renamed, everywhere that scope reads it |
+| an alias | renamed, in the `use` line and every reach through it |
+| a name bound at the top of a file | **refused** — another file may be importing it |
+| a field | **refused** — it belongs to a shape, and a shape crosses |
+| a name of another module | **refused** — it is declared in a file this one does not own |
+
+The refusal carries its reason, and a client shows it. It arrives at `prepareRename`, before
+the box opens, for a client that asks — and again from the rename itself, for one that does
+not.
+
+A new name is checked before anything is rewritten. Whether it is a name at all is asked of
+the lexer, so a keyword, a number or two words are refused for the same reason the compiler
+would refuse them; and a shape's new name has to start with a capital letter.
+
+**Scopes are read as the language reads them.** A declaration is a name inside the block it
+was written in, and the block ends at its brace. A name written where two declarations reach
+it means the deeper one, and where one block declares it twice, the one above it. Where there
+is none above, the one below answers: a deferred scope runs when it is called, so its body may
+name something written under it.
+
 **Scope:** the server lexes and parses the open document and the files it imports, and never evaluates. The imported files arrive through a port the host fills in — the command line reads a disk, the playground reads a map it already holds, since a browser has no files — so the same package answers wherever it is put. An imported file that is open in the editor is read as it is on screen, not as it is on disk: a name just typed resolves, and one just deleted stops resolving. See [modules.md](modules.md) for what a module is.
 
 **Known limitations**
 
 - The parser stops at the first error, so **one diagnostic per pass**. Fix it and the next one appears.
 - Go to definition lands on a declaration, never on every place a name is used: there is no
-  `textDocument/references`, and no rename that follows from it.
+  `textDocument/references`. Renaming knows those places, and shows them to nobody.
+- A rename stops at the file. What a module offers is refused rather than followed into the
+  files that import it, which is a walk of the project the server does not do yet.
 - Scope is read as the file is written, so a name declared inside a deferred scope and one
   declared at the top are told apart by which comes first, not by which is visible.
 - No code actions, no formatting, no incremental sync.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -86,9 +86,13 @@ What it does not do yet:
   it came from. What it does not do is watch a file nobody has open, so editing a module
   outside the editor updates what depends on it only when that file is touched. It does not
   need the resolver; it needs a capability the server does not have.
-- **A jump lands on a declaration and nothing else.** There is no
-  `textDocument/references` — every place a name is used — and so no rename either, which is
-  the same walk with an edit at the end of it.
+- **A rename stops at the file it is asked in.** A name bound inside a scope and an alias are
+  renamed everywhere they are written; a name bound at the top of a file is refused, with the
+  reason, because another file may be importing it. Completing those needs the walk that is
+  missing: which files of a project import this module, and under which alias. Nothing walks
+  a project today — the resolver reads what a file names, never who names it.
+- **Nothing lists where a name is used.** There is no `textDocument/references`. Renaming
+  works the list out and shows it to nobody, which is the whole of what is missing.
 - **Nothing measures what following an import costs.** Every pass reads and parses every
   module the document imports, with no cache, which is the honest place to start: a cache has
   invalidation, and invalidation is a bug that reads as the editor lying. The shape to copy

--- a/hosting/lsp/initialize/initialize.go
+++ b/hosting/lsp/initialize/initialize.go
@@ -69,6 +69,9 @@ func NewResponse(id int) InitializeResponse {
 				// Where a name was declared. Every name in Aurora is declared in the file
 				// that uses it or in a module it named, so the answer is always one place.
 				DefinitionProvider: true,
+				// Renaming a name everywhere it is written, with the prepare step: a client
+				// that asks first hears the refusal before it asks for a new name.
+				RenameProvider: &lsp.RenameOptions{PrepareProvider: true},
 				// The dot is declared as a trigger so a client asks for completion the
 				// moment someone types it — which is when the fields of a shape are
 				// what they want, and the only moment the document does not parse.

--- a/hosting/lsp/initialize/initialize_test.go
+++ b/hosting/lsp/initialize/initialize_test.go
@@ -75,6 +75,17 @@ func TestNewResponse(t *testing.T) {
 	if len(capabilities.SemanticTokensProvider.Legend.TokenTypes) == 0 {
 		t.Error("the legend cannot be empty, or the client has no names for the tokens")
 	}
+	if !capabilities.DefinitionProvider {
+		t.Error("go to definition should be advertised")
+	}
+	// A capability nobody announces is a feature nobody can use: the client decides what to
+	// ask for from this list alone.
+	if capabilities.RenameProvider == nil {
+		t.Fatal("rename should be advertised")
+	}
+	if !capabilities.RenameProvider.PrepareProvider {
+		t.Error("the server answers prepareRename, which is where a refusal is heard first")
+	}
 }
 
 // A client reads this as JSON, so the shape on the wire is what matters.

--- a/hosting/lsp/message.go
+++ b/hosting/lsp/message.go
@@ -12,6 +12,11 @@ const (
 // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#responseMessage
 const CodeMethodNotFound = -32601
 
+// CodeRequestFailed is a request the server understood and could not carry out. The message
+// is shown to whoever asked, so it is written for them.
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#errorCodes
+const CodeRequestFailed = -32803
+
 type URI string
 
 type Request struct {
@@ -54,6 +59,14 @@ func NewMethodNotFoundResponse(id int, method string) ErrorResponse {
 	}
 }
 
+// NewFailedResponse answers a request the server understood and refused, with the reason.
+func NewFailedResponse(id int, reason string) ErrorResponse {
+	return ErrorResponse{
+		Response: Response{RPC: "2.0", ID: &id},
+		Error:    ResponseError{Code: CodeRequestFailed, Message: reason},
+	}
+}
+
 func NewNullResponse(id *int) NullResponse {
 	return NullResponse{Response: Response{RPC: "2.0", ID: id}, Result: nil}
 }
@@ -80,8 +93,16 @@ type ServerCapabilities struct {
 	TextDocumentSync       int                    `json:"textDocumentSync"`
 	HoverProvider          bool                   `json:"hoverProvider"`
 	DefinitionProvider     bool                   `json:"definitionProvider"`
+	RenameProvider         *RenameOptions         `json:"renameProvider,omitempty"`
 	CompletionProvider     map[string]any         `json:"completionProvider"`
 	SemanticTokensProvider *SemanticTokensOptions `json:"semanticTokensProvider,omitempty"`
+}
+
+// RenameOptions says the server answers textDocument/prepareRename as well, which is what
+// lets a client ask whether a name can be renamed before it asks for a new one.
+// https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#renameOptions
+type RenameOptions struct {
+	PrepareProvider bool `json:"prepareProvider"`
 }
 
 type ServerInfo struct {

--- a/hosting/lsp/textdoc/rename.go
+++ b/hosting/lsp/textdoc/rename.go
@@ -1,0 +1,180 @@
+package textdoc
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// Renaming a name everywhere it is written.
+//
+// It is the one thing here that writes rather than answers, which is why it refuses more than
+// it accepts. An editor that offers a rename it cannot finish is worse than one that offers
+// none: the half that was renamed compiles, the half that was not is somebody else's file,
+// and nothing on screen says which is which.
+
+// ErrNotRenameable is what a refusal is, so a host can tell it from a failure. The message
+// says which name and why, and it is written for whoever is holding the cursor.
+var ErrNotRenameable = errors.New("not renameable")
+
+type RenameParams struct {
+	PositionParams
+	NewName string `json:"newName"`
+}
+
+type RenameRequest struct {
+	lsp.Request
+	Params RenameParams `json:"params"`
+}
+
+type RenameResponse struct {
+	lsp.Response
+	Result WorkspaceEdit `json:"result"`
+}
+
+// PrepareRenameRequest is what a client asks before it opens the box: which range is about to
+// be renamed, and whether it can be at all.
+type PrepareRenameRequest struct {
+	lsp.Request
+	Params PositionParams `json:"params"`
+}
+
+type PrepareRenameResponse struct {
+	lsp.Response
+	Result lsp.Range `json:"result"`
+}
+
+func ParseRenameRequest(contents []byte) (*RenameRequest, error) {
+	var req RenameRequest
+	if err := json.Unmarshal(contents, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func ParsePrepareRenameRequest(contents []byte) (*PrepareRenameRequest, error) {
+	var req PrepareRenameRequest
+	if err := json.Unmarshal(contents, &req); err != nil {
+		return nil, err
+	}
+	return &req, nil
+}
+
+func NewRenameResponse(id int, edit WorkspaceEdit) RenameResponse {
+	return RenameResponse{Response: lsp.Response{RPC: "2.0", ID: &id}, Result: edit}
+}
+
+func NewPrepareRenameResponse(id int, at lsp.Range) PrepareRenameResponse {
+	return PrepareRenameResponse{Response: lsp.Response{RPC: "2.0", ID: &id}, Result: at}
+}
+
+// A Rename is every place one name is written, in the file that writes it.
+type Rename struct {
+	Filename string
+	// Ranges holds the declaration and every use of it, in the order they are written.
+	Ranges []lsp.Range
+}
+
+// PrepareRename answers the range of the name under the cursor, and the reason when it is a
+// name that cannot be renamed. It is asked before the editor opens its box, so the refusal
+// arrives before somebody types a new name rather than after.
+func (s *Session) PrepareRename(doc Document, pos lsp.Position) (lsp.Range, error) {
+	analysis := s.Analyze(doc)
+	subject, _, err := s.renameable(analysis, pos)
+	if err != nil {
+		return lsp.Range{}, err
+	}
+	return rangeOf(analysis.Mapper, subject), nil
+}
+
+// RenameFor answers every place the name under the cursor is written, so the editor can
+// change all of them at once, and the reason when it must not.
+func (s *Session) RenameFor(doc Document, pos lsp.Position, newName string) (Rename, error) {
+	analysis := s.Analyze(doc)
+	subject, table, err := s.renameable(analysis, pos)
+	if err != nil {
+		return Rename{}, err
+	}
+	declaration := declarationOf(table, subject)
+	if err := s.nameable(analysis.Tokens, declaration, newName); err != nil {
+		return Rename{}, err
+	}
+
+	ranges := make([]lsp.Range, 0)
+	for _, tk := range analysis.Tokens {
+		if tk.GetCursor() != declaration.GetCursor() && !means(table, tk, declaration) {
+			continue
+		}
+		ranges = append(ranges, rangeOf(analysis.Mapper, tk))
+	}
+	return Rename{Filename: doc.Filename, Ranges: ranges}, nil
+}
+
+// renameable answers the name under the cursor and what the file's names mean, or the reason
+// this one is not something to rename.
+//
+// Both requests ask it, because a client that asks nothing first has to get the same answer
+// from the rename itself.
+func (s *Session) renameable(analysis *Analysis, pos lsp.Position) (token.Token, scopeTable, error) {
+	subject := analysis.TokenAt(pos)
+	if subject == nil || subject.GetTag().Id != token.ID {
+		return nil, scopeTable{}, fmt.Errorf("%w: there is no name here", ErrNotRenameable)
+	}
+
+	table := scopesOf(analysis.Tokens)
+	declaration := declarationOf(table, subject)
+	if declaration == nil {
+		return nil, scopeTable{}, fmt.Errorf("%w: %s is not declared in this file", ErrNotRenameable, subject.GetMatch())
+	}
+	// A name at the top of a file is what a module offers, and what a module offers another
+	// file may be reaching for by now. Renaming it here would be half of the change, and the
+	// half that is missing is in a file nobody has looked at.
+	if table.tops[declaration.GetCursor()] {
+		return nil, scopeTable{}, fmt.Errorf("%w: %s is bound at the top of this file, so another file may be importing it", ErrNotRenameable, subject.GetMatch())
+	}
+	return subject, table, nil
+}
+
+// nameable answers whether a new name is one the language would accept.
+//
+// Whether it is a name at all is asked of the lexer rather than of a rule written twice: a
+// keyword, a number, a space or a dot all come back as something other than one name. The
+// capital is asked here, because a shape's name has to start with one and the editor refusing
+// it now is better than the parser refusing it after every occurrence has been rewritten.
+func (s *Session) nameable(tokens []token.Token, declaration token.Token, newName string) error {
+	read, err := s.lexer.GetFilledTokens([]byte(newName))
+	if err != nil || len(read) != 2 || read[0].GetTag().Id != token.ID || read[1].GetTag().Id != token.EOF {
+		return fmt.Errorf("%w: %q is not a name", ErrNotRenameable, newName)
+	}
+	if i := indexOf(tokens, declaration); i > 0 && tokens[i-1].GetTag().Id == token.SHAPE && !capitalized(newName) {
+		return fmt.Errorf("%w: %s names a shape, and a shape's name starts with a capital letter", ErrNotRenameable, newName)
+	}
+	return nil
+}
+
+// capitalized says whether a name is written the way a shape's name has to be, which is the
+// parser's rule read here so the refusal arrives before the rewrite rather than after it.
+func capitalized(name string) bool {
+	first, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(first)
+}
+
+// declarationOf answers the declaration a name means, which is itself when the cursor is on
+// the declaration.
+func declarationOf(table scopeTable, subject token.Token) token.Token {
+	if _, declared := table.tops[subject.GetCursor()]; declared {
+		return subject
+	}
+	return table.means[subject.GetCursor()]
+}
+
+// means answers whether a token is a use of this declaration.
+func means(table scopeTable, tk, declaration token.Token) bool {
+	found, resolved := table.means[tk.GetCursor()]
+	return resolved && found.GetCursor() == declaration.GetCursor()
+}

--- a/hosting/lsp/textdoc/rename_test.go
+++ b/hosting/lsp/textdoc/rename_test.go
@@ -1,0 +1,234 @@
+package textdoc
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/hosting/lsp"
+)
+
+// applied is the document with the rename carried out, which is what the editor ends up
+// showing. Reading the result instead of the ranges is the only way to see the two mistakes
+// that matter: an occurrence left behind, and one taken that meant something else.
+func applied(t *testing.T, source string, ranges []lsp.Range, newName string) string {
+	t.Helper()
+
+	mapper := lsp.NewMapper(source)
+	out := source
+	// Backwards, so an edit does not move the ones not made yet.
+	for i := len(ranges) - 1; i >= 0; i-- {
+		start := mapper.Offset(ranges[i].Start)
+		end := mapper.Offset(ranges[i].End)
+		if start > end || end > len(out) {
+			t.Fatalf("range %+v is not inside the document", ranges[i])
+		}
+		out = out[:start] + newName + out[end:]
+	}
+	return out
+}
+
+// A name bound inside a scope, renamed everywhere it is written and nowhere else.
+func TestRenameInsideAScope(t *testing.T) {
+	const source = "ident area = defer {\n" +
+		"  ident side = feed(0);\n" +
+		"  side * side;\n" +
+		"};\n" +
+		"printd area(4);\n"
+
+	got, err := session().RenameFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 3}, "edge")
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+	if len(got.Ranges) != 3 {
+		t.Fatalf("found %d places, want the declaration and its two readings: %+v", len(got.Ranges), got.Ranges)
+	}
+
+	want := "ident area = defer {\n" +
+		"  ident edge = feed(0);\n" +
+		"  edge * edge;\n" +
+		"};\n" +
+		"printd area(4);\n"
+	if out := applied(t, source, got.Ranges, "edge"); out != want {
+		t.Errorf("renaming gives:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+// The same name in two scopes is two names. Renaming one leaves the other alone, which is
+// the mistake a search-and-replace makes and a scope walk does not.
+func TestRenameTakesOnlyItsOwnScope(t *testing.T) {
+	const source = "ident outer = defer {\n" +
+		"  ident n = 1;\n" +
+		"  n;\n" +
+		"};\n" +
+		"ident other = defer {\n" +
+		"  ident n = 2;\n" +
+		"  n + n;\n" +
+		"};\n"
+
+	got, err := session().RenameFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 5, Character: 8}, "count")
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+
+	out := applied(t, source, got.Ranges, "count")
+	if !strings.Contains(out, "ident count = 2;\n  count + count;") {
+		t.Errorf("the second scope was not renamed:\n%s", out)
+	}
+	if !strings.Contains(out, "ident n = 1;\n  n;") {
+		t.Errorf("the first scope was renamed too:\n%s", out)
+	}
+}
+
+// An alias belongs to the file that wrote it and to no other, so it is the one name that can
+// always be renamed — the use line and every reach through it.
+func TestRenameAnAlias(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "ident area = defer { feed(0); };\n"})
+	const source = "use geometry as g;\nprintd g.area(2);\nprintd g.area(3);\n"
+
+	got, err := session.RenameFor(Document{Filename: "src/main.ar", Source: source}, lsp.Position{Line: 1, Character: 7}, "geo")
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+
+	want := "use geometry as geo;\nprintd geo.area(2);\nprintd geo.area(3);\n"
+	if out := applied(t, source, got.Ranges, "geo"); out != want {
+		t.Errorf("renaming gives:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+// The path of a use line is a module's name, not this file's, so nothing in it is renamed by
+// asking about the alias — and asking about the path itself is refused.
+func TestRenameDoesNotTouchTheModulePath(t *testing.T) {
+	session := withModuleFiles(map[string]string{"src/geometry.ar": "ident area = defer { feed(0); };\n"})
+	doc := Document{Filename: "src/main.ar", Source: "use geometry as g;\nprintd g.area(2);\n"}
+
+	if _, err := session.RenameFor(doc, lsp.Position{Line: 0, Character: 6}, "shapes"); !errors.Is(err, ErrNotRenameable) {
+		t.Errorf("renaming the module path answered %v, want a refusal", err)
+	}
+	if _, err := session.RenameFor(doc, lsp.Position{Line: 1, Character: 11}, "surface"); !errors.Is(err, ErrNotRenameable) {
+		t.Errorf("renaming a name of another module answered %v, want a refusal", err)
+	}
+}
+
+// What a file offers, another file may already be reaching for. Renaming it here would be
+// half of the change, and the half that is missing is in a file nobody has looked at.
+func TestRenameRefusesWhatLeavesTheFile(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		at     lsp.Position
+		says   string
+	}{
+		{
+			name:   "a value bound at the top",
+			source: "ident total = 1;\nprintd total;\n",
+			at:     lsp.Position{Line: 1, Character: 8},
+			says:   "top of this file",
+		},
+		{
+			name:   "a shape declared at the top",
+			source: "shape Point { x, y };\nprintd Point{1, 2};\n",
+			at:     lsp.Position{Line: 1, Character: 8},
+			says:   "top of this file",
+		},
+		{
+			name:   "a field, which belongs to a shape",
+			source: "shape Point { x, y };\nident p = Point{1, 2};\nprintd p.y;\n",
+			at:     lsp.Position{Line: 2, Character: 9},
+			says:   "not declared in this file",
+		},
+		{
+			name:   "something that is not a name",
+			source: "printd 42;\n",
+			at:     lsp.Position{Line: 0, Character: 8},
+			says:   "no name here",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := session().RenameFor(Document{Filename: "main.ar", Source: tc.source}, tc.at, "other")
+			if !errors.Is(err, ErrNotRenameable) {
+				t.Fatalf("answered %v, want a refusal", err)
+			}
+			if !strings.Contains(err.Error(), tc.says) {
+				t.Errorf("said %q, want it to say %q", err, tc.says)
+			}
+		})
+	}
+}
+
+// A new name the language would refuse is refused here, before every occurrence is rewritten
+// and the file stops compiling.
+func TestRenameRefusesANameTheLanguageWouldNot(t *testing.T) {
+	const source = "ident area = defer {\n  ident side = feed(0);\n  side;\n};\n"
+
+	for _, newName := range []string{"defer", "2", "two words", "a.b", ""} {
+		if _, err := session().RenameFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 3}, newName); !errors.Is(err, ErrNotRenameable) {
+			t.Errorf("renaming to %q answered %v, want a refusal", newName, err)
+		}
+	}
+}
+
+// The editor asks before it opens its box, so the refusal arrives before somebody types.
+func TestPrepareRename(t *testing.T) {
+	const source = "ident area = defer {\n  ident side = feed(0);\n  side;\n};\n"
+	doc := Document{Filename: "main.ar", Source: source}
+
+	at, err := session().PrepareRename(doc, lsp.Position{Line: 2, Character: 3})
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+	if at != lsp.LineRange(2, 2, 6) {
+		t.Errorf("points at %+v, want the name under the cursor", at)
+	}
+
+	if _, err := session().PrepareRename(doc, lsp.Position{Line: 0, Character: 8}); !errors.Is(err, ErrNotRenameable) {
+		t.Errorf("preparing a name that leaves the file answered %v, want a refusal", err)
+	}
+}
+
+// A scope ends at its brace. A name declared inside one shadows the file's while it is open
+// and gives it back afterwards, so renaming the inner one leaves the readings under the
+// block alone.
+func TestRenameStopsAtTheEndOfTheScope(t *testing.T) {
+	const source = "ident n = 1;\n" +
+		"ident f = defer {\n" +
+		"  ident n = 2;\n" +
+		"  n * n;\n" +
+		"};\n" +
+		"printd n;\n"
+
+	got, err := session().RenameFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 8}, "inner")
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+
+	want := "ident n = 1;\n" +
+		"ident f = defer {\n" +
+		"  ident inner = 2;\n" +
+		"  inner * inner;\n" +
+		"};\n" +
+		"printd n;\n"
+	if out := applied(t, source, got.Ranges, "inner"); out != want {
+		t.Errorf("renaming gives:\n%s\nwant:\n%s", out, want)
+	}
+}
+
+// A deferred scope runs when it is called, so its body may name something written under it.
+// That reading is part of the rename, and leaving it behind would stop the file compiling.
+func TestRenameTakesAReadingWrittenAboveTheBinding(t *testing.T) {
+	const source = "ident outer = defer {\n" +
+		"  ident show = defer { later; };\n" +
+		"  ident later = 5;\n" +
+		"  show();\n" +
+		"};\n"
+
+	got, err := session().RenameFor(Document{Filename: "main.ar", Source: source}, lsp.Position{Line: 2, Character: 8}, "afterwards")
+	if err != nil {
+		t.Fatalf("refused: %v", err)
+	}
+	out := applied(t, source, got.Ranges, "afterwards")
+	if strings.Contains(out, "later") {
+		t.Errorf("a reading was left behind:\n%s", out)
+	}
+}

--- a/hosting/lsp/textdoc/scopes.go
+++ b/hosting/lsp/textdoc/scopes.go
@@ -1,0 +1,175 @@
+package textdoc
+
+import "github.com/guiferpa/aurora/wire/token"
+
+// Which declaration each name written in a file means.
+//
+// Go to definition asks this of one name and takes the nearest answer. Renaming asks it of
+// every name at once and cannot approximate: an occurrence left behind is a program that
+// stops compiling, and an occurrence taken by mistake is one that compiles and does the wrong
+// thing. So the scopes are read as the language reads them.
+
+// A scopeTable is every name a file writes, resolved: the declaration each occurrence means,
+// and which declarations sit at the top of the file, where another file could reach them.
+type scopeTable struct {
+	// means is the cursor of an occurrence -> the token that declares it. A name nothing
+	// declares is absent, which is the same answer a name of another file gets.
+	means map[int]token.Token
+	// tops is the cursor of a declaration -> whether another file could be writing it too.
+	tops map[int]bool
+}
+
+// A binding is one name declared, and the stretch of the file it is a name in: the block it
+// was written in, from its opening brace to its closing one, or the whole file.
+type binding struct {
+	name        string
+	declaration token.Token
+	at          int // where the declaration is written, as a token index
+	from, to    int // the scope it belongs to, as token indexes
+}
+
+// scopesOf answers what every name written in a file means.
+func scopesOf(tokens []token.Token) scopeTable {
+	bindings := bindingsOf(tokens)
+	table := scopeTable{means: make(map[int]token.Token), tops: make(map[int]bool)}
+
+	for _, b := range bindings {
+		// An alias is written at the top of a file and reaches no further than it: it names
+		// a module for this file alone, and no other file can write it.
+		_, alias := aliasOfUse(tokens, b.declaration)
+		table.tops[b.declaration.GetCursor()] = b.from == 0 && b.to == len(tokens) && !alias
+	}
+
+	for i, tk := range tokens {
+		if tk.GetTag().Id != token.ID || !occurrence(tokens, i) {
+			continue
+		}
+		if found := meaning(bindings, string(tk.GetMatch()), i); found != nil {
+			table.means[tk.GetCursor()] = found
+		}
+	}
+	return table
+}
+
+// bindingsOf reads every declaration a file makes, with the scope each one is a name in.
+//
+// The scope is the block it was written in rather than everything after it, because that is
+// what the language does: a name declared inside a block is gone at its closing brace. A
+// block left open by somebody still typing runs to the end of the file, which is what it will
+// mean once they close it.
+func bindingsOf(tokens []token.Token) []binding {
+	found := make([]binding, 0)
+	blocks := make([]int, 0) // the braces open right now, as token indexes
+	closes := make(map[int]int)
+	inside := make([]int, 0) // for each binding, the brace it was written inside, or -1
+
+	for i, tk := range tokens {
+		switch tk.GetTag().Id {
+		case token.O_CUR_BRK:
+			blocks = append(blocks, i)
+		case token.C_CUR_BRK:
+			if len(blocks) > 0 {
+				closes[blocks[len(blocks)-1]] = i
+				blocks = blocks[:len(blocks)-1]
+			}
+		case token.ID:
+			if !declaredHere(tokens, i) {
+				continue
+			}
+			block := -1
+			if len(blocks) > 0 {
+				block = blocks[len(blocks)-1]
+			}
+			found = append(found, binding{name: string(tk.GetMatch()), declaration: tk, at: i})
+			inside = append(inside, block)
+		}
+	}
+
+	for k, block := range inside {
+		if block < 0 {
+			found[k].from, found[k].to = 0, len(tokens)
+			continue
+		}
+		found[k].from = block
+		if closing, closed := closes[block]; closed {
+			found[k].to = closing
+		} else {
+			found[k].to = len(tokens)
+		}
+	}
+	return found
+}
+
+// meaning answers which declaration a name written at i means: the innermost scope that holds
+// both, and inside one scope the nearest declaration above it.
+//
+// Above it, because a name bound twice in the same scope is two names and the second shadows
+// the first from where it is written. When there is none above, the one below answers: a
+// deferred scope runs when it is called, so its body may name something written under it.
+func meaning(bindings []binding, name string, at int) token.Token {
+	var chosen *binding
+	for i := range bindings {
+		b := &bindings[i]
+		if b.name != name || at < b.from || at > b.to {
+			continue
+		}
+		if chosen == nil || closer(b, chosen, at) {
+			chosen = b
+		}
+	}
+	if chosen == nil {
+		return nil
+	}
+	return chosen.declaration
+}
+
+// closer answers whether one binding is the one a name at this point means, against another
+// that also holds it: the deeper scope first, then the declaration above rather than below,
+// then the nearest of the two.
+func closer(candidate, chosen *binding, at int) bool {
+	if candidate.from != chosen.from {
+		return candidate.from > chosen.from
+	}
+	if (candidate.at <= at) != (chosen.at <= at) {
+		return candidate.at <= at
+	}
+	if candidate.at <= at {
+		return candidate.at > chosen.at
+	}
+	return candidate.at < chosen.at
+}
+
+// declaredHere answers whether the name at i is being declared rather than used: `ident x`,
+// `shape Point`, and the alias of a use line.
+//
+// `as` is the alias only inside a use line — everywhere else it claims a shape, and the name
+// after it is one being used.
+func declaredHere(tokens []token.Token, i int) bool {
+	if i == 0 {
+		return false
+	}
+	switch tokens[i-1].GetTag().Id {
+	case token.IDENT, token.SHAPE:
+		return true
+	case token.AS:
+		_, inUse := aliasOfUse(tokens, tokens[i])
+		return inUse
+	}
+	return false
+}
+
+// occurrence answers whether the name at i is one this file declares somewhere.
+//
+// Three names are written that are not: a field, which belongs to a shape rather than to a
+// scope; a name reached through an alias, which belongs to another file; and the path of a
+// use line, which names a module and not a value.
+func occurrence(tokens []token.Token, i int) bool {
+	if i > 0 && tokens[i-1].GetTag().Id == token.DOT {
+		return false
+	}
+	if insideShapeDeclaration(tokens, i) {
+		return false
+	}
+	_, inUse := aliasOfUse(tokens, tokens[i])
+	return !inUse
+}


### PR DESCRIPTION
`textDocument/rename` e `textDocument/prepareRename`. Primeiro dos dois PRs que a gente combinou: renomeia por completo dentro do arquivo, e **recusa com o motivo** o nome que pode sair dele.

## O que ele aceita e o que recusa

| Sob o cursor | |
|---|---|
| um nome ligado dentro de um escopo | renomeado, em todo lugar que aquele escopo lê |
| um alias | renomeado, na linha `use` e em toda passagem por ele |
| um nome ligado no topo do arquivo | **recusado** — outro arquivo pode estar importando |
| um campo | **recusado** — pertence a uma shape, e shape atravessa |
| um nome de outro módulo | **recusado** — é declarado num arquivo que este aqui não possui |

A recusa carrega o motivo e o cliente mostra. Ela chega no `prepareRename`, **antes** da caixa abrir, para quem pergunta — e de novo do próprio rename, para quem não pergunta.

## O coração: qual declaração cada nome quer dizer

Go to definition pergunta isso de **um** nome e aceita a resposta mais próxima. Rename pergunta de **todos** de uma vez e não pode aproximar: uma ocorrência deixada para trás é um programa que para de compilar, e uma ocorrência levada por engano é um que compila e faz a coisa errada.

Então os escopos passaram a ser lidos como a linguagem lê:

- uma declaração é um nome **dentro do bloco em que foi escrita**, da chave que abre à que fecha;
- onde duas declarações alcançam o mesmo nome, vale a mais funda;
- onde um bloco declara duas vezes, vale a **de cima** — a segunda sombreia a primeira dali para baixo;
- onde não tem nenhuma acima, vale a **de baixo**: um `defer` roda quando é chamado, então o corpo dele pode nomear algo escrito embaixo — e num rename essa leitura tem que mudar junto.
- um bloco que ninguém fechou ainda vai até o fim do arquivo, que é o que ele vai significar quando fechar.

Os testes leem **o documento com o rename aplicado**, não os ranges. As duas falhas que importam só aparecem assim: a ocorrência que ficou para trás e a que foi levada sem ser daquele nome.

## O nome novo é conferido antes de reescrever

Se é um nome, quem responde é o lexer, não uma regra escrita duas vezes: keyword, número, duas palavras, `a.b` — tudo volta como outra coisa que não um nome só. E o nome novo de uma shape tem que começar com maiúscula, que o parser recusaria **depois** de todas as ocorrências terem sido reescritas.

## De passagem

O teste de capabilities não conferia o `definitionProvider` (esqueci no #83). Agora confere os dois — uma capability que ninguém anuncia é uma funcionalidade que ninguém consegue usar.

## O próximo PR

O walk do projeto: quais arquivos importam este módulo e sob qual alias. É o que levanta a recusa do topo e leva a edição para os outros arquivos. Está anotado no roadmap junto com o que falta para chegar lá.

## Verificação

`make check` limpo, `make complexity` sem nada novo. Testes: escopo, sombreamento, leitura escrita acima da ligação, alias, as quatro recusas, os nomes novos inválidos, o `prepareRename`, mais dois testes de sessão de verdade em `cmd/aurorals` — um com os edits, outro com a recusa chegando como erro com a razão dentro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)