### PR TITLE
feat: an instruction knows where it came from

### DIFF
--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -250,8 +250,11 @@ func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 				t.Errorf("%v: %v", tc.name, err)
 				return
 			}
+			// Compared as the IR reads rather than as the struct is: this is about the
+			// order instructions come out in, and an instruction also carries where it was
+			// written, which the expectations below have no business restating.
 			got := ResolveOperandsOrder(insts)
-			if !reflect.DeepEqual(got, tc.want) {
+			if ir.Format(got) != ir.Format(tc.want) {
 				t.Errorf("\ngot =\n%v \nwant =\n%v", ir.Format(got), ir.Format(tc.want))
 			}
 		})

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -73,7 +73,10 @@ var pending = map[byte]string{
 // the program would refuse it for a reason that expires. What must not happen is the binary
 // coming out quietly wrong, which is what happened until now.
 //
-// They arrive in the order the program uses them, once each.
+// They arrive in the order the program uses them, once each, and each one points at the first
+// place the program used it. That place comes from the instruction: the emitter knows where
+// every node was written and now says so, where before this named a feature and left the
+// person to find it.
 func Warnings(insts []ir.Instruction) []diag.Warning {
 	warnings := make([]diag.Warning, 0)
 	said := make(map[string]bool)
@@ -98,7 +101,11 @@ func Warnings(insts []ir.Instruction) []diag.Warning {
 			continue
 		}
 		said[message] = true
-		warnings = append(warnings, diag.Warning{Message: message})
+		warning := diag.Warning{Message: message}
+		if origin := inst.GetOrigin(); origin.Known() {
+			warning.Line, warning.Column = origin.Line, origin.Column
+		}
+		warnings = append(warnings, warning)
 	}
 
 	return warnings

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ir"
 )
 
@@ -123,4 +126,39 @@ func TestWarningsFollowTheProgram(t *testing.T) {
 	if !strings.Contains(warnings[0].Message, "printd") {
 		t.Errorf("said %q first, want the print", warnings[0].Message)
 	}
+}
+
+// A warning that names a feature and not a place leaves the person to search for it. The IR
+// carries where every instruction came from now, so the backend points at the first line that
+// used what it cannot carry.
+func TestWarningsPointAtWhereTheFeatureWasUsed(t *testing.T) {
+	const source = `ident sum = defer { feed(0) + feed(1); };
+printb sum(1, 2);`
+
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("lexer: %v", err)
+	}
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+
+	for _, warning := range Warnings(insts) {
+		if !strings.Contains(warning.Message, "calling a scope") {
+			continue
+		}
+		if !warning.Positioned() {
+			t.Fatal("the warning about calling a scope has no place to point at")
+		}
+		if warning.Line != 2 {
+			t.Errorf("it points at line %d, want the line the call was written on", warning.Line)
+		}
+		return
+	}
+	t.Fatal("nothing warned about calling a scope")
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -134,9 +134,13 @@ using any of the following **compiles successfully and does nothing on chain**.
   bytes and identifiers at about seven memory slots. `PUSH2` lifts it.
 
 `aurora build` now **says what it could not carry**, once per feature, in the order the
-program uses it — so a binary that does less than the source said is at least announced. What
-is missing is a place to point at: the IR carries instructions, not lines, so a warning names
-the feature and not where it was written.
+program uses it, and names the line the program first used it on — so a binary that does less
+than the source said is announced, in the form an editor follows.
+
+What a warning still cannot point at is a feature the emitter had no token for: an `if`, a
+`shape`, and the tape operations are parsed from nodes that do not keep the token they came
+from, so those name the feature and not the place. Giving those nodes a token is a change to
+the parser and would close the gap.
 
 ## Simulating a call off the chain
 

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -6,6 +6,7 @@ import (
 	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/ir"
+	"github.com/guiferpa/aurora/wire/token"
 )
 
 type Emitter interface {
@@ -21,6 +22,15 @@ func GenerateLabel(tc *int) []byte {
 	t := []byte(fmt.Sprintf("0%d", *tc))
 	*tc++
 	return t
+}
+
+// originOf answers where a token was written, so an instruction can point at it. A nil token
+// answers with nothing, which is what a phase after this one reads as "no place to point at".
+func originOf(t token.Token) ir.Origin {
+	if t == nil {
+		return ir.Origin{}
+	}
+	return ir.Origin{Line: t.GetLine(), Column: t.GetColumn()}
 }
 
 // printOpCodes maps each reading of a value to the instruction that writes it.
@@ -94,7 +104,7 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 func emitIdentLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentLiteral, tapeSize int) ir.Label {
 	lr := EmitInstruction(tc, insts, n.Value, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpIdent, ir.NameOf(n.Id), ir.RefTo(lr)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpIdent, ir.NameOf(n.Id), ir.RefTo(lr)).At(originOf(n.Token)))
 	// A binding has a value like every other expression — the neutral one — and the
 	// label has to come back, or a scope ending in a binding returns the fallback of
 	// a node the emitter did not recognise.
@@ -147,7 +157,7 @@ func emitUnaryExpression(tc *int, insts *[]ir.Instruction, n ast.UnaryExpression
 	*insts = append(*insts, ir.NewInstruction(lz, ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize)), ir.Nothing()))
 
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpSubtract, ir.RefTo(lz), ir.RefTo(lo)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSubtract, ir.RefTo(lz), ir.RefTo(lo)).At(originOf(n.Operation.Token)))
 	return l
 
 }
@@ -168,7 +178,7 @@ func emitRelativeExpression(tc *int, insts *[]ir.Instruction, n ast.RelativeExpr
 		op = ir.OpSmaller
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)))
+	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)).At(originOf(n.Operation.Token)))
 
 	return l
 
@@ -186,7 +196,7 @@ func emitBooleanExpression(tc *int, insts *[]ir.Instruction, n ast.BooleanExpres
 		op = ir.OpAnd
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)))
+	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)).At(originOf(n.Operation.Token)))
 	return l
 
 }
@@ -349,10 +359,10 @@ func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, ta
 	for i, p := range n.Params {
 		ll := EmitInstruction(tc, insts, p.Expression, tapeSize)
 		l := GenerateLabel(tc)
-		*insts = append(*insts, ir.NewInstruction(l, ir.OpPushFeed, ir.ImmNum(uint64(i)), ir.RefTo(ll)))
+		*insts = append(*insts, ir.NewInstruction(l, ir.OpPushFeed, ir.ImmNum(uint64(i)), ir.RefTo(ll)).At(originOf(n.Id.Token)))
 	}
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpCall, ir.NameOf(n.Id.Value), ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpCall, ir.NameOf(n.Id.Value), ir.Nothing()).At(originOf(n.Id.Token)))
 	return l
 
 }
@@ -372,7 +382,7 @@ func emitAssertStatement(tc *int, insts *[]ir.Instruction, n ast.AssertStatement
 	// written for whoever reads the result, and a value would have to fit in a tape.
 	cond := EmitInstruction(tc, insts, n.Condition, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpAssert, ir.RefTo(cond), ir.TextOf(n.Message)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpAssert, ir.RefTo(cond), ir.TextOf(n.Message)).At(originOf(n.Token)))
 	return l
 
 }
@@ -404,7 +414,7 @@ func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpressi
 	}
 
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)))
+	*insts = append(*insts, ir.NewInstruction(l, op, ir.RefTo(ll), ir.RefTo(lr)).At(originOf(n.Operation.Token)))
 
 	return l
 
@@ -413,7 +423,7 @@ func emitBinaryExpression(tc *int, insts *[]ir.Instruction, n ast.BinaryExpressi
 // emitNumberLiteral saves a number as a tape.
 func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize)), ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(byteutil.PaddingTape(byteutil.FromUint64(n.Value), tapeSize)), ir.Nothing()).At(originOf(n.Token)))
 	return l
 
 }
@@ -422,7 +432,7 @@ func emitNumberLiteral(tc *int, insts *[]ir.Instruction, n ast.NumberLiteral, ta
 func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSize int) ir.Label {
 	// Text is a tape holding its bytes, so it saves like any other value.
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(n.Value), ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(n.Value), ir.Nothing()).At(originOf(n.Token)))
 	return l
 
 }
@@ -430,7 +440,7 @@ func emitTextLiteral(tc *int, insts *[]ir.Instruction, n ast.TextLiteral, tapeSi
 // emitBooleanLiteral saves true or false, which are tapes like any other.
 func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(n.Value), ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(n.Value), ir.Nothing()).At(originOf(n.Token)))
 	return l
 
 }
@@ -438,7 +448,7 @@ func emitBooleanLiteral(tc *int, insts *[]ir.Instruction, n ast.BooleanLiteral, 
 // emitIdentifierLiteral loads what a name is bound to.
 func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLiteral, tapeSize int) ir.Label {
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, ir.NameOf(n.Value), ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpLoad, ir.NameOf(n.Value), ir.Nothing()).At(originOf(n.Token)))
 	return l
 
 }

--- a/wire/diag/warning.go
+++ b/wire/diag/warning.go
@@ -10,8 +10,9 @@ package diag
 // Compilation carries on and the program runs.
 //
 // Line and Column are 1-based and zero when the warning is about the program as a whole
-// rather than a place in it — which is what a backend answers with, since the IR carries
-// instructions and not lines.
+// rather than a place in it. That used to be every warning a backend produced, because the IR
+// carried instructions and no trace of where they came from; instructions carry an origin now,
+// so a backend points at a place whenever the emitter had one to give it.
 type Warning struct {
 	Message string
 	Line    int

--- a/wire/ir/instruction.go
+++ b/wire/ir/instruction.go
@@ -5,6 +5,7 @@ type Instruction interface {
 	GetOpCode() byte
 	GetLeft() Operand
 	GetRight() Operand
+	GetOrigin() Origin
 }
 
 type inst struct {
@@ -12,6 +13,7 @@ type inst struct {
 	opcode byte
 	left   Operand
 	right  Operand
+	origin Origin
 }
 
 func (i inst) GetLabel() []byte {
@@ -30,7 +32,21 @@ func (i inst) GetRight() Operand {
 	return i.right
 }
 
+func (i inst) GetOrigin() Origin {
+	return i.origin
+}
+
+// At answers the same instruction, knowing where it came from.
+//
+// It is a second step rather than a parameter because most instructions have somewhere to
+// point at and a few do not, and because an origin changes nothing about what the instruction
+// does — reading "NewInstruction(...).At(...)" says that, and a fifth argument would not.
+func (i inst) At(origin Origin) inst {
+	i.origin = origin
+	return i
+}
+
 // NewInstruction builds an instruction from operands that say what they are.
 func NewInstruction(label []byte, opcode byte, left, right Operand) inst {
-	return inst{label, opcode, left, right}
+	return inst{label: label, opcode: opcode, left: left, right: right}
 }

--- a/wire/ir/origin.go
+++ b/wire/ir/origin.go
@@ -1,0 +1,24 @@
+package ir
+
+// An Origin is where in the source an instruction came from.
+//
+// It is metadata, in the strict sense: dropping it changes nothing about what a program does.
+// What it changes is whether a phase after the emitter can point at a place. A backend that
+// cannot say where means a warning that names a feature and not the line it was written on,
+// and the person is left to search.
+//
+// The emitter is the only phase that can supply it. Every node of the tree carries the token
+// it was parsed from, and until now the emitter held that and let it go.
+//
+// Zero means the emitter had nothing to point at — a value it invented rather than one
+// somebody wrote, like the neutral tape a declaration answers with. Line and Column are
+// 1-based, matching diag.Warning and the token positions it comes from.
+type Origin struct {
+	Line   int
+	Column int
+}
+
+// Known reports whether the origin points at a place in the source.
+func (o Origin) Known() bool {
+	return o.Line > 0
+}


### PR DESCRIPTION
## O que o usuário ganha

Um aviso do backend que **aponta para a linha**, na forma que um editor segue:

```
main.ar:2:8: warning: calling a scope does not reach the bytecode yet: a contract using it
compiles and does nothing on chain
```

Antes ele nomeava a feature e mais nada. Verdade e inútil: num arquivo de trinta expressões, qual chamada?

## A limitação estava escrita em dois lugares, e era falsa

`docs/roadmap.md` registrava como limitação do IR:

> *"What is missing is a place to point at: the IR carries instructions, not lines"*

E `wire/diag/warning.go` registrava como **natureza** de um backend:

> *"zero when the warning is about the program as a whole — which is what a backend answers with, since the IR carries instructions and not lines"*

Não era nem uma coisa nem outra. **Todo nó da árvore carrega o token de onde veio**, e o emitter segurava isso e soltava.

## Como entra

Uma `Origin` na instrução. É metadado no sentido estrito — descartar não muda nada do que um programa faz — e é por isso que ela chega como **segundo passo** e não como quinto argumento:

```go
ir.NewInstruction(l, ir.OpCall, ir.NameOf(n.Id.Value), ir.Nothing()).At(originOf(n.Id.Token))
```

Ler `NewInstruction(...).At(...)` diz que a origem não participa do que a instrução faz. Um quinto argumento não diria.

## O que ainda não aponta, e por quê

Zero significa "o emitter não tinha para onde apontar", e ainda é a maioria. **Só sete tipos de nó guardam o token**, então dá para apontar em aritmética, comparação, `and`/`or`, uma chamada, uma ligação, uma leitura de nome e os literais — e **não** dá num `if`, num `shape` nem nas operações de tape.

Dar token àqueles nós é mudança no **parser**, e o roadmap agora diz isso em vez de culpar o IR.

## Uma nota sobre um teste

`TestResolveOperandsOrderFromSourceCode` comparava instruções com `reflect.DeepEqual` e passou a falhar, porque a origem difere. Ele passou a comparar pelo que o IR **lê** (`ir.Format`): o teste é sobre a ordem em que as instruções saem, e onde cada uma foi escrita não é coisa que as expectativas dele tenham que repetir.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)