### PR TITLE
fix: a name bound inside a scope is announced

### DIFF
--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"fmt"
 
+	"github.com/guiferpa/aurora/byteutil"
 	"github.com/guiferpa/aurora/wire/diag"
 	"github.com/guiferpa/aurora/wire/ir"
 )
@@ -18,6 +19,11 @@ import (
 //
 // OpDefer and OpBeginScope write nothing of their own and are not gaps: the first becomes an
 // entry in the dispatcher, and the second opens a scope the builder lays out flat.
+//
+// OpIdent is here for the one it does carry — the binding that names a deferred scope, which
+// the dispatcher reads as a selector. The one inside a scope it does not, and that is what
+// bindingsInsideScopes answers for: a per-opcode list cannot tell the two apart, because
+// which one it is depends on where the instruction sits.
 var handled = map[byte]bool{
 	ir.OpAdd:        true,
 	ir.OpSubtract:   true,
@@ -66,6 +72,45 @@ var pending = map[byte]string{
 	ir.OpField: "shape",
 }
 
+// bindingInsideAScope reports the first name bound inside a deferred scope, if there is one.
+//
+// It is its own walk because the list of handled opcodes cannot answer it. An OpIdent at the
+// top of a program names a deferred scope and becomes a selector the dispatcher reads; the
+// same opcode inside a scope stores a value, and the lowering hands that value to nothing, so
+// the MSTORE writing it finds an empty stack. Which one an instruction is depends on where it
+// sits, and a map keyed by opcode has no way to see that.
+//
+// Until now the map said OpIdent was handled and nothing was said at all: a scope binding a
+// name compiled, deployed, and answered a different number than the same program answers off
+// the chain. That is the worst outcome this file exists to prevent, and it was the one case
+// getting past it.
+func bindingInsideAScope(insts []ir.Instruction) (diag.Warning, bool) {
+	// A defer says how many instructions its body is, so its range is what has to be looked
+	// inside. Bodies nest, and the deepest end is what closes the outermost — a body that
+	// holds a defer holds that defer's body too.
+	end := 0
+	for at, inst := range insts {
+		switch inst.GetOpCode() {
+		case ir.OpDefer:
+			body := at + 1 + int(byteutil.ToUint64(inst.GetRight().Bytes()))
+			if body > end {
+				end = body
+			}
+		case ir.OpIdent:
+			if at >= end {
+				continue
+			}
+			warning := diag.Warning{Message: "a name bound inside a scope does not reach the bytecode: " +
+				"the value it stores is dropped, and the contract answers something else than the program does"}
+			if origin := inst.GetOrigin(); origin.Known() {
+				warning.Line, warning.Column = origin.Line, origin.Column
+			}
+			return warning, true
+		}
+	}
+	return diag.Warning{}, false
+}
+
 // Warnings reports what a program uses that does not reach the bytecode.
 //
 // They are warnings and not errors because the backend is being written in slices: refusing
@@ -79,6 +124,10 @@ var pending = map[byte]string{
 func Warnings(insts []ir.Instruction) []diag.Warning {
 	warnings := make([]diag.Warning, 0)
 	said := make(map[string]bool)
+
+	if warning, found := bindingInsideAScope(insts); found {
+		warnings = append(warnings, warning)
+	}
 
 	for _, inst := range insts {
 		op := inst.GetOpCode()

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -211,3 +211,55 @@ func TestEveryPendingFeatureNamesItsPlace(t *testing.T) {
 		})
 	}
 }
+
+// A name bound inside a scope compiles to an MSTORE with nothing under it: the lowering hands
+// the value to arithmetic and to a return and to nothing else, so the one the binding meant to
+// store is dropped. The contract answers a different number than the program does — "ident x =
+// feed(0); x + feed(1);" applied to 3 and 4 answers 7 off the chain and 4 on it.
+//
+// That is known and it is not this file's to fix. What is this file's is that it used to say
+// nothing: the map of handled opcodes claimed OpIdent, because the binding that names a
+// deferred scope is handled, and a map keyed by opcode cannot tell that one from this one.
+func TestABindingInsideAScopeIsAnnounced(t *testing.T) {
+	const source = "ident sum = defer {\n  ident x = feed(0);\n  x + feed(1);\n};"
+
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("lexer: %v", err)
+	}
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	if err != nil {
+		t.Fatalf("parser: %v", err)
+	}
+	insts, err := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
+	if err != nil {
+		t.Fatalf("emitter: %v", err)
+	}
+
+	for _, warning := range Warnings(insts) {
+		if !strings.Contains(warning.Message, "bound inside a scope") {
+			continue
+		}
+		if warning.Line != 2 {
+			t.Errorf("it points at line %d, want the line the name was bound on", warning.Line)
+		}
+		return
+	}
+	t.Fatal("nothing warned about the binding")
+}
+
+// The binding that names a deferred scope is handled — the dispatcher reads it as a selector —
+// so a program doing only that hears nothing about it.
+func TestABindingThatNamesAScopeIsNotAnnounced(t *testing.T) {
+	const source = "ident sum = defer { feed(0) + feed(1); };"
+
+	tokens, _ := lexer.New().GetFilledTokens([]byte(source))
+	tree, _ := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	insts, _ := emitter.New(emitter.NewEmitterOptions{}).Emit(tree)
+
+	for _, warning := range Warnings(insts) {
+		if strings.Contains(warning.Message, "bound inside a scope") {
+			t.Errorf("it warned about a binding that is handled: %q", warning.Message)
+		}
+	}
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -133,6 +133,12 @@ using any of the following **compiles successfully and does nothing on chain**.
 - Jump targets and memory offsets are written with `PUSH1`, which caps a runtime at 256
   bytes and identifiers at about seven memory slots. `PUSH2` lifts it.
 
+A name bound inside a scope is the one the compiler now names too. It compiles to an `MSTORE`
+with nothing under it, so the contract answers a different number than the program does — and
+until this it said nothing, because the list of what the builder handles is keyed by opcode and
+the binding that names a deferred scope is handled. Which one an `OpIdent` is depends on where
+it sits, and a map cannot see that.
+
 `aurora build` now **says what it could not carry**, once per feature, in the order the
 program uses it, and names the line the program first used it on — so a binary that does less
 than the source said is announced, in the form an editor follows.


### PR DESCRIPTION
## O que estava acontecendo

```
ident sum = defer {
  ident x = feed(0);
  x + feed(1);
};
```

Aplicado a 3 e 4, isso responde **7 fora da cadeia e 4 nela**. Medi com o harness diferencial.

A quebra em si é conhecida e está escrita no `CLAUDE.md`: a ligação compila para um `MSTORE` com nada embaixo, porque o lowering entrega o valor para a aritmética e para o retorno e para mais nada.

**O que não estava escrito é que o compilador não dizia nada.**

## Por que ele calava

`support.go` decide o que avisar por um mapa de opcodes, e ele reivindicava `OpIdent` — **corretamente**, para a ligação que dá nome a um escopo diferido, que o dispatcher lê como seletor.

Só que um `OpIdent` no topo de um programa e um dentro de um escopo são coisas diferentes, e **qual é qual depende de onde a instrução está**. Um mapa indexado por opcode não enxerga isso.

Resultado: o único caso que passava pelos avisos era justamente o que responde **errado**, em vez de responder **nada** — que é o pior dos dois. O comentário no topo daquele arquivo diz que é isso que ele existe para impedir.

## O que muda

Um passeio próprio, que sabe até onde vai o corpo de um `defer`, e avisa na linha onde o nome foi ligado:

```
main.ar:2:9: warning: a name bound inside a scope does not reach the bytecode: the value it
stores is dropped, and the contract answers something else than the program does
```

Dois testes: um que o aviso aparece com a posição certa, e um que a ligação que **nomeia** um escopo continua não avisando — senão todo programa ouviria falso alarme.

## O que este PR não faz

**Não conserta a divergência.** Ela é uma das duas coisas de tamanho de desenho pelas quais o backend está em stand-by, e o `CLAUDE.md` é explícito em que aquilo se abre deliberadamente e depois de conversa.

O que ele faz é o programa deixar de sair calado.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)