### PR TITLE
feat: a call that applies too few values is told about it

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -467,10 +467,14 @@ func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
 		exprs = append(exprs, ir.Expression{From: from, To: len(insts), Label: label})
 	}
 
+	warnings := checkDeferCapacity(tree.Nodes, e.tapeSize)
+	warnings = append(warnings, checkAsserts(tree.Nodes)...)
+	warnings = append(warnings, checkAppliedValues(tree.Nodes)...)
+
 	return ir.Program{
 		Instructions: insts,
 		Expressions:  exprs,
-		Warnings:     append(checkDeferCapacity(tree.Nodes, e.tapeSize), checkAsserts(tree.Nodes)...),
+		Warnings:     warnings,
 	}, nil
 }
 

--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -73,6 +73,107 @@ func checkAsserts(nodes []ast.Node) []diag.Warning {
 	return warnings
 }
 
+// checkAppliedValues reports a call that applies fewer values than the scope it reaches reads.
+//
+// A scope has no arity: applying is handing a vector to a block, and feed(n) reads a position
+// of it. But a body says how many positions it can address — the highest index it feeds, plus
+// one — and that number is known where the body is written.
+//
+// Applying fewer is not an error and will not become one. A position nobody wrote answers with
+// a tape of zeros, which is a defined answer and a reasonable thing to want. It is also almost
+// always a mistake, and since that answer is silent, this is the only place it can be said out
+// loud.
+//
+// It stays quiet unless it is sure. A name is checked only when it is bound to a deferred
+// scope exactly once in the file. Bound twice, or bound to anything else — an alias, an if
+// answering with one of two scopes — and which body a call reaches is a runtime question,
+// which is not one this can answer.
+func checkAppliedValues(nodes []ast.Node) []diag.Warning {
+	reads := scopeReads(nodes)
+
+	warnings := make([]diag.Warning, 0)
+	var walk func(scope []ast.Node)
+	walk = func(scope []ast.Node) {
+		for _, node := range scope {
+			if call, ok := node.(ast.CalleeLiteral); ok {
+				if positions, known := reads[call.Id.Value]; known && len(call.Params) < positions {
+					warnings = append(warnings, appliedValuesWarning(call, positions))
+				}
+			}
+			walk(childScopesOf(node))
+		}
+	}
+	walk(nodes)
+
+	return warnings
+}
+
+// appliedValuesWarning names the first position that will answer with zeros, which is the one
+// whoever wrote the call is least expecting. It points at the call rather than at the scope:
+// the scope is fine, and the call is what has to change.
+func appliedValuesWarning(call ast.CalleeLiteral, positions int) diag.Warning {
+	applied := len(call.Params)
+	warning := diag.Warning{Message: fmt.Sprintf(
+		"%s reads %d positions and %d were applied: feed(%d) answers with a tape of zeros",
+		call.Id.Value, positions, applied, applied)}
+	if call.Id.Token != nil {
+		warning.Line = call.Id.Token.GetLine()
+		warning.Column = call.Id.Token.GetColumn()
+	}
+	return warning
+}
+
+// scopeReads answers how many positions each name reads, for the names that answer that
+// unambiguously. A name bound more than once is dropped rather than guessed at.
+func scopeReads(nodes []ast.Node) map[string]int {
+	reads := make(map[string]int)
+	bound := make(map[string]bool)
+
+	var walk func(scope []ast.Node)
+	walk = func(scope []ast.Node) {
+		for _, node := range scope {
+			if binding, ok := node.(ast.IdentLiteral); ok {
+				deferred, deferring := binding.Value.(ast.DeferExpression)
+				switch {
+				case bound[binding.Id]:
+					delete(reads, binding.Id)
+				case deferring:
+					reads[binding.Id] = positionsRead(deferred.Block.Body)
+				}
+				bound[binding.Id] = true
+			}
+			walk(childScopesOf(node))
+		}
+	}
+	walk(nodes)
+
+	return reads
+}
+
+// positionsRead answers the highest position a body feeds, plus one.
+//
+// A nested deferred scope is not walked: its feeds read the vector applied to it, not the one
+// applied here. A body that feeds nothing reads nothing, and no call to it is ever short.
+func positionsRead(body []ast.Node) int {
+	highest := -1
+
+	var walk func(scope []ast.Node)
+	walk = func(scope []ast.Node) {
+		for _, node := range scope {
+			if _, nested := node.(ast.DeferExpression); nested {
+				continue
+			}
+			if feed, ok := node.(ast.FeedExpression); ok && int(feed.Nth.Value) > highest {
+				highest = int(feed.Nth.Value)
+			}
+			walk(childScopesOf(node))
+		}
+	}
+	walk(body)
+
+	return highest + 1
+}
+
 // childScopesOf returns the expressions a node holds, so a walk reaches what is nested.
 //
 // Every node that holds an expression belongs here. One that is missing does not make a check

--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -74,6 +74,13 @@ func checkAsserts(nodes []ast.Node) []diag.Warning {
 }
 
 // childScopesOf returns the expressions a node holds, so a walk reaches what is nested.
+//
+// Every node that holds an expression belongs here. One that is missing does not make a check
+// fail — it makes it go quiet, which is the worse way for a check to be wrong: the answer
+// looks the same as having nothing to say.
+//
+// The test of an if, the operands of an operator and the argument of a call are all places an
+// expression is written, and each one left out is a warning nobody gets.
 func childScopesOf(node ast.Node) []ast.Node {
 	switch n := node.(type) {
 	case ast.IdentLiteral:
@@ -83,7 +90,10 @@ func childScopesOf(node ast.Node) []ast.Node {
 	case ast.DeferExpression:
 		return n.Block.Body
 	case ast.IfExpression:
-		body := make([]ast.Node, 0, len(n.Body)+1)
+		// The test is walked with the body: it is an expression like the ones inside, and
+		// leaving it out hid whatever was written there.
+		body := make([]ast.Node, 0, len(n.Body)+2)
+		body = append(body, n.Test)
 		body = append(body, n.Body...)
 		if n.Else != nil {
 			body = append(body, n.Else.Body...)
@@ -91,6 +101,8 @@ func childScopesOf(node ast.Node) []ast.Node {
 		return body
 	case ast.PrintStatement:
 		return []ast.Node{n.Param}
+	case ast.AssertStatement:
+		return []ast.Node{n.Condition}
 	case ast.ShapeLiteral:
 		// A field can hold a deferred scope, so the values of a shape are walked like any
 		// other place a scope can hide.
@@ -98,6 +110,32 @@ func childScopesOf(node ast.Node) []ast.Node {
 	case ast.FieldExpression:
 		return []ast.Node{n.Expression}
 	case ast.ShapedExpression:
+		return []ast.Node{n.Expression}
+	case ast.CalleeLiteral:
+		params := make([]ast.Node, 0, len(n.Params))
+		for _, param := range n.Params {
+			params = append(params, param.Expression)
+		}
+		return params
+	case ast.BinaryExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.RelativeExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.BooleanExpression:
+		return []ast.Node{n.Left, n.Right}
+	case ast.UnaryExpression:
+		return []ast.Node{n.Expression}
+	case ast.PrimaryExpression:
+		return []ast.Node{n.Expression}
+	case ast.TapeBracketExpression:
+		return n.Items
+	case ast.PullExpression:
+		return []ast.Node{n.Target, n.Item}
+	case ast.PushExpression:
+		return []ast.Node{n.Target, n.Item}
+	case ast.HeadExpression:
+		return []ast.Node{n.Expression}
+	case ast.TailExpression:
 		return []ast.Node{n.Expression}
 	default:
 		return nil

--- a/emitter/warning_test.go
+++ b/emitter/warning_test.go
@@ -1,10 +1,14 @@
 package emitter
 
 import (
-	"github.com/guiferpa/aurora/wire/diag"
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/diag"
 )
 
 func warningsFor(t *testing.T, source string, tapeSize int) []diag.Warning {
@@ -90,5 +94,69 @@ func TestWarningsAreReportedPerTapeSize(t *testing.T) {
 	}
 	if warnings := warningsFor(t, source, 4); len(warnings) != 0 {
 		t.Errorf("a four-byte tape names plenty: %v", warnings)
+	}
+}
+
+// treeOf parses source and answers the nodes of it, so a walk can be followed from the top.
+//
+// The filename is a parameter because the parser reads it: assert is only accepted in a
+// ".test.ar" file, and that is where the warning about it has anything to say.
+func treeOf(t *testing.T, filename, source string) []ast.Node {
+	t.Helper()
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("lexer: %v", err)
+	}
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: filename, Tokens: tokens})
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	return tree.Nodes
+}
+
+// reaches answers whether a full walk from the top finds a feed, which is the probe: it is a
+// leaf expression and can be written almost anywhere one is allowed.
+func reaches(nodes []ast.Node) bool {
+	found := false
+	var walk func([]ast.Node)
+	walk = func(scope []ast.Node) {
+		for _, node := range scope {
+			if _, ok := node.(ast.FeedExpression); ok {
+				found = true
+			}
+			walk(childScopesOf(node))
+		}
+	}
+	walk(nodes)
+	return found
+}
+
+// A walk that does not reach an expression does not fail — it goes quiet, and a check built on
+// it answers "nothing to say" for a program it never looked at. Every place an expression can
+// be written has to be reachable, so each of these is one that used to be a blind spot.
+func TestTheWalkReachesEveryExpression(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{name: "an operand of an operator", source: "printb 1 + feed(7);"},
+		{name: "an operand of a comparison", source: "printb feed(7) bigger 1;"},
+		{name: "an operand of and/or", source: "printb feed(7) and true;"},
+		{name: "the test of an if", source: "printb if feed(7) bigger 1 { 1; };"},
+		{name: "an argument of a call", source: "ident f = defer { 1; };\nprintb f(feed(7));"},
+		{name: "an item of a tape", source: "printb [feed(7)];"},
+		// pull, push, head and tail are walked too, and are not probed here: the parser
+		// narrows what may sit in those positions (isValidTapeTarget, isValidTapeItem), so
+		// a feed cannot be written there to look for.
+		{name: "the operand of a negation", source: "printb -feed(7);"},
+		{name: "inside parentheses", source: "printb (feed(7));"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if !reaches(treeOf(t, "main.ar", tc.source)) {
+				t.Errorf("the walk did not reach the feed in %q", tc.source)
+			}
+		})
 	}
 }

--- a/emitter/warning_test.go
+++ b/emitter/warning_test.go
@@ -160,3 +160,129 @@ func TestTheWalkReachesEveryExpression(t *testing.T) {
 		})
 	}
 }
+
+// A scope has no arity, but a body says how many positions it can address: the highest index
+// it feeds, plus one. Applying fewer is not an error — what was not applied answers with a
+// tape of zeros, which is a defined answer — but that answer is silent, so it is said here.
+func TestApplyingFewerValuesThanTheScopeReads(t *testing.T) {
+	source := "ident sum = defer { feed(0) + feed(1); };\nprintb sum(5);\n"
+
+	warnings := warningsFor(t, source, 0)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %v", warnings)
+	}
+	message := warnings[0].Message
+	for _, want := range []string{"sum", "2 positions", "1 were applied", "feed(1)"} {
+		if !strings.Contains(message, want) {
+			t.Errorf("warning = %q, want it to mention %q", message, want)
+		}
+	}
+	// It points at the call, not at the scope: the scope is fine, and the call is what has
+	// to change.
+	if warnings[0].Line != 2 {
+		t.Errorf("warning points at line %d, want the line of the call", warnings[0].Line)
+	}
+}
+
+// The highest index is what counts, not how many are read: a body that only reads feed(3)
+// still needs four positions for that read to reach anything.
+func TestTheHighestPositionIsWhatCounts(t *testing.T) {
+	source := "ident third = defer { feed(3); };\nprintb third(1, 2, 3);\n"
+
+	warnings := warningsFor(t, source, 0)
+	if len(warnings) != 1 {
+		t.Fatalf("expected one warning, got %v", warnings)
+	}
+	if !strings.Contains(warnings[0].Message, "4 positions") {
+		t.Errorf("warning = %q, want it to count four positions", warnings[0].Message)
+	}
+}
+
+func TestNoWarningWhenEnoughWasApplied(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "exactly what it reads",
+			source: "ident sum = defer { feed(0) + feed(1); };\nprintb sum(1, 2);",
+		},
+		{
+			// Extra values are unread, and that is the language: a scope is blind to how
+			// many arrive.
+			name:   "more than it reads",
+			source: "ident double = defer { feed(0) * 2; };\nprintb double(5, 99, 100);",
+		},
+		{
+			name:   "a scope that reads nothing",
+			source: "ident two = defer { 2; };\nprintb two();",
+		},
+		{
+			// The feeds of a nested scope read the vector applied to it, not the one
+			// applied here.
+			name:   "a nested scope reading further",
+			source: "ident outer = defer { ident inner = defer { feed(3); }; feed(0); };\nprintb outer(1);",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if warnings := warningsFor(t, tc.source, 0); len(warnings) != 0 {
+				t.Errorf("expected no warning, got %v", warnings)
+			}
+		})
+	}
+}
+
+// It stays quiet unless it is sure. Which body a call reaches is a runtime question whenever
+// the name does not answer it on its own, and a warning that guesses is worse than none.
+func TestItSaysNothingWhenTheScopeIsNotKnown(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "an alias, which is a name bound to a name",
+			source: "ident sum = defer { feed(0) + feed(1); };\nident f = sum;\nprintb f(5);",
+		},
+		{
+			name:   "a name bound twice, to scopes reading different amounts",
+			source: "ident f = defer { feed(0) + feed(1); };\nident f = defer { feed(0); };\nprintb f(5);",
+		},
+		{
+			name:   "a name answered by a branch",
+			source: "ident a = defer { feed(0) + feed(1); };\nident b = defer { feed(0); };\nident g = if true { a; } else { b; };\nprintb g(5);",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if warnings := warningsFor(t, tc.source, 0); len(warnings) != 0 {
+				t.Errorf("expected no warning, got %v", warnings)
+			}
+		})
+	}
+}
+
+// A call written inside an operand, inside the test of an if or as another call's argument is
+// still a call. This is what the walk is for, and what it used to miss.
+func TestACallIsFoundWhereverItIsWritten(t *testing.T) {
+	const scope = "ident sum = defer { feed(0) + feed(1); };\n"
+
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{name: "in an operand", source: scope + "printb 1 + sum(5);"},
+		{name: "in the test of an if", source: scope + "printb if sum(5) bigger 1 { 1; };"},
+		{name: "as an argument", source: scope + "printb sum(sum(5), 2);"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if warnings := warningsFor(t, tc.source, 0); len(warnings) != 1 {
+				t.Errorf("expected one warning, got %v", warnings)
+			}
+		})
+	}
+}

--- a/hosting/cli/compiling_test.go
+++ b/hosting/cli/compiling_test.go
@@ -105,3 +105,27 @@ func TestAssertBelongsToATestFile(t *testing.T) {
 		t.Error("assert should be rejected outside .test.ar")
 	}
 }
+
+// A short call is told about where it was written, in the form an editor follows.
+//
+// The whole point of the warning is that the answer is silent: reading past what was applied
+// gives a tape of zeros, so nothing at runtime says the value never arrived. It has to reach
+// the person, with a place to look — which is the part no test of the emitter alone can show,
+// since it crosses the loader, the session and the writer to get there.
+func TestAShortCallIsReportedWithWhereToLook(t *testing.T) {
+	dir := t.TempDir()
+	source := writeFile(t, dir, "main.ar", "ident sum = defer { feed(0) + feed(1); };\nprintb sum(5);\n")
+	warnings := &strings.Builder{}
+
+	if _, err := newSession(t, sessionOpts{warnings: warnings}).
+		Build(t.Context(), source, filepath.Join(dir, "bin", "main")); err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+
+	got := warnings.String()
+	for _, want := range []string{"main.ar:2:8:", "sum reads 2 positions", "feed(1)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("the compiler said %q, want it to mention %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## O que o usuário ganha

```
ident sum = defer { feed(0) + feed(1); };
printb sum(5);

main.ar:2:8: warning: sum reads 2 positions and 1 were applied: feed(1) answers with a tape of zeros
```

Desde a #92, ler além do que foi aplicado responde **tape de zeros**. É resposta definida e é uma coisa razoável de se querer — e é **silenciosa**: um valor que nunca chegou fica idêntico a um valor que era zero. Este aviso é a compensação desse silêncio.

## O que ele não é

**Não é assinatura.** Um escopo continua sem aridade, e não vai ganhar uma — executar é aplicar um vetor a um bloco. O que existe é um número que o **corpo** sabe de si mesmo: o maior índice de `feed` que aparece nele, mais um.

**Não é erro, e não vai virar.** A `returns` é opcional justamente porque *"a scope has no signature — it does not declare how many values it receives"* (`docs/language-design.md`). Transformar isto em erro daria ao `defer` uma assinatura por inferência e derrubaria aquele argumento.

**Só "faltar" é dito.** Sobrar segue legal, porque é a linguagem: *"the scope is blind to how many values arrive"*, e `examples/callables.ar` demonstra com `double(5, 99, 100)`.

## Ele se cala quando não tem certeza

Um nome só é checado quando está ligado a um `defer` **exatamente uma vez no arquivo**. Alias, nome ligado duas vezes, nome respondido por um `if` — ali qual corpo a chamada alcança é pergunta de runtime, e aviso que chuta é pior que aviso nenhum. Chamada qualificada por módulo também não é checada: isto lê um arquivo.

Cada um desses é um caso de teste, não um comentário.

## Dois commits, dois concerns

**1. O passeio alcança toda expressão.** `childScopesOf` não respondia por quase nenhum nó: teste de `if`, operandos, negação, parêntese, argumentos de chamada, itens de tape, `pull`/`push`/`head`/`tail`, condição de `assert`. Um passeio que não alcança **não falha — fica quieto**, e "nada a dizer" é indistinguível de "nada errado". Uma chamada se escreve em qualquer uma dessas posições, então a checagem não funcionaria sem isso.

**2. A checagem.** `checkAppliedValues`, `scopeReads`, `positionsRead`, ligada como terceira em `EmitProgram`.

## Relação com as RFCs

O número que `positionsRead` calcula é o mesmo que a convenção de frame da `rfcs/if_and_call.md` precisa — ela descreve o cálculo em prosa e agora pode apontar para uma função.

Ele **não** entra no IR proposto na #93, e isso é decisão: pelo teste de três perguntas da própria RFC ele reprova na segunda (um consumidor recupera numa passada), igual à contagem de leituras e ao grafo `preds`/`succs` que ela já lista no que fica de fora.

## Verificação

Cobertura de unidade no emitter, incluindo um caso para cada situação em que a checagem se cala. E um caso de integração em `hosting/cli` provando que o aviso atravessa o loader, a sessão e o escritor até virar linha no terminal, com a posição que um editor segue:

```
main.ar:2:8: warning: sum reads 2 positions and 1 were applied: feed(1) answers with a tape of zeros
```

Uma versão anterior deste texto afirmava que os avisos do emitter não chegavam ao stderr no `aurora build`. **Era falso** — eu não tinha verificado. Chegam, primeiro na lista, e o caso acima é o que passa a garantir isso.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
