### PR TITLE
refactor: an operation is handed operands, and one place says what they are worth

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -108,10 +108,22 @@ func (e *Evaluator) GetAssertErrors() []error {
 	return errs
 }
 
-// operands reads the two temps an operation consumes, as tapes of the configured size.
-func (e *Evaluator) operands(left, right []byte) (*uint256.Int, *uint256.Int) {
-	x := byteutil.ToUint256(e.environ.GetTemp(byteutil.ToHex(left)), e.tapeSize)
-	y := byteutil.ToUint256(e.environ.GetTemp(byteutil.ToHex(right)), e.tapeSize)
+// value answers what an operand is worth.
+//
+// A Ref names a value another instruction left behind, so it is looked up. An Imm is the
+// value: the program wrote it down and there is nothing to look up. Everything a position
+// holding a value can be, and the only place that has to know it.
+func (e *Evaluator) value(operand ir.Operand) []byte {
+	if operand.Kind() == ir.KindImm {
+		return operand.Bytes()
+	}
+	return e.environ.GetTemp(byteutil.ToHex(operand.Bytes()))
+}
+
+// operands reads the two values an operation consumes, as tapes of the configured size.
+func (e *Evaluator) operands(left, right ir.Operand) (*uint256.Int, *uint256.Int) {
+	x := byteutil.ToUint256(e.value(left), e.tapeSize)
+	y := byteutil.ToUint256(e.value(right), e.tapeSize)
 	return x, y
 }
 
@@ -130,28 +142,28 @@ func (e *Evaluator) setCondition(label []byte, cond bool) {
 	e.environ.SetTemp(byteutil.ToHex(label), value)
 }
 
-func (e *Evaluator) EvaluateAdd(label, left, right []byte) error {
+func (e *Evaluator) EvaluateAdd(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setValue(label, new(uint256.Int).Add(x, y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateSubtract(label, left, right []byte) error {
+func (e *Evaluator) EvaluateSubtract(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setValue(label, new(uint256.Int).Sub(x, y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateMultiply(label, left, right []byte) error {
+func (e *Evaluator) EvaluateMultiply(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setValue(label, new(uint256.Int).Mul(x, y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateDivide(label, left, right []byte) error {
+func (e *Evaluator) EvaluateDivide(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	if y.IsZero() {
 		return fmt.Errorf("integer divide by zero")
@@ -161,52 +173,52 @@ func (e *Evaluator) EvaluateDivide(label, left, right []byte) error {
 	return nil
 }
 
-func (e *Evaluator) EvaluateExponential(label, left, right []byte) error {
+func (e *Evaluator) EvaluateExponential(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setValue(label, new(uint256.Int).Exp(x, y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateDiff(label, left, right []byte) error {
+func (e *Evaluator) EvaluateDiff(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setCondition(label, !x.Eq(y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateEquals(label, left, right []byte) error {
+func (e *Evaluator) EvaluateEquals(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setCondition(label, x.Eq(y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateBigger(label, left, right []byte) error {
+func (e *Evaluator) EvaluateBigger(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setCondition(label, x.Gt(y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateSmaller(label, left, right []byte) error {
+func (e *Evaluator) EvaluateSmaller(label []byte, left, right ir.Operand) error {
 	x, y := e.operands(left, right)
 	e.setCondition(label, x.Lt(y))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateAnd(label, left, right []byte) error {
-	x := byteutil.ToBoolean(e.environ.GetTemp(byteutil.ToHex(left)))
-	y := byteutil.ToBoolean(e.environ.GetTemp(byteutil.ToHex(right)))
+func (e *Evaluator) EvaluateAnd(label []byte, left, right ir.Operand) error {
+	x := byteutil.ToBoolean(e.value(left))
+	y := byteutil.ToBoolean(e.value(right))
 	e.setCondition(label, x && y)
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateOr(label, left, right []byte) error {
-	x := byteutil.ToBoolean(e.environ.GetTemp(byteutil.ToHex(left)))
-	y := byteutil.ToBoolean(e.environ.GetTemp(byteutil.ToHex(right)))
+func (e *Evaluator) EvaluateOr(label []byte, left, right ir.Operand) error {
+	x := byteutil.ToBoolean(e.value(left))
+	y := byteutil.ToBoolean(e.value(right))
 	e.setCondition(label, x || y)
 	e.IncrementCursor()
 	return nil
@@ -220,9 +232,9 @@ func (e *Evaluator) EvaluateOr(label, left, right []byte) error {
 // pulling 4 into a tape moves it one byte, not a whole tape width.
 
 // EvaluatePull shifts the tape left and lets the item in at the right end.
-func (e *Evaluator) EvaluatePull(label, left, right []byte) error {
-	tape := byteutil.PaddingTape(e.environ.GetTemp(byteutil.ToHex(left)), e.tapeSize)
-	item := byteutil.ExtractSignificantBytes(e.environ.GetTemp(byteutil.ToHex(right)))
+func (e *Evaluator) EvaluatePull(label []byte, left, right ir.Operand) error {
+	tape := byteutil.PaddingTape(e.value(left), e.tapeSize)
+	item := byteutil.ExtractSignificantBytes(e.value(right))
 
 	shifted := make([]byte, 0, len(tape)+len(item))
 	shifted = append(shifted, tape...)
@@ -235,9 +247,9 @@ func (e *Evaluator) EvaluatePull(label, left, right []byte) error {
 }
 
 // EvaluatePush shifts the tape right and lets the item in at the left end.
-func (e *Evaluator) EvaluatePush(label, left, right []byte) error {
-	tape := byteutil.PaddingTape(e.environ.GetTemp(byteutil.ToHex(left)), e.tapeSize)
-	item := byteutil.ExtractSignificantBytes(e.environ.GetTemp(byteutil.ToHex(right)))
+func (e *Evaluator) EvaluatePush(label []byte, left, right ir.Operand) error {
+	tape := byteutil.PaddingTape(e.value(left), e.tapeSize)
+	item := byteutil.ExtractSignificantBytes(e.value(right))
 
 	shifted := make([]byte, 0, len(tape)+len(item))
 	shifted = append(shifted, item...)
@@ -292,9 +304,9 @@ func (e *Evaluator) EvaluatePullOver(label []byte, operands []ir.Operand) error 
 	return nil
 }
 
-func (e *Evaluator) EvaluateJoin(label, left, right []byte) error {
-	run := e.environ.GetTemp(byteutil.ToHex(left))
-	tape := byteutil.PaddingTape(e.environ.GetTemp(byteutil.ToHex(right)), e.tapeSize)
+func (e *Evaluator) EvaluateJoin(label []byte, left, right ir.Operand) error {
+	run := e.value(left)
+	tape := byteutil.PaddingTape(e.value(right), e.tapeSize)
 
 	joined := make([]byte, 0, len(run)+len(tape))
 	joined = append(joined, run...)
@@ -311,9 +323,9 @@ func (e *Evaluator) EvaluateJoin(label, left, right []byte) error {
 // Reading past the end gives the neutral value rather than failing, the same answer feed
 // gives past the end of what was applied: an operation on tapes does not stop a running
 // program.
-func (e *Evaluator) EvaluateField(label, left, right []byte) error {
-	run := e.environ.GetTemp(byteutil.ToHex(left))
-	start := int(byteutil.ToUint64(right)) * e.tapeSize
+func (e *Evaluator) EvaluateField(label []byte, left, right ir.Operand) error {
+	run := e.value(left)
+	start := int(byteutil.ToUint64(right.Bytes())) * e.tapeSize
 
 	value := byteutil.FalseTape(e.tapeSize)
 	if start >= 0 && start+e.tapeSize <= len(run) {
@@ -325,7 +337,7 @@ func (e *Evaluator) EvaluateField(label, left, right []byte) error {
 	return nil
 }
 
-func (e *Evaluator) EvaluateHead(label, left, right []byte) error {
+func (e *Evaluator) EvaluateHead(label []byte, left, right ir.Operand) error {
 	significant, n := e.tapeSlice(left, right)
 	e.environ.SetTemp(byteutil.ToHex(label), byteutil.PaddingTape(significant[:n], e.tapeSize))
 	e.IncrementCursor()
@@ -333,7 +345,7 @@ func (e *Evaluator) EvaluateHead(label, left, right []byte) error {
 }
 
 // EvaluateTail drops the first n significant bytes of the tape and keeps the rest.
-func (e *Evaluator) EvaluateTail(label, left, right []byte) error {
+func (e *Evaluator) EvaluateTail(label []byte, left, right ir.Operand) error {
 	significant, n := e.tapeSlice(left, right)
 	e.environ.SetTemp(byteutil.ToHex(label), byteutil.PaddingTape(significant[n:], e.tapeSize))
 	e.IncrementCursor()
@@ -342,12 +354,12 @@ func (e *Evaluator) EvaluateTail(label, left, right []byte) error {
 
 // tapeSlice reads the tape under left and the index under right, and returns the tape's
 // significant bytes with the index already normalized into them.
-func (e *Evaluator) tapeSlice(left, right []byte) ([]byte, int) {
-	tape := byteutil.PaddingTape(e.environ.GetTemp(byteutil.ToHex(left)), e.tapeSize)
+func (e *Evaluator) tapeSlice(left, right ir.Operand) ([]byte, int) {
+	tape := byteutil.PaddingTape(e.value(left), e.tapeSize)
 	significant := byteutil.ExtractSignificantBytes(tape)
 
-	// The index is a literal operand, not a temp: the emitter writes it inline.
-	n := int(byteutil.ToUint64(right) % uint64(e.tapeSize))
+	// The index is what the operation takes about itself, not a value: it is written inline.
+	n := int(byteutil.ToUint64(right.Bytes()) % uint64(e.tapeSize))
 	if n > len(significant) {
 		n = len(significant)
 	}
@@ -360,15 +372,15 @@ func (e *Evaluator) tapeSlice(left, right []byte) ([]byte, int) {
 // What comes back is the value of the expression. Everything in Aurora answers with
 // something, and a print used to be the exception — it left nothing under its label, which is
 // why a line of "printd 42" in the REPL showed no value at all.
-func (e *Evaluator) EvaluatePrintBytes(label, left []byte) error {
+func (e *Evaluator) EvaluatePrintBytes(label []byte, left ir.Operand) error {
 	return e.print(e.printBytes, label, left)
 }
 
-func (e *Evaluator) EvaluatePrintChars(label, left []byte) error {
+func (e *Evaluator) EvaluatePrintChars(label []byte, left ir.Operand) error {
 	return e.print(e.printChars, label, left)
 }
 
-func (e *Evaluator) EvaluatePrintDecimal(label, left []byte) error {
+func (e *Evaluator) EvaluatePrintDecimal(label []byte, left ir.Operand) error {
 	return e.print(e.printDecimal, label, left)
 }
 
@@ -376,8 +388,8 @@ func (e *Evaluator) EvaluatePrintDecimal(label, left []byte) error {
 //
 // The error is returned rather than dropped: writing used to be "_, _ =", so a program whose
 // output went nowhere — a closed pipe — carried on as if it had been heard.
-func (e *Evaluator) print(printer Printer, label, left []byte) error {
-	val := e.environ.GetTemp(byteutil.ToHex(left))
+func (e *Evaluator) print(printer Printer, label []byte, left ir.Operand) error {
+	val := e.value(left)
 	if printer == nil {
 		return fmt.Errorf("no printer was given for this reading")
 	}
@@ -392,8 +404,8 @@ func (e *Evaluator) print(printer Printer, label, left []byte) error {
 	return nil
 }
 
-func (e *Evaluator) EvaluateSave(label, left, right []byte) error {
-	e.environ.SetTemp(byteutil.ToHex(label), left)
+func (e *Evaluator) EvaluateSave(label []byte, left, right ir.Operand) error {
+	e.environ.SetTemp(byteutil.ToHex(label), left.Bytes())
 	e.IncrementCursor()
 	return nil
 }
@@ -425,18 +437,18 @@ func (e *Evaluator) resolve(name []byte) ([]byte, *environ.Environ) {
 	return home.GetLocalIdent(key), home
 }
 
-func (e *Evaluator) EvaluateLoad(label, left, right []byte) error {
-	val, _ := e.resolve(left)
+func (e *Evaluator) EvaluateLoad(label []byte, left, right ir.Operand) error {
+	val, _ := e.resolve(left.Bytes())
 	if val == nil {
-		return fmt.Errorf("identifier %s not found", left)
+		return fmt.Errorf("identifier %s not found", left.Bytes())
 	}
 	e.environ.SetTemp(byteutil.ToHex(label), val)
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateIf(label, left, right []byte) error {
-	test := byteutil.ToBoolean(e.environ.GetTemp(byteutil.ToHex(left)))
+func (e *Evaluator) EvaluateIf(label []byte, left, right ir.Operand) error {
+	test := byteutil.ToBoolean(e.value(left))
 	next := environ.NewEnviron(environ.NewEnvironOptions{})
 	next.SetArguments(e.environ.GetArguments())
 	e.environ = e.environ.Ahead(next)
@@ -444,25 +456,25 @@ func (e *Evaluator) EvaluateIf(label, left, right []byte) error {
 		e.cursor++
 		return nil
 	}
-	e.AddCursor(byteutil.ToUint64(right) + 1)
+	e.AddCursor(byteutil.ToUint64(right.Bytes()) + 1)
 	return nil
 }
 
-func (e *Evaluator) EvaluateJump(label, left, right []byte) error {
-	e.AddCursor(byteutil.ToUint64(left) + 1)
+func (e *Evaluator) EvaluateJump(label []byte, left, right ir.Operand) error {
+	e.AddCursor(byteutil.ToUint64(left.Bytes()) + 1)
 	return nil
 }
 
-func (e *Evaluator) EvaluateBeginScope(label, left, right []byte) error {
+func (e *Evaluator) EvaluateBeginScope(label []byte, left, right ir.Operand) error {
 	next := environ.NewEnviron(environ.NewEnvironOptions{})
 	e.environ = e.environ.Ahead(next)
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateReturn(_, left, right []byte) error {
-	label := byteutil.ToHex(left)
-	value := e.environ.GetTemp(byteutil.ToHex(right))
+func (e *Evaluator) EvaluateReturn(_ []byte, left, right ir.Operand) error {
+	label := byteutil.ToHex(left.Bytes())
+	value := e.value(right)
 	if value == nil {
 		value = byteutil.FalseTape(e.tapeSize)
 	}
@@ -472,20 +484,20 @@ func (e *Evaluator) EvaluateReturn(_, left, right []byte) error {
 	return nil
 }
 
-func (e *Evaluator) EvaluateIdent(label, left, right []byte) error {
-	k := byteutil.ToHex(left)
+func (e *Evaluator) EvaluateIdent(label []byte, left, right ir.Operand) error {
+	k := byteutil.ToHex(left.Bytes())
 	if v := e.environ.GetLocalIdent(k); v != nil {
-		return fmt.Errorf("conflict between identifiers named %s", left)
+		return fmt.Errorf("conflict between identifiers named %s", left.Bytes())
 	}
-	val := e.environ.GetTemp(byteutil.ToHex(right))
+	val := e.value(right)
 	e.environ.SetIdent(k, val)
 	e.environ.SetTemp(byteutil.ToHex(label), byteutil.FalseTape(e.tapeSize))
 	e.IncrementCursor()
 	return nil
 }
 
-func (e *Evaluator) EvaluateGetArg(label, left, right []byte) error {
-	index := byteutil.ToUint64(left)
+func (e *Evaluator) EvaluateGetArg(label []byte, left, right ir.Operand) error {
+	index := byteutil.ToUint64(left.Bytes())
 	v := builtin.FeedFunction(e.environ.GetArguments(), index, e.tapeSize)
 	l := byteutil.ToHex(label)
 	e.environ.SetTemp(l, v)
@@ -493,12 +505,12 @@ func (e *Evaluator) EvaluateGetArg(label, left, right []byte) error {
 	return nil
 }
 
-func (e *Evaluator) EvaluateDefer(label, left, right []byte) error {
-	bodylength := byteutil.ToUint64(right)
+func (e *Evaluator) EvaluateDefer(label []byte, left, right ir.Operand) error {
+	bodylength := byteutil.ToUint64(right.Bytes())
 	// e.cursor is the index of this OpDefer; the next instruction is the start of the deferred block (OpBeginScope).
 	from := e.cursor + 1
 	to := from + bodylength // index of OpReturn (last instruction of the block)
-	returnKey := byteutil.ToHex(left)
+	returnKey := byteutil.ToHex(left.Bytes())
 
 	// The value of a defer is its index as a tape, like every other value in the language.
 	// It used to be the hex key itself — 16 bytes of ASCII text that ignored the tape size.
@@ -553,10 +565,10 @@ func (e *Evaluator) EvaluateCallOver(label []byte, operands []ir.Operand) error 
 // EvaluateAssert checks a condition, but only under a runner that asked for it. A plain
 // run consumes the operands and moves on: assertions belong to "aurora test", and a
 // program that happens to hold one should not fail because of it.
-func (e *Evaluator) EvaluateAssert(label, left, right []byte) error {
-	cond := e.environ.GetTemp(byteutil.ToHex(left))
+func (e *Evaluator) EvaluateAssert(label []byte, left, right ir.Operand) error {
+	cond := e.value(left)
 	// The message is written inline by the emitter, not held in a temp.
-	msg := string(right)
+	msg := string(right.Bytes())
 
 	if !e.asserts {
 		e.environ.SetTemp(byteutil.ToHex(label), byteutil.FalseTape(e.tapeSize))
@@ -609,7 +621,7 @@ func (e *Evaluator) AddCursor(offset uint64) {
 
 // operation is what an opcode runs: the label the result is written under, and the two
 // operands the emitter wrote beside it.
-type operation func(e *Evaluator, label, left, right []byte) error
+type operation func(e *Evaluator, label []byte, left, right ir.Operand) error
 
 // Which operation each opcode runs.
 //
@@ -644,13 +656,13 @@ func init() {
 
 		// Builtins. A print reads one operand, and the opcode is the whole difference between
 		// the three readings of it.
-		ir.OpPrintBytes: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintBytes: func(e *Evaluator, label []byte, left, _ ir.Operand) error {
 			return e.EvaluatePrintBytes(label, left)
 		},
-		ir.OpPrintChars: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintChars: func(e *Evaluator, label []byte, left, _ ir.Operand) error {
 			return e.EvaluatePrintChars(label, left)
 		},
-		ir.OpPrintDecimal: func(e *Evaluator, label, left, _ []byte) error {
+		ir.OpPrintDecimal: func(e *Evaluator, label []byte, left, _ ir.Operand) error {
 			return e.EvaluatePrintDecimal(label, left)
 		},
 
@@ -718,7 +730,7 @@ func (e *Evaluator) ExecuteInstruction(inst ir.Instruction) error {
 		e.IncrementCursor()
 		return nil
 	}
-	return op(e, inst.GetLabel(), inst.GetLeft().Bytes(), inst.GetRight().Bytes())
+	return op(e, inst.GetLabel(), inst.GetLeft(), inst.GetRight())
 }
 
 func (e *Evaluator) ExecuteInstructions(from, to uint64) (eval.Returns, error) {

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -39,7 +39,7 @@ func TestEvaluateAdd(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(1))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(2))
-	if err := ev.EvaluateAdd([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateAdd([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating add: %v", err)
 		return
 	}
@@ -54,7 +54,7 @@ func TestEvaluateSubtract(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateSubtract([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateSubtract([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating subtract: %v", err)
 		return
 	}
@@ -69,7 +69,7 @@ func TestEvaluateMultiply(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateMultiply([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateMultiply([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating multiply: %v", err)
 		return
 	}
@@ -84,7 +84,7 @@ func TestEvaluateDivide(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateDivide([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateDivide([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating divide: %v", err)
 		return
 	}
@@ -99,7 +99,7 @@ func TestEvaluateExponential(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(3))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(3))
-	if err := ev.EvaluateExponential([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateExponential([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating exponential: %v", err)
 		return
 	}
@@ -114,7 +114,7 @@ func TestEvaluateDiff(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateDiff([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateDiff([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating diff: %v", err)
 		return
 	}
@@ -129,7 +129,7 @@ func TestEvaluateEquals(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateEquals([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateEquals([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating equals: %v", err)
 		return
 	}
@@ -144,7 +144,7 @@ func TestEvaluateBigger(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateBigger([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateBigger([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating bigger: %v", err)
 		return
 	}
@@ -159,7 +159,7 @@ func TestEvaluateSmaller(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FromUint64(2))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FromUint64(1))
-	if err := ev.EvaluateSmaller([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateSmaller([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating smaller: %v", err)
 		return
 	}
@@ -174,7 +174,7 @@ func TestEvaluateAnd(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.TrueTape(byteutil.DefaultTapeSize))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.TrueTape(byteutil.DefaultTapeSize))
-	if err := ev.EvaluateAnd([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateAnd([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating and: %v", err)
 		return
 	}
@@ -189,7 +189,7 @@ func TestEvaluateAnd_False(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.TrueTape(byteutil.DefaultTapeSize))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FalseTape(byteutil.DefaultTapeSize))
-	if err := ev.EvaluateAnd([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateAnd([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating and: %v", err)
 		return
 	}
@@ -204,7 +204,7 @@ func TestEvaluateOr(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FalseTape(byteutil.DefaultTapeSize))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.TrueTape(byteutil.DefaultTapeSize))
-	if err := ev.EvaluateOr([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateOr([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating or: %v", err)
 		return
 	}
@@ -219,7 +219,7 @@ func TestEvaluateOr_False(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FalseTape(byteutil.DefaultTapeSize))
 	ev.environ.SetTemp(byteutil.ToHex([]byte("01")), byteutil.FalseTape(byteutil.DefaultTapeSize))
-	if err := ev.EvaluateOr([]byte("02"), []byte("00"), []byte("01")); err != nil {
+	if err := ev.EvaluateOr([]byte("02"), ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))); err != nil {
 		t.Errorf("Error evaluating or: %v", err)
 		return
 	}
@@ -233,7 +233,7 @@ func TestEvaluateOr_False(t *testing.T) {
 func TestEvaluateSave(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	val := byteutil.FromUint64(42)
-	if err := ev.EvaluateSave([]byte("00"), val, nil); err != nil {
+	if err := ev.EvaluateSave([]byte("00"), ir.RefTo(val), ir.Nothing()); err != nil {
 		t.Errorf("Error evaluating save: %v", err)
 		return
 	}
@@ -247,7 +247,7 @@ func TestEvaluateLoad(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	expected := byteutil.FromUint64(13)
 	ev.environ.SetIdent(byteutil.ToHex([]byte("00")), expected)
-	if err := ev.EvaluateLoad([]byte("01"), []byte("00"), nil); err != nil {
+	if err := ev.EvaluateLoad([]byte("01"), ir.RefTo([]byte("00")), ir.Nothing()); err != nil {
 		t.Errorf("Error evaluating load: %v", err)
 		return
 	}
@@ -264,7 +264,7 @@ func TestEvaluateReturn(t *testing.T) {
 
 	expected := byteutil.FromUint64(100)
 	ev.environ.SetTemp(byteutil.ToHex([]byte("00")), expected)
-	if err := ev.EvaluateReturn([]byte("01"), []byte("02"), []byte("00")); err != nil {
+	if err := ev.EvaluateReturn([]byte("01"), ir.RefTo([]byte("02")), ir.RefTo([]byte("00"))); err != nil {
 		t.Errorf("Error evaluating return: %v", err)
 		return
 	}
@@ -282,7 +282,7 @@ func TestEvaluateGetArg(t *testing.T) {
 	ev := New(NewEvaluatorOptions{
 		Args: args,
 	})
-	if err := ev.EvaluateGetArg([]byte("00"), byteutil.FromUint64(0), nil); err != nil {
+	if err := ev.EvaluateGetArg([]byte("00"), ir.RefTo(byteutil.FromUint64(0)), ir.Nothing()); err != nil {
 		t.Errorf("Error evaluating get arg: %v", err)
 		return
 	}
@@ -300,7 +300,7 @@ func TestEvaluateIf(t *testing.T) {
 		ev := New(NewEvaluatorOptions{})
 		ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.TrueTape(byteutil.DefaultTapeSize))
 		ev.cursor = 0
-		if err := ev.EvaluateIf([]byte("01"), []byte("00"), byteutil.FromUint64(10)); err != nil {
+		if err := ev.EvaluateIf([]byte("01"), ir.RefTo([]byte("00")), ir.RefTo(byteutil.FromUint64(10))); err != nil {
 			t.Errorf("Error evaluating if: %v", err)
 			return
 		}
@@ -313,7 +313,7 @@ func TestEvaluateIf(t *testing.T) {
 		ev := New(NewEvaluatorOptions{})
 		ev.environ.SetTemp(byteutil.ToHex([]byte("00")), byteutil.FalseTape(byteutil.DefaultTapeSize))
 		ev.cursor = 0
-		if err := ev.EvaluateIf([]byte("01"), []byte("00"), byteutil.FromUint64(3)); err != nil {
+		if err := ev.EvaluateIf([]byte("01"), ir.RefTo([]byte("00")), ir.RefTo(byteutil.FromUint64(3))); err != nil {
 			t.Errorf("Error evaluating if: %v", err)
 			return
 		}
@@ -326,7 +326,7 @@ func TestEvaluateIf(t *testing.T) {
 func TestEvaluateJump(t *testing.T) {
 	ev := New(NewEvaluatorOptions{})
 	ev.cursor = 0
-	if err := ev.EvaluateJump([]byte("00"), byteutil.FromUint64(2), nil); err != nil {
+	if err := ev.EvaluateJump([]byte("00"), ir.RefTo(byteutil.FromUint64(2)), ir.Nothing()); err != nil {
 		t.Errorf("Error evaluating jump: %v", err)
 		return
 	}
@@ -342,7 +342,7 @@ func TestEvaluateJump(t *testing.T) {
 func TestEvaluatePrintHandsOverTheWholeValue(t *testing.T) {
 	cases := []struct {
 		name  string
-		print func(ev *Evaluator, label, left []byte) error
+		print func(ev *Evaluator, label []byte, left ir.Operand) error
 		port  func(p *recorder) NewEvaluatorOptions
 	}{
 		{
@@ -370,7 +370,7 @@ func TestEvaluatePrintHandsOverTheWholeValue(t *testing.T) {
 			ev := New(tc.port(printer))
 			ev.environ.SetTemp(byteutil.ToHex([]byte("00")), reel)
 
-			if err := tc.print(ev, []byte("01"), []byte("00")); err != nil {
+			if err := tc.print(ev, []byte("01"), ir.RefTo([]byte("00"))); err != nil {
 				t.Fatalf("%s: %v", tc.name, err)
 			}
 			if !bytes.Equal(printer.seen, reel) {


### PR DESCRIPTION
Preparação. **Nada muda no que um programa responde** — o emitter ainda não escreve um `Imm` em posição de valor, e é isto que precisa ser verdade antes que ele possa.

## O que havia

As 26 funções `Evaluate*` recebiam os operandos como bytes e cada uma procurava o seu:

```go
func (e *Evaluator) EvaluateAdd(label, left, right []byte) error {
	x, y := e.operands(left, right)   // e.operands faz GetTemp(ToHex(...)) nos dois
```

Ler um operando estava escrito vinte e seis vezes, e ler de outro jeito não era possível.

## O que passa a haver

Elas recebem os operandos, e **um lugar só** diz o que um vale:

```go
// value answers what an operand is worth.
//
// A Ref names a value another instruction left behind, so it is looked up. An Imm is the
// value: the program wrote it down and there is nothing to look up.
func (e *Evaluator) value(operand ir.Operand) []byte {
	if operand.Kind() == ir.KindImm {
		return operand.Bytes()
	}
	return e.environ.GetTemp(byteutil.ToHex(operand.Bytes()))
}
```

## Uma coisa que o teste de documentação pegou

`"identifier x not found"` tinha virado `"identifier name 0x78 not found"` — porque um operando sabe se imprimir, e a mensagem queria o nome de dentro dele. `docs_test.go` executa os blocos da documentação e compara a mensagem, então ele viu:

```
docs/defer_scope_visibility.md:41 says it fails with "identifier x not found",
and it failed with "identifier name 0x78 not found"
```

É a regra do `CLAUDE.md` — *"an integration test for anything the user perceives"* — pagando.

## Por que só a preparação

A dobra em si (`a + 10` emitindo uma instrução em vez de duas) foi implementada e revertida: ela quebra **114 casos em seis pacotes**, porque o backend conta com `OpSave` virar um `PUSH` e não há mais `OpSave`. Materializar um `Imm` no backend é decidir **onde** empilhar, que é escalonamento de pilha — a área que o `CLAUDE.md` põe em stand-by.

Fica registrado em RFC própria.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)