### PR TITLE
feat: the walk reaches every expression, so a check can see it

### DIFF
--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -74,6 +74,13 @@ func checkAsserts(nodes []ast.Node) []diag.Warning {
 }
 
 // childScopesOf returns the expressions a node holds, so a walk reaches what is nested.
+//
+// Every node that holds an expression belongs here. One that is missing does not make a check
+// fail — it makes it go quiet, which is the worse way for a check to be wrong: the answer
+// looks the same as having nothing to say.
+//
+// The test of an if, the operands of an operator and the argument of a call are all places an
+// expression is written, and each one left out is a warning nobody gets.
 func childScopesOf(node ast.Node) []ast.Node {
 	switch n := node.(type) {
 	case ast.IdentLiteral:
@@ -83,7 +90,10 @@ func childScopesOf(node ast.Node) []ast.Node {
 	case ast.DeferExpression:
 		return n.Block.Body
 	case ast.IfExpression:
-		body := make([]ast.Node, 0, len(n.Body)+1)
+		// The test is walked with the body: it is an expression like the ones inside, and
+		// leaving it out hid whatever was written there.
+		body := make([]ast.Node, 0, len(n.Body)+2)
+		body = append(body, n.Test)
 		body = append(body, n.Body...)
 		if n.Else != nil {
 			body = append(body, n.Else.Body...)
@@ -91,6 +101,8 @@ func childScopesOf(node ast.Node) []ast.Node {
 		return body
 	case ast.PrintStatement:
 		return []ast.Node{n.Param}
+	case ast.AssertStatement:
+		return []ast.Node{n.Condition}
 	case ast.ShapeLiteral:
 		// A field can hold a deferred scope, so the values of a shape are walked like any
 		// other place a scope can hide.
@@ -98,6 +110,32 @@ func childScopesOf(node ast.Node) []ast.Node {
 	case ast.FieldExpression:
 		return []ast.Node{n.Expression}
 	case ast.ShapedExpression:
+		return []ast.Node{n.Expression}
+	case ast.CalleeLiteral:
+		params := make([]ast.Node, 0, len(n.Params))
+		for _, param := range n.Params {
+			params = append(params, param.Expression)
+		}
+		return params
+	case ast.BinaryExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.RelativeExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.BooleanExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.UnaryExpression:
+		return []ast.Node{n.Expression}
+	case ast.PrimaryExpression:
+		return []ast.Node{n.Expression}
+	case ast.TapeBracketExpression:
+		return n.Items
+	case ast.PullExpression:
+		return []ast.Node{n.Target, n.Item}
+	case ast.PushExpression:
+		return []ast.Node{n.Target, n.Item}
+	case ast.HeadExpression:
+		return []ast.Node{n.Expression}
+	case ast.TailExpression:
 		return []ast.Node{n.Expression}
 	default:
 		return nil

--- a/emitter/warning_test.go
+++ b/emitter/warning_test.go
@@ -1,10 +1,14 @@
 package emitter
 
 import (
-	"github.com/guiferpa/aurora/wire/diag"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/diag"
 )
 
 func warningsFor(t *testing.T, source string, tapeSize int) []diag.Warning {
@@ -90,5 +94,88 @@ func TestWarningsAreReportedPerTapeSize(t *testing.T) {
 	}
 	if warnings := warningsFor(t, source, 4); len(warnings) != 0 {
 		t.Errorf("a four-byte tape names plenty: %v", warnings)
+	}
+}
+
+// treeOf parses source and answers the nodes of it, so a walk can be followed from the top.
+//
+// The filename is a parameter because the parser reads it: assert is only accepted in a
+// ".test.ar" file, and that is where the warning about it has anything to say.
+func treeOf(t *testing.T, filename, source string) []ast.Node {
+	t.Helper()
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("lexer: %v", err)
+	}
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: filename, Tokens: tokens})
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	return tree.Nodes
+}
+
+// reaches answers whether a full walk from the top finds a feed, which is the probe: it is a
+// leaf expression and can be written almost anywhere one is allowed.
+func reaches(nodes []ast.Node) bool {
+	found := false
+	var walk func([]ast.Node)
+	walk = func(scope []ast.Node) {
+		for _, node := range scope {
+			if _, ok := node.(ast.FeedExpression); ok {
+				found = true
+			}
+			walk(childScopesOf(node))
+		}
+	}
+	walk(nodes)
+	return found
+}
+
+// A walk that does not reach an expression does not fail — it goes quiet, and a check built on
+// it answers "nothing to say" for a program it never looked at. Every place an expression can
+// be written has to be reachable, so each of these is one that used to be a blind spot.
+func TestTheWalkReachesEveryExpression(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{name: "an operand of an operator", source: "printb 1 + feed(7);"},
+		{name: "an operand of a comparison", source: "printb feed(7) bigger 1;"},
+		{name: "an operand of and/or", source: "printb feed(7) and true;"},
+		{name: "the test of an if", source: "printb if feed(7) bigger 1 { 1; };"},
+		{name: "an argument of a call", source: "ident f = defer { 1; };\nprintb f(feed(7));"},
+		{name: "an item of a tape", source: "printb [feed(7)];"},
+		// pull, push, head and tail are walked too, and are not probed here: the parser
+		// narrows what may sit in those positions (isValidTapeTarget, isValidTapeItem), so
+		// a feed cannot be written there to look for.
+		{name: "the operand of a negation", source: "printb -feed(7);"},
+		{name: "inside parentheses", source: "printb (feed(7));"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reaches(treeOf(t, "main.ar", tc.source)) {
+				t.Errorf("the walk did not reach the feed in %q", tc.source)
+			}
+		})
+	}
+}
+
+// And the gap seen from where it is felt. An assert written as the argument of a call is an
+// assert like any other: it runs under "aurora test" and is consumed in silence in a plain
+// run, which is exactly what the warning exists to say out loud — and it used to say nothing,
+// because the walk stopped at the call.
+func TestAnAssertIsFoundWhereverItIsWritten(t *testing.T) {
+	source := "ident f = defer { 1; };\nprintb f(assert(1 equals 1, \"one\"));\n"
+
+	warnings := checkAsserts(treeOf(t, "main.test.ar", source))
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0].Message, "assert only runs under") {
+		t.Errorf("warning = %q, want it to be about the assert", warnings[0].Message)
+	}
+	if warnings[0].Line != 2 {
+		t.Errorf("warning points at line %d, want the line the assert is on", warnings[0].Line)
 	}
 }


### PR DESCRIPTION
## O que o usuário ganha

Um `assert` escrito como argumento de uma chamada passa a ser avisado. Hoje ele não é:

```
ident f = defer { 1; };
printb f(assert(1 equals 1, "one"));
```

Aquele assert roda sob `aurora test` e é **consumido em silêncio** numa execução comum — dizer isso em voz alta é a razão inteira de o aviso existir.

## A causa

`childScopesOf` (`emitter/warning.go`) responde o que um nó contém, e não respondia para quase nenhum: o teste de um `if`, os operandos de operador / comparação / `and`-`or`, a negação, o parêntese, os argumentos de uma chamada, os itens de um tape, os operandos de `pull`/`push`/`head`/`tail`, e a condição de um `assert`.

**Um passeio que não alcança uma expressão não falha — ele fica quieto.** Uma checagem construída em cima responde "nada a dizer" sobre um programa que ela nunca olhou, e isso é indistinguível de um programa sem problema. É o pior jeito de uma checagem errar.

## Testes

Dois, e o primeiro é o que impede a lacuna de voltar:

- **`TestTheWalkReachesEveryExpression`** — usa `feed(7)` como sonda (é expressão-folha e cabe em quase todo lugar) e afirma que o passeio a encontra em cada posição. Cada caso é um ponto cego de hoje.
- **`TestAnAssertIsFoundWhereverItIsWritten`** — o efeito visível acima.

`checkAsserts` **não tinha teste nenhum** antes deste. E como o parser só aceita `assert` em arquivo `.test.ar`, o helper de parse passou a receber o nome do arquivo.

`pull`, `push`, `head` e `tail` são percorridos e não são sondados: o parser estreita o que pode ocupar aquelas posições (`isValidTapeTarget`, `isValidTapeItem`), então não há como escrever um `feed` ali para procurar.

## Fora do escopo, e nomeado

`countDefers` tem a mesma lacuna — um `defer` escrito dentro de um operando não entra na conta de `checkDeferCapacity`. É bug latente, é concern próprio, e não é este PR.

## Por que agora

Primeiro de dois. O seguinte acrescenta um aviso para uma chamada que aplica menos valores do que o escopo lê — compensando o silêncio que a #92 criou — e ele **não funciona** sem este passeio, porque uma chamada escrita dentro de um operando não seria encontrada.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)