### PR TITLE
fix: reading past what was applied answers zero, on both sides

### DIFF
--- a/docs/defer_and_scope_callable_philosofy.md
+++ b/docs/defer_and_scope_callable_philosofy.md
@@ -89,8 +89,9 @@ Internally, `feed` reads the **vector of values applied to the current execution
 ## Feed access semantics
 
 * Fed values are stored as a sequential structure
-* Access is **always normalized using modulo with the vector length**
-* Negative indices are normalized by absolute value before modulo
+* Reading a position nothing was applied to gives **a tape of zeros**
+* There is no negative index: a tape is a run of bytes and carries no sign, so the parser
+  refuses one
 * Access never fails and never throws
 
 Example:
@@ -98,10 +99,10 @@ Example:
 ```lang
 feed(0)
 feed(10)
-feed(-1)
 ```
 
-All expressions return a valid value according to the normalization rules.
+Both answer: the first with what was applied at that position, the second with a tape of
+zeros when nothing was.
 
 ---
 

--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -212,7 +212,7 @@ load under it.
 Because the declaration exists to catch mistakes, these are compile errors: a field the shape
 does not have, a value whose shape nothing declared, a construction that miscounts the
 and a shape name used as a value. Reading a field past the end of a value is not one — it gives the neutral value, the
-way `head` saturates and `feed` wraps.
+way `feed` does past the end of what was applied, and the way `head` saturates.
 
 Reading a field binds tighter than any operator, so `p.x * p.y` multiplies two fields.
 
@@ -287,8 +287,8 @@ _feed -> FEED O_PAREN _num C_PAREN
        | FEED _num
 ```
 
-Reads the nth value applied to the running scope. The index is normalized modulo the
-length of the vector, so it never fails.
+Reads the nth value applied to the running scope. A position nothing was applied to gives a
+tape of zeros, so it never fails.
 
 #### Examples
 `feed(0)`, `feed(1)`

--- a/evaluator/builtin/feed_test.go
+++ b/evaluator/builtin/feed_test.go
@@ -12,10 +12,12 @@ func tape(size int, value uint64) []byte {
 	return byteutil.PaddingTape(byteutil.FromUint64(value), size)
 }
 
-// feed(n) reads the vector of values applied to a scope. The scope never learns how many
-// it received, so the index wraps around the length: the read always answers with a tape
-// and never fails. It used to return nil for anything out of range, which is not a value
-// at all — "printb feed(0)" with nothing applied printed an empty array.
+// feed(n) reads the vector of values applied to a scope. The scope never learns how many it
+// received, so a position nothing was applied to answers with a tape of zeros: the read
+// always answers with a tape and never fails.
+//
+// It used to wrap the index around the length instead, which answered with a value that was
+// sent rather than with the absence of one.
 func TestFeedFunction(t *testing.T) {
 	feed := map[uint64][]byte{
 		0: tape(8, 10),
@@ -29,9 +31,8 @@ func TestFeedFunction(t *testing.T) {
 	}{
 		{name: "first", index: 0, want: 10},
 		{name: "second", index: 1, want: 20},
-		{name: "one past the end wraps to the first", index: 2, want: 10},
-		{name: "and keeps wrapping", index: 3, want: 20},
-		{name: "far past the end", index: 100, want: 10},
+		{name: "one past the end", index: 2, want: 0},
+		{name: "far past the end", index: 100, want: 0},
 	}
 
 	for _, tc := range cases {

--- a/evaluator/builtin/functions.go
+++ b/evaluator/builtin/functions.go
@@ -18,13 +18,19 @@ import (
 //
 // Execution in Aurora is the application of a vector of values to a scope, not a function
 // call — there is no signature, no arity and no parameter, so this only reads a position.
-// The scope never learns how many values it got: the index wraps around the length of the
-// vector, so the read always answers with a tape and never fails.
+// The scope never learns how many values it got, and a position nothing was applied to
+// answers with the neutral tape: the read always answers, and never fails.
+//
+// It used to take the index modulo the length of the vector, which turned a value that was
+// never sent into a repeat of one that was: "sum(5)" on a scope reading feed(0) and feed(1)
+// answered 10. That also made the answer depend on how many values the caller sent — a fact
+// no backend can know without carrying the count, and the EVM one never carried it. The same
+// program answered 10 off chain and 5 on it.
+//
+// Reading past the end now gives the neutral value, which is what reading a field past the
+// end of a shape already gave.
 func FeedFunction(feed map[uint64][]byte, index uint64, tapeSize int) []byte {
-	if len(feed) == 0 {
-		return byteutil.FalseTape(tapeSize)
-	}
-	value, ok := feed[index%uint64(len(feed))]
+	value, ok := feed[index]
 	if !ok {
 		return byteutil.FalseTape(tapeSize)
 	}

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -272,8 +272,9 @@ func (e *Evaluator) EvaluateJoin(label, left, right []byte) error {
 // EvaluateField takes one tape out of a run, by index. The index is a literal operand
 // written inline by the emitter, resolved from a shape declaration that no longer exists.
 //
-// Reading past the end gives the neutral value rather than failing, the way head saturates
-// and feed wraps: an operation on tapes does not stop a running program.
+// Reading past the end gives the neutral value rather than failing, the same answer feed
+// gives past the end of what was applied: an operation on tapes does not stop a running
+// program.
 func (e *Evaluator) EvaluateField(label, left, right []byte) error {
 	run := e.environ.GetTemp(byteutil.ToHex(left))
 	start := int(byteutil.ToUint64(right)) * e.tapeSize

--- a/examples/callables.ar
+++ b/examples/callables.ar
@@ -6,7 +6,8 @@
 #-
 #- There is no signature, no arity and no parameter list: executing is applying
 #- a vector of values to a scope. The scope never learns how many it received —
-#- feed(n) normalizes the index, so it always answers.
+#- feed(n) reads a position, and one that nothing was applied to gives a tape of
+#- zeros, so it always answers.
 #-
 #- Run: aurora run examples/callables.ar
 #-

--- a/examples/shapes.ar
+++ b/examples/shapes.ar
@@ -62,7 +62,7 @@ printd Point{1, 2} equals Pair{1, 2};
 printd Pair{"ab", 98};
 
 #- Reading past the end gives the neutral value instead of stopping the program,
-#- the way head saturates and feed wraps. A claim can be wrong.
+#- the way feed does past the end of what was applied. A claim can be wrong.
 ident single = 7 as Point;
 printd single.y;
 

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -204,3 +204,17 @@ func TestArithmeticWrapsAtTheTapeWidthOnBothSides(t *testing.T) {
 		})
 	}
 }
+
+// Reading past the values applied to a scope is not an error — the read always answers with a
+// tape. What it answers with is the question, and today the two backends answer differently:
+// the evaluator takes the index modulo the length of the vector, so a missing argument comes
+// back as the first one; the chain reads past the end of the calldata, which the EVM gives as
+// zeros.
+//
+// Nothing in the IR says which of the two is right. OpGetFeed carries an index and nothing
+// else, so the meaning lives in whichever consumer implemented it first.
+func TestReadingPastTheValuesAppliedAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `ident sum = defer { feed(0) + feed(1); };`
+
+	agree(t, source, "sum", []string{"5"}, 0)
+}


### PR DESCRIPTION
## O que o usuário ganha

Um escopo que lê `feed(0)` e `feed(1)`, chamado com um valor só, respondia **10 fora da cadeia e 5 nela**. A Aurora existe para que o mesmo programa responda a mesma coisa nos dois lugares, e nada estava conferindo esse caso.

Agora responde **5** nos dois. E um argumento que faltou para de parecer um número plausível: `sum(5)` é 5, não 10.

## O que estava acontecendo

O evaluator tomava o índice **módulo o tamanho do vetor**, então um valor que nunca foi enviado voltava como repetição de um que foi. A cadeia lia além do fim da calldata, que a EVM devolve como zeros.

Nenhum dos dois estava errado sobre a própria regra — **o IR nunca disse qual era a regra**. `OpGetFeed` carrega um índice e mais nada, e o significado morava em quem implementou primeiro.

## Por que zero, e não a volta

Zero é a resposta que a linguagem **já dá para a mesma forma de pergunta**: ler um campo além do fim de um shape dá o valor neutro (`grammar.md`, `EvaluateField`). Isso faz o `feed` virar a regra em vez da exceção.

E os outros wraps da linguagem dão a volta em **constante conhecida em compilação** — aritmética na largura do tape, `head`/`tail` no índice. O `feed` dava a volta no tamanho do vetor, que é propriedade do *sítio de chamada*: um fato que nenhum backend consegue saber sem carregar a contagem junto, e que a EVM nunca carregou.

## O diff

**O backend não muda uma linha.** O evaluator perde o `%`, e o guard `len(feed) == 0` vai junto — uma busca que não acha já responde o tape neutro:

```go
-	if len(feed) == 0 {
-		return byteutil.FalseTape(tapeSize)
-	}
-	value, ok := feed[index%uint64(len(feed))]
+	value, ok := feed[index]
```

Efeito colateral: `evaluator/builtin` foi de 90.9% para **100%** de cobertura, porque aquele guard era o ramo que nenhum teste alcançava.

O resto são os oito pontos que afirmavam a volta: a documentação da gramática, a filosofia de `defer`, dois exemplos, e os casos do `feed_test.go` que se invertem.

## A prova

O caso novo em `hosting/cli/evm_harness_test.go` **falhava antes e passa depois** — `the chain answered 5 and the evaluator 10`. É a única razão para acreditar em qualquer coisa acima, e é o que impede a divergência de voltar.

`make check` verde, 0 issues.

## Duas notas

**`docs/defer_and_scope_callable_philosofy.md`** prometia *"negative indices are normalized by absolute value before modulo"*. Sem o modulo a frase ficaria contraditória, então virou o que de fato acontece — não existe índice negativo, um tape não carrega sinal, e o parser recusa (`ParseNumber`). Aquela linha documentava um comportamento que nunca existiu.

**A #91** (RFC do IR) cita essa divergência no presente. Quando isto entrar, o tempo verbal muda lá — e o argumento dela fica mais forte: passa a ser a segunda vez que a mesma doença é remendada à mão depois do fato, sendo a primeira o `WriteMask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)