### PR TITLE
feat: a node keeps the token it came from, so every warning names a place

### DIFF
--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -162,3 +162,52 @@ printb sum(1, 2);`
 	}
 	t.Fatal("nothing warned about calling a scope")
 }
+
+// Every feature the backend cannot carry names the line it was written on. A warning that
+// names only the feature leaves the person to search, which is what this used to do.
+func TestEveryPendingFeatureNamesItsPlace(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		says   string
+		line   int
+	}{
+		{name: "an if", source: "printb 1;\nprintb if true { 1; };", says: "if", line: 2},
+		{name: "a call", source: "ident f = defer { 1; };\nprintb f();", says: "calling a scope", line: 2},
+		{name: "a comparison", source: "printb 1;\nprintb 2 bigger 1;", says: "a comparison", line: 2},
+		{name: "and or or", source: "printb 1;\nprintb true and false;", says: "and/or", line: 2},
+		{name: "an exponent", source: "printb 1;\nprintb 2 ^ 3;", says: "^", line: 2},
+		// A tape literal is itself a tape operation — it builds the run byte by byte — so
+		// the first place the program uses one is the literal, not the pull below it.
+		{name: "a tape operation", source: "printb 1;\nident t = [1];\nprintb pull t 2;", says: "a tape operation", line: 2},
+		{name: "a shape", source: "shape Point { x, y };\nprintb Point{1, 2}.x;", says: "shape", line: 2},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tokens, err := lexer.New().GetFilledTokens([]byte(tc.source))
+			if err != nil {
+				t.Fatalf("lexer: %v", err)
+			}
+			tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+			if err != nil {
+				t.Fatalf("parser: %v", err)
+			}
+			insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
+			if err != nil {
+				t.Fatalf("emitter: %v", err)
+			}
+
+			for _, warning := range Warnings(insts) {
+				if !strings.Contains(warning.Message, tc.says) {
+					continue
+				}
+				if warning.Line != tc.line {
+					t.Errorf("%q points at line %d, want %d", warning.Message, warning.Line, tc.line)
+				}
+				return
+			}
+			t.Fatalf("nothing warned about %q", tc.says)
+		})
+	}
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -137,11 +137,6 @@ using any of the following **compiles successfully and does nothing on chain**.
 program uses it, and names the line the program first used it on — so a binary that does less
 than the source said is announced, in the form an editor follows.
 
-What a warning still cannot point at is a feature the emitter had no token for: an `if`, a
-`shape`, and the tape operations are parsed from nodes that do not keep the token they came
-from, so those name the feature and not the place. Giving those nodes a token is a change to
-the parser and would close the gap.
-
 ## Simulating a call off the chain
 
 `aurora call` speaks to a network and nothing else, so there is no way to ask for one scope by

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -212,7 +212,7 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBrack
 	for _, i := range n.Items {
 		la := GenerateLabel(tc)
 		li := EmitInstruction(tc, insts, i, tapeSize)
-		*insts = append(*insts, ir.NewInstruction(la, ir.OpPull, ir.RefTo(l), ir.RefTo(li)))
+		*insts = append(*insts, ir.NewInstruction(la, ir.OpPull, ir.RefTo(l), ir.RefTo(li)).At(originOf(n.Token)))
 		l = la
 	}
 	return l
@@ -255,7 +255,7 @@ func emitShapeLiteral(tc *int, insts *[]ir.Instruction, n ast.ShapeLiteral, tape
 	for _, value := range n.Values {
 		lv := EmitInstruction(tc, insts, value, tapeSize)
 		lj := GenerateLabel(tc)
-		*insts = append(*insts, ir.NewInstruction(lj, ir.OpJoin, ir.RefTo(l), ir.RefTo(lv)))
+		*insts = append(*insts, ir.NewInstruction(lj, ir.OpJoin, ir.RefTo(l), ir.RefTo(lv)).At(originOf(n.Token)))
 		l = lj
 	}
 	return l
@@ -268,7 +268,7 @@ func emitFieldExpression(tc *int, insts *[]ir.Instruction, n ast.FieldExpression
 	// shape head and tail use. Nothing here knows the field had a name.
 	lv := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpField, ir.RefTo(lv), ir.ImmNum(n.Index)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpField, ir.RefTo(lv), ir.ImmNum(n.Index)).At(originOf(n.Token)))
 	return l
 
 }
@@ -286,7 +286,7 @@ func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, 
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpPull, ir.RefTo(lt), ir.RefTo(li)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpPull, ir.RefTo(lt), ir.RefTo(li)).At(originOf(n.Token)))
 	return l
 
 }
@@ -295,7 +295,7 @@ func emitPullExpression(tc *int, insts *[]ir.Instruction, n ast.PullExpression, 
 func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, tapeSize int) ir.Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpHead, ir.RefTo(e), ir.ImmNum(n.Length)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpHead, ir.RefTo(e), ir.ImmNum(n.Length)).At(originOf(n.Token)))
 	return l
 
 }
@@ -304,7 +304,7 @@ func emitHeadExpression(tc *int, insts *[]ir.Instruction, n ast.HeadExpression, 
 func emitTailExpression(tc *int, insts *[]ir.Instruction, n ast.TailExpression, tapeSize int) ir.Label {
 	e := EmitInstruction(tc, insts, n.Expression, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpTail, ir.RefTo(e), ir.ImmNum(n.Length)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpTail, ir.RefTo(e), ir.ImmNum(n.Length)).At(originOf(n.Token)))
 	return l
 
 }
@@ -314,7 +314,7 @@ func emitPushExpression(tc *int, insts *[]ir.Instruction, n ast.PushExpression, 
 	lt := EmitInstruction(tc, insts, n.Target, tapeSize)
 	li := EmitInstruction(tc, insts, n.Item, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpPush, ir.RefTo(lt), ir.RefTo(li)))
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpPush, ir.RefTo(lt), ir.RefTo(li)).At(originOf(n.Token)))
 	return l
 
 }
@@ -341,10 +341,10 @@ func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tape
 
 	lt := EmitInstruction(tc, insts, n.Test, tapeSize)
 	inl := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(inl, ir.OpIf, ir.RefTo(lt), bodylen))
+	*insts = append(*insts, ir.NewInstruction(inl, ir.OpIf, ir.RefTo(lt), bodylen).At(originOf(n.Token)))
 
 	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpReturn, ir.RefTo(inl), ir.RefTo(bl)))
-	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpJump, euzelen, ir.Nothing()))
+	body = append(body, ir.NewInstruction(GenerateLabel(tc), ir.OpJump, euzelen, ir.Nothing()).At(originOf(n.Token)))
 	*insts = append(*insts, body...)
 
 	euze = append(euze, ir.NewInstruction(GenerateLabel(tc), ir.OpReturn, ir.RefTo(inl), ir.RefTo(eul)))

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -296,7 +296,8 @@ func (p *pr) parsePrimaryExpr() (ast.Node, error) {
 }
 
 func (p *pr) ParseTapeBrk() (ast.Node, error) {
-	if _, err := p.EatToken(token.O_BRK); err != nil {
+	at, err := p.EatToken(token.O_BRK)
+	if err != nil {
 		return nil, err
 	}
 	items := make([]ast.Node, 0)
@@ -329,11 +330,12 @@ func (p *pr) ParseTapeBrk() (ast.Node, error) {
 	if len(items) > p.tapeSize {
 		return nil, token.NewError(closing, "tape literal has %d values but a tape holds %d bytes", len(items), p.tapeSize)
 	}
-	return ast.TapeBracketExpression{Items: items}, nil
+	return ast.TapeBracketExpression{Items: items, Token: at}, nil
 }
 
 func (p *pr) ParsePull() (ast.Node, error) {
-	if _, err := p.EatToken(token.PULL); err != nil {
+	at, err := p.EatToken(token.PULL)
+	if err != nil {
 		return nil, err
 	}
 
@@ -352,11 +354,12 @@ func (p *pr) ParsePull() (ast.Node, error) {
 	if !isValidTapeItem(expr) {
 		return nil, errors.New("it is not a valid append item")
 	}
-	return ast.PullExpression{Target: target, Item: expr}, nil
+	return ast.PullExpression{Target: target, Item: expr, Token: at}, nil
 }
 
 func (p *pr) ParseHead() (ast.Node, error) {
-	if _, err := p.EatToken(token.HEAD); err != nil {
+	at, err := p.EatToken(token.HEAD)
+	if err != nil {
 		return nil, err
 	}
 	expr, err := p.ParseExpr()
@@ -371,11 +374,12 @@ func (p *pr) ParseHead() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ast.HeadExpression{Expression: expr, Length: length.Value}, nil
+	return ast.HeadExpression{Expression: expr, Length: length.Value, Token: at}, nil
 }
 
 func (p *pr) ParseTail() (ast.Node, error) {
-	if _, err := p.EatToken(token.TAIL); err != nil {
+	at, err := p.EatToken(token.TAIL)
+	if err != nil {
 		return nil, err
 	}
 	expr, err := p.ParseExpr()
@@ -390,11 +394,12 @@ func (p *pr) ParseTail() (ast.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ast.TailExpression{Expression: expr, Length: length.Value}, nil
+	return ast.TailExpression{Expression: expr, Length: length.Value, Token: at}, nil
 }
 
 func (p *pr) ParsePush() (ast.Node, error) {
-	if _, err := p.EatToken(token.PUSH); err != nil {
+	at, err := p.EatToken(token.PUSH)
+	if err != nil {
 		return nil, err
 	}
 
@@ -413,7 +418,7 @@ func (p *pr) ParsePush() (ast.Node, error) {
 	if !isValidTapeItem(expr) {
 		return nil, errors.New("it is not a valid push item")
 	}
-	return ast.PushExpression{Target: target, Item: expr}, nil
+	return ast.PushExpression{Target: target, Item: expr, Token: at}, nil
 }
 
 func (p *pr) ParseUnaExpr() (ast.Node, error) {
@@ -743,7 +748,8 @@ func (p *pr) ParseDefer() (ast.Node, error) {
 }
 
 func (p *pr) ParseIf() (ast.Node, error) {
-	if _, err := p.EatToken(token.IF); err != nil {
+	at, err := p.EatToken(token.IF)
+	if err != nil {
 		return nil, err
 	}
 	test, err := p.ParseBoolExpr()
@@ -762,9 +768,9 @@ func (p *pr) ParseIf() (ast.Node, error) {
 	}
 	if p.GetLookahead().GetTag().Id == token.ELSE {
 		euze, err := p.ParseElse()
-		return ast.IfExpression{Test: test, Body: body, Else: euze}, err
+		return ast.IfExpression{Test: test, Body: body, Else: euze, Token: at}, err
 	}
-	return ast.IfExpression{Test: test, Body: body, Else: nil}, nil
+	return ast.IfExpression{Test: test, Body: body, Else: nil, Token: at}, nil
 }
 
 func (p *pr) ParseElse() (*ast.ElseExpression, error) {

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -107,31 +107,36 @@ type TapeExpression struct {
 
 type TapeBracketExpression struct {
 	mark
-	Items []Node `json:"items"`
+	Items []Node      `json:"items"`
+	Token token.Token `json:"-"`
 }
 
 type PullExpression struct {
 	mark
-	Target Node `json:"target"`
-	Item   Node `json:"item"`
+	Target Node        `json:"target"`
+	Item   Node        `json:"item"`
+	Token  token.Token `json:"-"`
 }
 
 type HeadExpression struct {
 	mark
-	Expression Node   `json:"expression"`
-	Length     uint64 `json:"length"`
+	Expression Node        `json:"expression"`
+	Length     uint64      `json:"length"`
+	Token      token.Token `json:"-"`
 }
 
 type TailExpression struct {
 	mark
-	Expression Node   `json:"expression"`
-	Length     uint64 `json:"length"`
+	Expression Node        `json:"expression"`
+	Length     uint64      `json:"length"`
+	Token      token.Token `json:"-"`
 }
 
 type PushExpression struct {
 	mark
-	Target Node `json:"target"`
-	Item   Node `json:"item"`
+	Target Node        `json:"target"`
+	Item   Node        `json:"item"`
+	Token  token.Token `json:"-"`
 }
 
 type RelativeExpression struct {
@@ -168,9 +173,10 @@ type DeferExpression struct {
 
 type IfExpression struct {
 	mark
-	Test Node            `json:"test"`
-	Body []Node          `json:"body"`
-	Else *ElseExpression `json:"else"`
+	Test  Node            `json:"test"`
+	Body  []Node          `json:"body"`
+	Else  *ElseExpression `json:"else"`
+	Token token.Token     `json:"-"`
 }
 
 type ElseExpression struct {


### PR DESCRIPTION
Fecha a lacuna que a #99 abriu e escreveu no roadmap. **Todo aviso do backend agora nomeia a linha.**

## Metade da lacuna que eu documentei era falsa

A #99 dizia que só sete tipos de nó guardam o token, e que `shape` era um dos que não podiam apontar. Contei com um grep que perdia os campos cujos nomes estão alinhados:

```go
Token token.Token   // pegava
Token     token.Token   // nao pegava
```

São **treze**, não sete. `ShapeLiteral` e `FieldExpression` **já guardavam** o token — o emitter é que não estava lendo. Culpei o parser por coisa que não era dele.

## A outra metade era real

`IfExpression`, `PullExpression`, `PushExpression`, `HeadExpression`, `TailExpression` e `TapeBracketExpression` nascem de uma palavra-chave que o parser come e joga fora. Agora guardam.

## O resultado

Cada feature que o backend não carrega nomeia a linha do primeiro uso, e há **um caso de teste para cada uma** — que é o único jeito de essa lista continuar verdadeira:

| feature | aponta |
|---|---|
| `if` | ✓ |
| chamada de escopo | ✓ |
| comparação | ✓ |
| `and` / `or` | ✓ |
| `^` | ✓ |
| operação de tape | ✓ |
| `shape` | ✓ |

## Um detalhe que parece off-by-one e não é

**Um literal de tape é ele mesmo uma operação de tape** — ele constrói o run byte a byte, com `OpPull`. Então o primeiro uso que um programa faz de uma operação de tape é o literal, não o `pull` escrito abaixo dele. O teste diz isso em voz alta, porque sem a frase parece erro de contagem.

## O roadmap

O parágrafo que descrevia a lacuna **saiu**, em vez de ser reescrito. Não sobrou nada dele.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)