### PR TITLE
feat: what each instruction takes, and what it leaves

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,20 @@ The language proves itself in the **evaluator** and in the **REPL**, and the poi
 backend is that **the same program answers the same thing on a chain and off it** — Aurora
 exists to let an on-chain call be simulated off-chain.
 
-**The backend is on stand-by, and stays there.** The architecture it was waiting for has
-landed; what surfaced underneath is bigger than a slice. Binding a name inside a scope —
-`ident x = feed(0);` in a `defer` body — reverts on chain: the lowering hands a value to
-arithmetic and to a return and to nothing else, so the one an `ident` meant to store is
-dropped and its `MSTORE` finds an empty stack. The builder still counts that instruction as
-covered, so the binary comes out silent. Under it sits a second ceiling: memory offsets, jump
-targets and the runtime size are all written with `PUSH1`, and each truncates past 255 without
-a word. Neither is a bug with a patch behind it — both are designs — and opening them now
-would stop the language moving. **Do not start there.** When the turn comes, it is deliberate
-and it is discussed first.
+**The backend is open again, deliberately, and it is being walked in order.** The first of the
+two things the stand-by named is done: the lowering used to hand values to arithmetic and to a
+return and to nothing else, so a name bound inside a scope compiled to an `MSTORE` with
+nothing under it — the contract deployed, the call succeeded, and the answer came back empty.
+What each instruction takes and leaves is written down now, per opcode, and a value is put on
+the stack right before whoever takes it.
+
+The second is still standing: memory offsets, jump targets and the runtime size are written
+with `PUSH1` and truncate past 255. It is next, and `PUSH2` closes it for good — a deployed
+contract cannot pass 24,576 bytes, so two bytes cover every legal one.
+
+After it come `if` and then `call`, in that order, and both need the table the lowering now
+keeps: a jump is only writable when the stack is known where the code splits. **Anything else
+in `builder/evm` still waits its turn**, and the turn is discussed first.
 
 What the backend gained before stopping is the differential harness
 (`hosting/cli/evm_harness_test.go`) — the same source compiled, deployed to an EVM in memory,

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -68,7 +68,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 		return nil, cursor, false
 	}
 	body := b.insts[cursor+1 : end]
-	body = Lowering(body)
+	body = Lowering(body, b.tapeSize)
 
 	// Emit EVM bytecode for the defer body (OpBeginScope, ...exprs..., OpReturn).
 	code := bytes.NewBuffer(make([]byte, 0))
@@ -115,7 +115,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	}
 
 	if len(rootinsts) > 0 {
-		rootinsts = Lowering(rootinsts)
+		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
 		if _, err := WriteCode(root, b.identManager, rootinsts, b.tapeSize); err != nil {
 			return nil, err

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -5,111 +5,156 @@ import (
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
-func Lowering(insts []ir.Instruction) []ir.Instruction {
-	if len(insts) == 0 {
-		return insts
-	}
-	return ResolveOperandsOrder(insts)
-}
+// Putting the instructions of a scope in the order the stack needs.
+//
+// The IR names values: an instruction carries a label, and whoever uses that value names the
+// label instead of holding it. The EVM has no names — it has a stack, and an operand has to be
+// on top of it at the moment the instruction that eats it runs. This is where one becomes the
+// other.
+//
+// It used to be a pattern match: two operands and an operator in the middle, with a special
+// case for the one other instruction that takes a value. Everything else was emitted as it
+// came, which is why `ident x = feed(0);` inside a scope compiled to an MSTORE with nothing
+// under it — the value it was meant to store was never pushed, and the contract answered
+// nothing at all, quietly.
+//
+// So the shape is written down instead of guessed. Each instruction says what it takes and
+// whether it leaves anything, and the order falls out of that: an operand is emitted right
+// before whoever asked for it. A jump needs exactly this to be possible — it has to know what
+// is on the stack where the code splits.
 
-func IsOperand(op byte) bool {
-	switch op {
-	case ir.OpGetFeed, ir.OpSave, ir.OpLoad:
-		return true
-	default:
-		return false
-	}
-}
+// A field is where an instruction writes the label of a value it takes.
+type field int
 
-func IsAssociativeOperator(op byte) bool {
+const (
+	fieldLeft field = iota
+	fieldRight
+)
+
+// consumes answers the fields of an instruction that name values it takes, in the order those
+// values have to reach the stack.
+//
+// Subtraction and division read theirs the other way round: the EVM pops the left operand
+// first and computes `top - next`, so the right one is pushed first.
+func consumes(op byte) []field {
 	switch op {
+	case ir.OpAdd, ir.OpMultiply:
+		return []field{fieldLeft, fieldRight}
 	case ir.OpSubtract, ir.OpDivide:
-		return true
+		return []field{fieldRight, fieldLeft}
+	case ir.OpIdent, ir.OpReturn:
+		return []field{fieldRight}
 	default:
-		return false
+		return nil
 	}
 }
 
-// IsBinaryValueConsumer returns true for ops that consume two value operands (left/right) from the operand map.
-// Used so we only reorder for Add/Sub/Mul/Div; OpReturn, OpBeginScope, etc. are left as-is and not merged.
-func IsBinaryValueConsumer(op byte) bool {
+// produces answers whether an instruction leaves its value on the stack, under its own label.
+//
+// A binding does not: its value goes to memory and the stack comes out as it went in. That is
+// why it is not here, and why the one place a binding is read as a value — a scope whose last
+// expression is one — is handled where that is known.
+func produces(op byte) bool {
 	switch op {
-	case ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide:
+	case ir.OpSave, ir.OpGetFeed, ir.OpLoad, ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide:
 		return true
 	default:
 		return false
 	}
 }
 
-func OperandStackDelta(op byte) int {
-	if IsOperand(op) {
-		return 1
-	}
-	if IsAssociativeOperator(op) {
-		return -1
-	}
-	return 0
-}
-
-func GetOperandStackDeltaDepth(insts []ir.Instruction) []int {
-	depth := make([]int, len(insts)+1)
-	depth[0] = 0
-	for at, inst := range insts {
-		depth[at+1] = depth[at] + OperandStackDelta(inst.GetOpCode())
-	}
-	return depth
-}
-
-func ResolveOperandsOrder(insts []ir.Instruction) []ir.Instruction {
+// Lowering answers the instructions of one scope in the order the stack needs them.
+func Lowering(insts []ir.Instruction, tapeSize int) []ir.Instruction {
 	if len(insts) < 2 {
 		return insts
 	}
-	operands := make(map[string][]ir.Instruction, 0)
-	out := make([]ir.Instruction, 0)
+	return ResolveOperandsOrder(insts, tapeSize)
+}
+
+// ResolveOperandsOrder emits every value right before whoever takes it.
+//
+// An instruction that leaves a value is held back under its label rather than emitted where it
+// was written: the code that produces it belongs next to the code that eats it. Holding it
+// back is safe because everything held back is pure — a constant, an argument, a read of
+// memory, or arithmetic over those — so moving it moves nothing observable.
+//
+// A value nobody takes has nowhere to be moved to, so it stays where it was written — that is
+// the last expression of a scope, which is the scope's answer.
+func ResolveOperandsOrder(insts []ir.Instruction, tapeSize int) []ir.Instruction {
+	taken := labelsTaken(insts)
+	pending := make(map[string][]ir.Instruction)
+	out := make([]ir.Instruction, 0, len(insts))
+
 	for _, inst := range insts {
-		if IsOperand(inst.GetOpCode()) {
-			label := byteutil.ToHex(inst.GetLabel())
-			operands[label] = []ir.Instruction{inst}
-			continue
+		op := inst.GetOpCode()
+
+		sequence := make([]ir.Instruction, 0, 3)
+		for _, where := range consumes(op) {
+			label := byteutil.ToHex(fieldOf(inst, where))
+			// A label with nothing under it is a value from outside this scope, or one
+			// already taken. Either way there is nothing to emit for it here.
+			if produced, held := pending[label]; held {
+				sequence = append(sequence, produced...)
+				delete(pending, label)
+			}
 		}
+		sequence = append(sequence, inst)
 
-		ll := byteutil.ToHex(inst.GetLeft())
-		lr := byteutil.ToHex(inst.GetRight())
-		ld := byteutil.ToHex(inst.GetLabel())
-
-		ol, okl := operands[ll]
-		or, okr := operands[lr]
-
-		if IsBinaryValueConsumer(inst.GetOpCode()) && okl && okr {
-			curb := make([]ir.Instruction, 0)
-
-			if IsAssociativeOperator(inst.GetOpCode()) {
-				curb = append(curb, or...)
-				curb = append(curb, ol...)
-			} else {
-				curb = append(curb, ol...)
-				curb = append(curb, or...)
-			}
-			curb = append(curb, inst)
-			operands[ld] = curb
-
-			delete(operands, ll)
-			delete(operands, lr)
-
-			out = curb
-		} else {
-			// OpReturn consumes one value (return value); emit it before Return only when not already in out.
-			// (After a binary op we set out = curb, so the result is already last in out; don't duplicate.)
-			if inst.GetOpCode() == ir.OpReturn && okr {
-				lastIsBinary := len(out) > 0 && IsBinaryValueConsumer(out[len(out)-1].GetOpCode())
-				if !lastIsBinary {
-					out = append(out, or...)
-				}
-				delete(operands, lr)
-			}
-			out = append(out, inst)
+		label := byteutil.ToHex(inst.GetLabel())
+		switch {
+		case produces(op) && taken[label] > 0:
+			pending[label] = sequence
+		case produces(op):
+			// Nobody takes it, so there is nowhere to move it to: it is the answer of the
+			// scope it was written in, and it stays where it was written.
+			out = append(out, sequence...)
+		case op == ir.OpIdent && taken[label] > 0:
+			// A scope whose last expression is a binding answers with the neutral value,
+			// which is what the evaluator answers. On the stack that has to be pushed: the
+			// binding itself left nothing there.
+			sequence = append(sequence, ir.NewInstruction(inst.GetLabel(), ir.OpSave, byteutil.FalseTape(tapeSize), nil))
+			pending[label] = sequence
+		default:
+			out = append(out, sequence...)
 		}
 	}
 
 	return out
+}
+
+// labelsTaken counts how many instructions ask for each value.
+func labelsTaken(insts []ir.Instruction) map[string]int {
+	taken := make(map[string]int)
+	for _, inst := range insts {
+		for _, where := range consumes(inst.GetOpCode()) {
+			taken[byteutil.ToHex(fieldOf(inst, where))]++
+		}
+	}
+	return taken
+}
+
+// fieldOf reads the label an instruction wrote in one of its fields.
+func fieldOf(inst ir.Instruction, where field) []byte {
+	if where == fieldLeft {
+		return inst.GetLeft()
+	}
+	return inst.GetRight()
+}
+
+// StackDepth answers how deep the stack is after each instruction of a lowered scope, starting
+// at zero.
+//
+// It is what says a scope is balanced, and it is what a jump will need: the two sides of a
+// branch have to meet with the same stack under them.
+func StackDepth(insts []ir.Instruction) []int {
+	depth := make([]int, len(insts)+1)
+	for at, inst := range insts {
+		op := inst.GetOpCode()
+		after := depth[at] - len(consumes(op))
+		if produces(op) {
+			after++
+		}
+		depth[at+1] = after
+	}
+	return depth
 }

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -12,33 +12,9 @@ import (
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
-func TestOperandStackDelta(t *testing.T) {
-	cases := []struct {
-		name string
-		op   byte
-		want int
-	}{
-		{name: "OpGetFeed_push", op: ir.OpGetFeed, want: 1},
-		{name: "OpSave_push", op: ir.OpSave, want: 1},
-		{name: "OpLoad_push", op: ir.OpLoad, want: 1},
-		{name: "OpSubtract_pop2_push1", op: ir.OpSubtract, want: -1},
-		{name: "OpDivide_pop2_push1", op: ir.OpDivide, want: -1},
-		{name: "OpBeginScope_neutral", op: ir.OpBeginScope, want: 0},
-		{name: "OpReturn_neutral", op: ir.OpReturn, want: 0},
-		{name: "OpIdent_neutral", op: ir.OpIdent, want: 0},
-		{name: "OpDefer_neutral", op: ir.OpDefer, want: 0},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			got := OperandStackDelta(tc.op)
-			if got != tc.want {
-				t.Errorf("OperandStackDelta(0x%02x) = %d, want %d", tc.op, got, tc.want)
-			}
-		})
-	}
-}
-
-func TestGetOperandStackDeltaDepth(t *testing.T) {
+// The depth after each instruction, which is what says a scope is balanced — and what the two
+// sides of a branch will have to agree on when there are branches.
+func TestStackDepth(t *testing.T) {
 	cases := []struct {
 		name  string
 		insts []ir.Instruction
@@ -50,89 +26,91 @@ func TestGetOperandStackDeltaDepth(t *testing.T) {
 			want:  []int{0},
 		},
 		{
-			name: "single_GetArg",
+			name: "one argument is one value",
 			insts: []ir.Instruction{
 				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
 			},
 			want: []int{0, 1},
 		},
 		{
-			name: "two_GetArg",
-			insts: []ir.Instruction{
-				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
-				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
-			},
-			want: []int{0, 1, 2},
-		},
-		{
-			name: "GetArg_GetArg_Add",
+			name: "two arguments and a sum leave one",
 			insts: []ir.Instruction{
 				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
 				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
 				ir.NewInstruction([]byte("2"), ir.OpAdd, []byte("0"), []byte("1")),
 			},
-			want: []int{0, 1, 2, 2},
-		},
-		{
-			name: "GetArg_GetArg_Sub",
-			insts: []ir.Instruction{
-				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
-				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
-				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
-			},
 			want: []int{0, 1, 2, 1},
 		},
 		{
-			name: "GetArg_GetArg_GetArg_Sub_Sub",
+			name: "a binding takes its value and leaves nothing",
 			insts: []ir.Instruction{
 				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
-				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
-				ir.NewInstruction([]byte("2"), ir.OpGetFeed, byteutil.FromUint64(2), nil),
-				ir.NewInstruction([]byte("3"), ir.OpSubtract, []byte("0"), []byte("1")),
-				ir.NewInstruction([]byte("4"), ir.OpSubtract, []byte("2"), []byte("3")),
+				ir.NewInstruction([]byte("1"), ir.OpIdent, []byte("side"), []byte("0")),
 			},
-			want: []int{0, 1, 2, 3, 2, 1},
+			want: []int{0, 1, 0},
 		},
 		{
-			name: "BeginScope_GetArg_GetArg_Sub_Return",
+			name: "a return takes the answer with it",
 			insts: []ir.Instruction{
-				ir.NewInstruction(nil, ir.OpBeginScope, nil, nil),
 				ir.NewInstruction([]byte("0"), ir.OpGetFeed, byteutil.FromUint64(0), nil),
-				ir.NewInstruction([]byte("1"), ir.OpGetFeed, byteutil.FromUint64(1), nil),
-				ir.NewInstruction([]byte("2"), ir.OpSubtract, []byte("0"), []byte("1")),
-				ir.NewInstruction(nil, ir.OpReturn, nil, nil),
+				ir.NewInstruction([]byte("1"), ir.OpReturn, nil, []byte("0")),
 			},
-			want: []int{0, 0, 1, 2, 1, 1},
+			want: []int{0, 1, 0},
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := GetOperandStackDeltaDepth(tc.insts)
-			if !reflect.DeepEqual(got, tc.want) {
-				t.Errorf("GetOperandStackDeltaDepth(...) = %v, want %v", got, tc.want)
+			if got := StackDepth(tc.insts); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("StackDepth(...) = %v, want %v", got, tc.want)
 			}
 		})
 	}
 }
 
-func TestIsAsociativeOperator(t *testing.T) {
+// What an instruction takes, and in which order it has to reach the stack. Subtraction and
+// division read theirs the other way round, which is the one case worth a table.
+func TestWhatAnInstructionTakes(t *testing.T) {
 	cases := []struct {
+		name string
+		op   byte
+		want []field
+	}{
+		{name: "a sum takes both, left first", op: ir.OpAdd, want: []field{fieldLeft, fieldRight}},
+		{name: "a subtraction takes them the other way round", op: ir.OpSubtract, want: []field{fieldRight, fieldLeft}},
+		{name: "a division too", op: ir.OpDivide, want: []field{fieldRight, fieldLeft}},
+		{name: "a binding takes the value it binds", op: ir.OpIdent, want: []field{fieldRight}},
+		{name: "a return takes what it answers with", op: ir.OpReturn, want: []field{fieldRight}},
+		{name: "an argument takes nothing", op: ir.OpGetFeed, want: nil},
+		{name: "opening a scope takes nothing", op: ir.OpBeginScope, want: nil},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := consumes(tc.op); !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("consumes(0x%02x) = %v, want %v", tc.op, got, tc.want)
+			}
+		})
+	}
+}
+
+// What is left on the stack afterwards. A binding is the one that surprises: it writes to
+// memory and the stack comes out as it went in.
+func TestWhatAnInstructionLeaves(t *testing.T) {
+	for _, tc := range []struct {
 		name string
 		op   byte
 		want bool
 	}{
-		{name: "Sub", op: ir.OpSubtract, want: true},
-		{name: "Div", op: ir.OpDivide, want: true},
-		{name: "Mul", op: ir.OpMultiply, want: false},
-		{name: "Add", op: ir.OpAdd, want: false},
-		{name: "GetArg", op: ir.OpGetFeed, want: false},
-		{name: "Return", op: ir.OpReturn, want: false},
-	}
-	for _, tc := range cases {
+		{name: "a constant", op: ir.OpSave, want: true},
+		{name: "an argument", op: ir.OpGetFeed, want: true},
+		{name: "a read of a name", op: ir.OpLoad, want: true},
+		{name: "a sum", op: ir.OpAdd, want: true},
+		{name: "a binding", op: ir.OpIdent, want: false},
+		{name: "a return", op: ir.OpReturn, want: false},
+		{name: "opening a scope", op: ir.OpBeginScope, want: false},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
-			got := IsAssociativeOperator(tc.op)
-			if got != tc.want {
-				t.Errorf("IsAssociativeOperator(0x%02x) = %v, want %v", tc.op, got, tc.want)
+			if got := produces(tc.op); got != tc.want {
+				t.Errorf("produces(0x%02x) = %v, want %v", tc.op, got, tc.want)
 			}
 		})
 	}
@@ -251,7 +229,7 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
-			got := ResolveOperandsOrder(insts)
+			got := ResolveOperandsOrder(insts, 0)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("\ngot =\n%v \nwant =\n%v", ir.Format(got), ir.Format(tc.want))
 			}
@@ -296,7 +274,7 @@ func TestLowering(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Lowering(tc.insts)
+			got := Lowering(tc.insts, 0)
 			if !reflect.DeepEqual(got, tc.want) {
 				t.Errorf("Lowering(%v) = %v, want %v", tc.insts, got, tc.want)
 			}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,7 +131,13 @@ using any of the following **compiles successfully and does nothing on chain**.
   On chain they are the only way a contract says anything, and they are the honest target for
   whatever Aurora ends up calling logging.
 - Jump targets and memory offsets are written with `PUSH1`, which caps a runtime at 256
-  bytes and identifiers at about seven memory slots. `PUSH2` lifts it.
+  bytes and identifiers at about seven memory slots. `PUSH2` lifts it, and lifts it far enough
+  to stop: a deployed contract cannot pass 24,576 bytes, so two bytes cover every legal one.
+- **A value is put on the stack right before whoever takes it**, which is what lets a binding
+  inside a scope work — it used to compile to an MSTORE with nothing under it, and the
+  contract answered empty. What each instruction takes and leaves is written down now, per
+  opcode, and that table is what a branch will read: the two sides of a jump have to meet with
+  the same stack under them.
 
 `aurora build` now **says what it could not carry**, once per feature, in the order the
 program uses it — so a binary that does less than the source said is at least announced. What

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -204,3 +204,43 @@ func TestArithmeticWrapsAtTheTapeWidthOnBothSides(t *testing.T) {
 		})
 	}
 }
+
+// A name bound inside a scope, which is what a body of more than one line is made of.
+//
+// It compiled before this and answered nothing: the lowering handed values to arithmetic and
+// to a return and to nothing else, so the one the binding meant to store was never pushed and
+// its MSTORE ran on an empty stack. The contract deployed, the call succeeded, and the answer
+// came back empty — which reads as zero, and reads as nothing being wrong.
+func TestALocalInsideAScopeAnswersTheSameOnChainAndOff(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		args   []string
+	}{
+		{
+			name:   "read twice",
+			source: "ident area = defer {\n  ident side = feed(0);\n  side * side;\n};",
+			args:   []string{"5"},
+		},
+		{
+			name:   "two of them, and one reads the other",
+			source: "ident total = defer {\n  ident base = feed(0) + feed(1);\n  ident twice = base * 2;\n  twice + base;\n};",
+			args:   []string{"3", "4"},
+		},
+		{
+			name:   "one that nothing reads",
+			source: "ident area = defer {\n  ident unused = feed(1);\n  feed(0) * feed(0);\n};",
+			args:   []string{"6", "9"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, functionOf(tc.source), tc.args, 0)
+		})
+	}
+}
+
+// functionOf reads the name of the first scope a source binds, which is the one these call.
+func functionOf(source string) string {
+	name := strings.TrimPrefix(source, "ident ")
+	return strings.TrimSpace(name[:strings.Index(name, "=")])
+}

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -18,7 +18,11 @@ Toda RFC abre dizendo em que estado está:
 | **implementada** | virou código; o arquivo sai daqui na sequência |
 | **recusada** | decidida contra, e o porquê fica registrado |
 
-**Nenhuma aberta no momento.**
+**Abertas:**
+
+| RFC | Estado | Sobre |
+|---|---|---|
+| [storage.md](storage.md) | proposta | o que sobrevive à chamada: `sload`/`sstore` e o módulo `storage` por cima |
 
 A última foi `crossing_shapes.md` — a forma de um struct atravessa módulo, e o nome dele é
 escrito como o do módulo. Foi implementada em dois pull requests, e o que ficou decidido está

--- a/rfcs/storage.md
+++ b/rfcs/storage.md
@@ -1,0 +1,230 @@
+# `storage` — o que sobrevive à chamada
+
+**Estado:** proposta · **Data:** 2026-08-20
+
+Um contrato que não guarda nada é uma calculadora. Esta RFC diz como um programa Aurora
+escreve e lê o que **persiste entre duas chamadas**, e é o que falta para o primeiro contrato
+de verdade.
+
+São duas camadas, e a divisão é o desenho inteiro:
+
+| camada | quem escreve | o que é |
+|---|---|---|
+| `sload` / `sstore` | só a biblioteca padrão | as palavras cruas: um slot, uma palavra |
+| módulo `storage` | qualquer programa | escopos com chave, escritos em Aurora sobre as duas palavras |
+
+Ela **não** trata de ambiente de processo (`os`), de quem chamou (`caller`), de evento nem de
+chamada a outro contrato. Cada um é a sua conversa.
+
+Tudo abaixo foi medido no código de hoje.
+
+> Os blocos aqui **não** estão marcados como `aurora`: `hosting/cli/docs_test.go` executa todo
+> bloco assim marcado no repositório, e nada disto compila ainda.
+
+---
+
+## Por que persistência é palavra-chave e memória não
+
+Memória a Aurora já usa, implicitamente: o emitter escreve os locais em offsets decididos na
+compilação, e ninguém pede nada. É rascunho — some no fim da chamada — e expor um offset
+arbitrário só daria ao programa a chance de corromper os próprios locais.
+
+Storage é a outra coisa. É o disco: sobrevive à chamada, custa caro (`SSTORE` de zero para
+não-zero são 20k de gas), e **nenhum programa consegue chegar nele por acidente**. Não há como
+o compilador adivinhar que este valor devia durar e aquele não. Quem decide é quem escreve, e
+por isso precisa de palavra.
+
+---
+
+## As duas palavras
+
+```
+_sload  -> SLOAD _prie
+_sstore -> SSTORE _prie _prie
+```
+
+Palavra e operandos, sem parênteses e sem vírgula, que é a forma que `pull`, `push`, `head` e
+`tail` já têm. **Operando primário e não expressão**, de propósito: `sload 0 + 1` lê como
+`(sload 0) + 1`, sem a ambiguidade que o `_pull -> PULL _expr _expr` tem hoje. O `_head` já
+restringe o operando dele pelo mesmo motivo, então há precedente.
+
+| | responde |
+|---|---|
+| `sload k` | a palavra guardada na chave `k`, e zero onde nada foi escrito |
+| `sstore k v` | `v`, o valor que acabou de escrever |
+
+> **Aberto:** `sstore` responder o valor **anterior** é mais útil e menos óbvio. Responder o
+> escrito é o que faz `sstore k (sload k + 1)` compor.
+
+**Só a biblioteca padrão escreve as duas.** É a regra de arquivo que já limita `assert` a
+`*.test.ar`, lida do `ParseInput`: um programa comum que escreve `sstore` é recusado, e a
+mensagem manda usar o módulo. O motivo não é gosto — é que um slot cru é um número mágico, e
+dois programas escolhendo o mesmo número em silêncio é o modo de falha que este projeto mais
+recusa.
+
+---
+
+## O módulo
+
+```
+use storage as s;
+
+ident balances = s.new(1);
+
+ident deposit = defer {
+  s.set(balances, feed(0), s.get(balances, feed(0)) + feed(1));
+};
+
+ident balance_of = defer { s.get(balances, feed(0)); };
+```
+
+| | responde |
+|---|---|
+| `new(id)` | um escopo: a base de onde as chaves dele saem |
+| `set(scope, key, value)` | o valor guardado |
+| `get(scope, key)` | o valor guardado nessa chave, ou zero |
+
+O corpo é Aurora comum, escrito sobre as duas palavras:
+
+```
+ident new = defer { feed(0); };
+ident set = defer { sstore (slot_of(feed(0), feed(1))) feed(2); };
+ident get = defer { sload (slot_of(feed(0), feed(1))); };
+```
+
+### `new` não escreve nada, e isso é a decisão principal
+
+A leitura natural de `new` é "aloque um escopo": leia um contador, incremente, devolva o
+próximo. **Isso está errado aqui**, e o motivo é quando o código roda.
+
+O topo de um arquivo Aurora roda a cada chamada, não no deploy. Um `new` que incrementasse um
+contador daria um escopo **diferente a cada transação** — os saldos de ontem ficariam num
+escopo que ninguém mais acha. Para funcionar, ele teria que rodar uma vez só, no construtor, e
+construtor com estado é uma máquina que não existe.
+
+Então `new` é **derivação pura**: um id entra, uma base sai, sem tocar em storage. Chamar duas
+vezes com o mesmo id dá o mesmo escopo, hoje e amanhã. O id é escolhido por quem escreve o
+programa, como o número do slot em Solidity é escolhido pela ordem de declaração.
+
+> **Aberto:** `new` passa a significar "nomeie um escopo", não "aloque um". `scope`, `at` ou
+> `open` dizem isso melhor. O nome foi pedido como `new`; fica registrado que ele mente um
+> pouco.
+
+### Como um escopo vira slot
+
+A EVM dá um espaço plano de 2²⁵⁶ chaves e **não hasheia nada** — a chave é o slot. O
+`keccak(chave . slot)` que se vê em contrato Solidity é escolha de layout dela, não regra da
+máquina.
+
+A Aurora não tem `KECCAK256` em runtime; o keccak que ela faz hoje é em build time, para o
+seletor do dispatcher. Então a derivação do beta é **aritmética**, e vem com uma fronteira
+escrita:
+
+| candidato | colide quando |
+|---|---|
+| `base + chave` | sempre que `b1 + k1 == b2 + k2` — barato e frouxo demais |
+| `base * 2¹²⁸ + chave` | quando a chave passa de 2¹²⁸, ou o escopo passa de 2¹²⁸ |
+
+A segunda é a proposta: com `tape_size` 32 ela é exata para toda chave de 16 bytes ou menos —
+o que inclui endereço, que tem 20... **não inclui.** Um endereço não cabe em 2¹²⁸, então a
+fronteira tem que ser escolhida sabendo que a chave típica é uma carteira.
+
+**Isso é o item mais aberto desta RFC**, e ele tem uma saída limpa: quando `KECCAK256` entrar,
+a derivação vira `keccak(escopo . chave)` e a fronteira some. O preço de trocar depois é que o
+layout muda — o que só afeta contrato já publicado, e no beta não há nenhum.
+
+---
+
+## Fora da chain
+
+Storage é **simulável**, e é por isso que ele é palavra-chave e o ambiente do processo não é.
+
+| | `sload` / `sstore` |
+|---|---|
+| na chain | `SLOAD` / `SSTORE` |
+| no evaluator | um mapa que o host segura, chave de tape para valor de tape |
+
+O evaluator não toca no mundo: o mapa chega por porta, como o print já chega.
+
+```go
+// A Store is what a program keeps between calls, and where it keeps it.
+type Store interface {
+	Load(key []byte) []byte
+	Save(key, value []byte) error
+}
+```
+
+| host | o que passa |
+|---|---|
+| `aurora run`, REPL | um mapa em memória, vazio a cada execução |
+| `aurora test` | um mapa por arquivo de teste |
+| playground | um mapa em memória |
+| harness diferencial | o mesmo programa nos dois lados, e as respostas comparadas |
+
+O `aurora run` começando com o mapa vazio é honesto: uma execução local não é uma chain com
+histórico, é uma simulação de **uma** chamada. Guardar isso em disco entre execuções é outra
+RFC, e provavelmente uma má ideia.
+
+---
+
+## O que falta compilar
+
+Medido: `WriteCode` cobre aritmética, `OpSave`, `OpIdent`, `OpLoad`, `OpGetFeed` e `OpReturn`.
+O resto compila e não faz nada na chain, em silêncio.
+
+Em ordem de dependência:
+
+| # | o que | quem precisa |
+|---|---|---|
+| 1 | **`ident` dentro de escopo** — hoje o valor é descartado e o `MSTORE` acha a pilha vazia; reverte | qualquer corpo com mais de uma linha |
+| 2 | **Largura de verdade** — offset, alvo de jump e tamanho do runtime são `PUSH1` e truncam em 255 | qualquer contrato com estado |
+| 3 | **`OpSLoad` / `OpSStore`** | esta RFC |
+| 4 | **`call`** — jump com endereço de retorno | **o módulo**: `s.get(...)` é uma chamada |
+| 5 | `if` e `assert` → `JUMPI` e `REVERT` | o cofre, não esta RFC |
+
+**1 e 2 são os dois do stand-by**, e continuam sendo desenho e não remendo. Um `sstore`
+compilado dentro de um corpo que reverte é um teste verde que mente.
+
+E **4 é o preço do módulo**: as duas palavras sozinhas compilam sem `call`; a superfície
+amigável não. Dá para entregar `sload`/`sstore` funcionando na chain antes do `storage`
+existir, e é o que eu faria.
+
+---
+
+## O que fica de fora
+
+- **`caller`**, evento, chamada a outro contrato, `msg.value`.
+- **Apagar** um slot: escrever zero é o que a EVM chama de apagar, e o reembolso de gas que
+  vem com isso não é assunto de linguagem.
+- **Iterar** um escopo. Um mapa esparso não se percorre; quem quer lista guarda o tamanho.
+- **Layout compatível com Solidity.** Um `cast storage` de fora não vai adivinhar onde as
+  coisas estão, e tudo bem — a compatibilidade que importa é a da ABI, que o dispatcher já dá.
+
+---
+
+## As etapas
+
+1. **`sload` e `sstore`** como palavras: nó, opcode, a regra de arquivo que as limita à
+   biblioteca, e o evaluator com a porta atrás delas.
+2. **Os dois do stand-by**, sem os quais nada disso roda na chain.
+3. **`OpSLoad` e `OpSStore` no backend**, e o primeiro contrato com estado no harness
+   diferencial: escreve, chama de novo, lê o que escreveu — dos dois lados.
+4. **`call` no backend**, e então o módulo `storage` embutido (`shared/stdlib`, `//go:embed`,
+   o gancho `Builtin` no resolver, e a recusa de um `src/storage.ar` do projeto sombrear o
+   embutido).
+
+Ordem de grandeza: 1 é pequena e fechada. 2 é a conversa que está parada desde o stand-by. 3 é
+onde o beta aparece. 4 é o açúcar, e pode esperar.
+
+---
+
+## Em aberto
+
+1. **A derivação do slot** e a fronteira dela, que hoje não cobre um endereço.
+2. **`sstore` responde o escrito ou o anterior.**
+3. **`new` mente**: ele nomeia um escopo, não aloca um.
+4. **Chave menor que uma palavra**: estender a tape para 32 bytes é o que a aritmética já faz,
+   mas dois projetos de larguras diferentes escrevem no mesmo slot com chaves diferentes.
+5. **`sload` de um slot nunca escrito responde zero**, que é o que a EVM faz — e a Aurora não
+   tem valor nenhum, então zero é a única resposta possível. Vale escrever que é uma escolha
+   herdada, não desenhada.


### PR DESCRIPTION
O primeiro dos dois itens do stand-by. **A inteiro**, como combinado, e com o probe que você aprovou.

## O que o probe mostrou

Rodei os dois casos antes de escrever qualquer coisa:

```
ident area = defer { ident side = feed(0); side * side; };   → chain 0, evaluator 25
ident f    = defer { feed(0) + 1; feed(0) + 2; };            → passa
```

Ou seja: **a minha suspeita do `out = curb` estava errada** — duas expressões funcionam. E o caso do local é pior do que o stand-by descrevia: ele **não reverte**, ele responde vazio. O contrato faz deploy, a chamada tem sucesso, e a resposta volta zero. A falha mais silenciosa das duas.

## O modelo

O lowering era um casador de padrão: dois operandos com um operador no meio, mais um caso especial para a única outra instrução que consome valor. O resto era emitido como vinha — e por isso o `MSTORE` do `ident` chegava numa pilha vazia.

Agora a forma está escrita, por opcode:

- **`consumes(op)`** — quais campos nomeiam valores que ele toma, **na ordem em que precisam chegar na pilha**. Subtração e divisão leem ao contrário, porque a EVM tira o operando da esquerda primeiro.
- **`produces(op)`** — se ele deixa um valor.

A emissão cai disso: o valor entra na pilha imediatamente antes de quem o toma, e um valor que ninguém toma fica onde foi escrito — porque ele é a resposta do escopo.

**O binding é o caso que paga pela tabela**: ele toma um valor e não deixa nenhum, a pilha sai como entrou. E o único lugar onde um binding é lido como valor — um escopo cuja última expressão é um — ganha o neutro empurrado, que é o que o evaluator responde ali.

## `StackDepth`

Substitui os helpers antigos de delta por um construído sobre a mesma tabela. É o que diz que um escopo está balanceado, e é **o que o `if` vai ler**: os dois lados de um salto têm que se encontrar com a mesma pilha embaixo.

## Verificação

O harness ganhou o caso que estava quebrado, em três formas — um local lido duas vezes, dois deles onde um lê o outro, e um que ninguém lê. Os três respondiam vazio na chain antes disto.

`make check` limpo, `make complexity` sem nada novo.

## O que vem

O `CLAUDE.md` deixou de dizer que o backend está em stand-by e passou a dizer a ordem: **`PUSH2` primeiro, depois `if`, depois `call`**. E o teto do `PUSH1` agora tem fim e não direção — um contrato publicado não passa de 24.576 bytes, então dois bytes cobrem todo contrato legal e não existe terceiro tamanho depois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)