### PR TITLE
fix: a contract is not published cut short

### DIFF
--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -43,8 +43,9 @@ func TestBuildStartsWithTheInstantiateBlock(t *testing.T) {
 	if len(code) <= INSTANTIATE_BLOCK_SIZE {
 		t.Fatalf("bytecode is %d bytes, too short to hold the instantiate block", len(code))
 	}
-	// PUSH1 <size> PUSH1 0x0c PUSH1 0x00 CODECOPY PUSH1 <size> PUSH1 0x00 RETURN
-	want := []byte{OpPush1, byte(len(code) - INSTANTIATE_BLOCK_SIZE), OpPush1, 0x0c, OpPush1, 0x00, OpCodeCopy}
+	// PUSH2 <size> PUSH1 <this block> PUSH1 0x00 CODECOPY PUSH2 <size> PUSH1 0x00 RETURN
+	runtime := len(code) - INSTANTIATE_BLOCK_SIZE
+	want := []byte{OpPush2, byte(runtime >> 8), byte(runtime), OpPush1, INSTANTIATE_BLOCK_SIZE, OpPush1, 0x00, OpCodeCopy}
 	if !bytes.Equal(code[:len(want)], want) {
 		t.Errorf("instantiate block = %s, want %s",
 			byteutil.ToUpperHex(code[:len(want)]), byteutil.ToUpperHex(want))
@@ -69,7 +70,8 @@ func TestBuildAnnouncesTheRuntimeSize(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
 			code := build(t, tc.source, byteutil.DefaultTapeSize)
-			announced := int(code[1])
+			// Two bytes, big-endian, right after the PUSH2.
+			announced := int(code[1])<<8 | int(code[2])
 			if got := len(code) - INSTANTIATE_BLOCK_SIZE; announced != got {
 				t.Errorf("the block announces %d runtime bytes, %d follow", announced, got)
 			}

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -8,6 +8,7 @@ package evm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/guiferpa/aurora/byteutil"
@@ -20,7 +21,18 @@ const (
 	NO_MATCH_DISPATCHER_SIZE = 1
 	CALLDATA_SLOT_READABLE   = 32
 	MEMORY_SLOT_SIZE         = 32
-	INSTANTIATE_BLOCK_SIZE   = 12
+	// PUSH_ONE_SIZE and PUSH_TWO_SIZE are the opcode and what it carries.
+	PUSH_ONE_SIZE = 2
+	PUSH_TWO_SIZE = 3
+	// INSTANTIATE_BLOCK_SIZE is what the constructor measures, and the runtime begins right
+	// after it — so the block carries this number inside itself, as the offset it copies
+	// from. It is added up here rather than written as a literal, because it was the same
+	// number in two places and a push changing size meant remembering both.
+	INSTANTIATE_BLOCK_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1 + PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
+	// MAX_CONTRACT_SIZE is what a chain will keep: 24,576 bytes, by EIP-170. A runtime past
+	// it is refused rather than written, because writing it produces a binary that deploys
+	// and is not the program.
+	MAX_CONTRACT_SIZE = 24576
 )
 
 type Dispatcher struct {
@@ -147,7 +159,12 @@ func (b *Builder) Build() ([]byte, error) {
 
 	out := bytes.NewBuffer(make([]byte, 0))
 
-	if _, err := WriteInstantiateBlock(out, byte(GetRuntimeCodeLength(rc))); err != nil {
+	runtimeSize := GetRuntimeCodeLength(rc)
+	if runtimeSize > MAX_CONTRACT_SIZE {
+		return nil, fmt.Errorf("the runtime is %d bytes and a chain keeps at most %d: this program cannot be deployed", runtimeSize, MAX_CONTRACT_SIZE)
+	}
+
+	if _, err := WriteInstantiateBlock(out, runtimeSize); err != nil {
 		return nil, err
 	}
 

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -127,26 +127,46 @@ func WriteStop(w io.Writer) (int, error) {
 	return w.Write([]byte{OpStop})
 }
 
-func WriteInstantiateBlock(w io.Writer, runtimeSize byte) (int, error) {
-	if _, err := w.Write([]byte{OpPush1, runtimeSize}); err != nil { // 2 bytes
+// WritePush2 emits PUSH2 with a number in two bytes, big-endian.
+//
+// Two bytes because one is not enough and three would never be: a published contract cannot
+// pass 24,576 bytes (EIP-170), so every length and every address inside a legal one fits in
+// 65,535. There is no size after this one.
+func WritePush2(w io.Writer, n int) (int, error) {
+	return w.Write([]byte{OpPush2, byte(n >> 8), byte(n)})
+}
+
+// WriteInstantiateBlock emits the constructor: it copies the runtime out of the code being
+// deployed and hands it to the chain, which is what the chain then keeps.
+//
+// The size is pushed in two bytes. It used to be one, and a runtime past 255 bytes was
+// truncated by the conversion — a program with three deferred scopes reached that — so the
+// constructor asked for 96 bytes of a contract that had 352. It deployed, and what the chain
+// kept was cut off in the middle of an instruction.
+//
+// The offset it copies from is this block's own length, since the runtime begins right after
+// it. That number is derived rather than written down twice: the two used to be the same
+// literal in two places, and changing a push meant remembering both.
+func WriteInstantiateBlock(w io.Writer, runtimeSize int) (int, error) {
+	if _, err := WritePush2(w, runtimeSize); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpPush1, 0x0c}); err != nil { // 2 bytes
+	if _, err := w.Write([]byte{OpPush1, byte(INSTANTIATE_BLOCK_SIZE)}); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil { // 2 bytes
+	if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpCodeCopy}); err != nil { // 1 byte
+	if _, err := w.Write([]byte{OpCodeCopy}); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpPush1, runtimeSize}); err != nil { // 2 bytes
+	if _, err := WritePush2(w, runtimeSize); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil { // 2 bytes
+	if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil {
 		return 0, err
 	}
-	return w.Write([]byte{OpReturn}) // 1 byte
+	return w.Write([]byte{OpReturn})
 }
 
 func WriteNoMatchDispatcher(w io.Writer) (int, error) {

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -7,25 +7,44 @@ import (
 	"github.com/guiferpa/aurora/byteutil"
 )
 
+// The constructor copies the runtime out of the code being deployed and hands it to the chain.
+// The size goes in two bytes, and the offset it copies from is this block's own length —
+// written once, in the constant, and read here rather than repeated.
 func TestWriteInstantiateBlock(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
-	runtimeSize := byte(8)
-	if _, err := WriteInstantiateBlock(bs, runtimeSize); err != nil {
-		t.Errorf("Error writing instantiate block: %v", err)
-		return
+	if _, err := WriteInstantiateBlock(bs, 8); err != nil {
+		t.Fatalf("writing the instantiate block: %v", err)
 	}
-	got := bs.Bytes()
+
 	expected := []byte{
-		OpPush1, runtimeSize,
-		OpPush1, 0x0c,
+		OpPush2, 0x00, 0x08,
+		OpPush1, INSTANTIATE_BLOCK_SIZE,
 		OpPush1, 0x00,
 		OpCodeCopy,
-		OpPush1, runtimeSize,
+		OpPush2, 0x00, 0x08,
 		OpPush1, 0x00,
 		OpReturn,
 	}
-	if !bytes.Equal(got, expected) {
-		t.Errorf("Instantiate block: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+	if got := bs.Bytes(); !bytes.Equal(got, expected) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+	}
+	if got := bs.Len(); got != INSTANTIATE_BLOCK_SIZE {
+		t.Errorf("the block measures %d and says it measures %d — the offset it copies from is its own length", got, INSTANTIATE_BLOCK_SIZE)
+	}
+}
+
+// A runtime past what one byte holds used to be truncated by the conversion, so the
+// constructor asked for 96 bytes of a contract that had 352 and the chain kept the first 96.
+// Three deferred scopes reached that.
+func TestARuntimePastOneByteIsWrittenWhole(t *testing.T) {
+	bs := bytes.NewBuffer(make([]byte, 0))
+	if _, err := WriteInstantiateBlock(bs, 352); err != nil {
+		t.Fatalf("writing the instantiate block: %v", err)
+	}
+
+	got := bs.Bytes()
+	if want := []byte{OpPush2, 0x01, 0x60}; !bytes.Equal(got[:3], want) {
+		t.Errorf("it copies %v bytes, want %v — 352, not 352 modulo 256", byteutil.ToUpperHex(got[:3]), byteutil.ToUpperHex(want))
 	}
 }
 

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -267,3 +267,19 @@ func TestAValueWrittenDownAnswersTheSameOnChainAndOff(t *testing.T) {
 		})
 	}
 }
+
+// A contract whose runtime is longer than a byte can count used to be published cut short.
+// The constructor pushed the size with PUSH1, so 352 bytes became 96 by conversion: it copied
+// 96 and the chain kept 96, of a contract that ended in the middle of an instruction. Three
+// deferred scopes with ordinary bodies reach that.
+//
+// What this proves is the constructor. It calls the first scope on purpose, because a
+// dispatcher still pushes its jump target with PUSH1 — the second of the three ceilings, and
+// not this one.
+func TestARuntimeLongerThanAByteIsPublishedWhole(t *testing.T) {
+	const source = `ident one = defer { feed(0) + feed(1) * 3 - feed(0) / 2; };
+ident two = defer { feed(0) + feed(1) * 5 - feed(0) / 2; };
+ident three = defer { feed(0) + feed(1) * 7 - feed(0) / 2; };`
+
+	agree(t, source, "one", []string{"6", "7"}, 0)
+}


### PR DESCRIPTION
O primeiro dos três tetos de `PUSH1` que o `CLAUDE.md` nomeia.

## O que acontecia

O construtor empurrava o tamanho do runtime com `PUSH1`, que carrega **um byte**:

```go
WriteInstantiateBlock(out, byte(GetRuntimeCodeLength(rc)))
```

Runtime de 352 bytes → `byte(352)` = **96**. Ele copiava 96, devolvia 96, e a cadeia guardava 96 bytes de um contrato que terminava no meio de uma instrução. **O deploy dava certo.**

## E não é canto

Medido: **dois escopos diferidos já dão 235 bytes de runtime.** No terceiro estoura.

```
2 escopos -> 235 bytes -> responde certo
3 escopos -> 352 bytes -> a cadeia respondeu 0 e o evaluator 10
```

## O que muda

Dois bytes, e **não existe um terceiro tamanho depois**: um contrato publicado não passa de 24.576 bytes (EIP-170), então todo comprimento dentro de um contrato legal cabe em 65.535.

Passando disso o builder **recusa** em vez de escrever — escrever produziria um binário que faz deploy e não é o programa, que é a falha que este PR existe para tirar.

## Um detalhe que estava duplicado

O offset de onde o construtor copia é **o tamanho deste mesmo bloco** — o runtime começa logo depois dele. Esse número estava escrito como literal (`0x0c`) num lugar e como constante (`INSTANTIATE_BLOCK_SIZE = 12`) noutro.

Agora é somado uma vez, das partes:

```go
INSTANTIATE_BLOCK_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1 + PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
```

Sem isso, trocar um push por `PUSH2` deixaria os dois discordando e o construtor copiaria a partir do lugar errado — a mesma falha calada, por outro caminho.

## O que este PR **não** faz

Os outros dois tetos continuam de pé:

- **o alvo de salto do dispatcher** ainda é `PUSH1`. Num contrato de 12 escopos, `scope0` responde e `scope2` dá `invalid jump destination`;
- **o offset de memória de um nome** ainda é um byte, então o nono nome escreve por cima do primeiro.

Por isso o caso de harness chama **o primeiro escopo** do contrato, e o comentário diz por quê: o que ele prova é o construtor.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)