### PR TITLE
fix: the dispatcher and the names reach past a byte

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,12 +18,14 @@ empty one. `ident x = feed(0); x + feed(1);` answered 4 on the chain where the p
 each operand is now, so the lowering reads instead of guessing, and the harness covers the
 case.
 
-The second is still standing: memory offsets, jump targets and the runtime size are written
-with `PUSH1` and truncate past 255. It is next, and `PUSH2` closes it for good — a deployed
-contract cannot pass 24,576 bytes, so two bytes cover every legal one and there is no third
-size after it.
+The second is done too. Memory offsets, jump targets and the runtime size were written with
+`PUSH1` and truncated past 255, each in its own way: a contract was published cut short, a
+scope past byte 255 was jumped to at the wrong address, and the ninth name in a contract was
+given the address of the first. They go in two bytes now, and there is no third size after it —
+a deployed contract cannot pass 24,576 bytes, so two bytes cover every legal one. Past that the
+builder refuses rather than writing.
 
-After it come `if` and then `call`, in that order, and both need what the lowering now keeps: a
+What is left is `if` and then `call`, in that order, and both need what the lowering keeps: a
 jump is only writable when the stack is known where the code splits. **Anything else in
 `builder/evm` still waits its turn**, and the turn is discussed first.
 

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -16,14 +16,20 @@ import (
 )
 
 const (
-	BYTE_SIZE                = 8
-	DISPATCHER_BYTES_SIZE    = 15
+	BYTE_SIZE = 8
+	// DISPATCHER_BYTES_SIZE is what one entry of the dispatcher measures, added up from its
+	// parts rather than written as a number: the address of every body is counted from it, so
+	// a push changing size and this staying behind would put every jump one byte off per
+	// entry — and it would do that quietly.
+	DISPATCHER_BYTES_SIZE    = PUSH_ONE_SIZE + 1 + PUSH_ONE_SIZE + 1 + PUSH_FOUR_SIZE + 1 + PUSH_TWO_SIZE + 1
 	NO_MATCH_DISPATCHER_SIZE = 1
 	CALLDATA_SLOT_READABLE   = 32
 	MEMORY_SLOT_SIZE         = 32
 	// PUSH_ONE_SIZE and PUSH_TWO_SIZE are the opcode and what it carries.
 	PUSH_ONE_SIZE = 2
 	PUSH_TWO_SIZE = 3
+	// PUSH_FOUR_SIZE is the opcode and the four bytes of a selector.
+	PUSH_FOUR_SIZE = 5
 	// INSTANTIATE_BLOCK_SIZE is what the constructor measures, and the runtime begins right
 	// after it — so the block carries this number inside itself, as the offset it copies
 	// from. It is added up here rather than written as a literal, because it was the same

--- a/builder/evm/ident.go
+++ b/builder/evm/ident.go
@@ -1,14 +1,14 @@
 package evm
 
 type IdentManager struct {
-	offsetIdents map[string]byte
+	offsetIdents map[string]int
 }
 
-func (m *IdentManager) GetOffset(ident []byte) byte {
+func (m *IdentManager) GetOffset(ident []byte) int {
 	return m.offsetIdents[string(ident)]
 }
 
-func (m *IdentManager) SetOffset(ident string, offset byte) {
+func (m *IdentManager) SetOffset(ident string, offset int) {
 	m.offsetIdents[ident] = offset
 }
 
@@ -17,5 +17,5 @@ func (m *IdentManager) GetLength() uint {
 }
 
 func NewIdentManager() *IdentManager {
-	return &IdentManager{offsetIdents: make(map[string]byte)}
+	return &IdentManager{offsetIdents: make(map[string]int)}
 }

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -173,32 +173,38 @@ func WriteNoMatchDispatcher(w io.Writer) (int, error) {
 	return w.Write([]byte{OpStop})
 }
 
+// WriteDispatcher emits the entry for one scope: it reads the selector out of the calldata,
+// compares it with the one this scope answers to, and jumps to the body when they match.
+//
+// The address goes in two bytes. It used to go in one, so a body living past byte 255 of the
+// runtime was jumped to at an address that had been truncated — a contract with twelve scopes
+// answered for the first and refused the third with "invalid jump destination". The body was
+// there; the dispatcher could not name it.
 func WriteDispatcher(bs io.Writer, id string, jumpTo int) (int, error) {
-	if _, err := bs.Write([]byte{OpPush1, 0x00}); err != nil { // 2 bytes
+	if _, err := bs.Write([]byte{OpPush1, 0x00}); err != nil {
 		return 0, err
 	}
-	if _, err := bs.Write([]byte{OpCallDataLoad}); err != nil { // 1 byte
+	if _, err := bs.Write([]byte{OpCallDataLoad}); err != nil {
 		return 0, err
 	}
 	// Isolate the first 4 bytes of the keccak256 hash of the id
-	if _, err := bs.Write([]byte{OpPush1, byte((CALLDATA_SLOT_READABLE - 4) * BYTE_SIZE)}); err != nil { // 2 bytes
+	if _, err := bs.Write([]byte{OpPush1, byte((CALLDATA_SLOT_READABLE - 4) * BYTE_SIZE)}); err != nil {
 		return 0, err
 	}
-	if _, err := bs.Write([]byte{OpShiftRight}); err != nil { // 1 byte
+	if _, err := bs.Write([]byte{OpShiftRight}); err != nil {
 		return 0, err
 	}
 	selector := crypto.Keccak256([]byte(id))[:4]
-	if _, err := bs.Write(append([]byte{OpPush4}, selector...)); err != nil { // 5 bytes
+	if _, err := bs.Write(append([]byte{OpPush4}, selector...)); err != nil {
 		return 0, err
 	}
-	if _, err := bs.Write([]byte{OpEqual}); err != nil { // 1 byte
+	if _, err := bs.Write([]byte{OpEqual}); err != nil {
 		return 0, err
 	}
-	// PUSH1 limits jumpTo to 0–255; larger runtimes would need PUSH2.
-	if _, err := bs.Write([]byte{OpPush1, byte(jumpTo)}); err != nil { // 2 bytes
+	if _, err := WritePush2(bs, jumpTo); err != nil {
 		return 0, err
 	}
-	return bs.Write([]byte{OpJumpIf}) // 1 byte
+	return bs.Write([]byte{OpJumpIf})
 }
 
 func WriteDispatchers(bs io.Writer, ds []Dispatcher) (int, error) {

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -68,15 +68,19 @@ func WriteSave(w io.Writer, left []byte, size int) (int, error) {
 }
 
 type IdentOffsetMapper interface {
-	GetOffset(ident []byte) byte
-	SetOffset(ident string, offset byte)
+	GetOffset(ident []byte) int
+	SetOffset(ident string, offset int)
 	GetLength() uint
 }
 
+// WriteIdent stores a value under a name, in a slot of memory of its own.
+//
+// The address goes in two bytes. It used to go in one, and a slot is thirty-two wide, so the
+// ninth name in a contract was given the address of the first — 8 * 32 is 256, and one byte
+// holds none of it. Two names became one piece of memory, and each wrote over the other.
 func WriteIdent(w io.Writer, m IdentOffsetMapper, ident []byte) (int, error) {
-	// offset fits in byte only if idents count * MEMORY_SLOT_SIZE < 256 (e.g. up to 7 slots of 32).
-	offset := byte(m.GetLength() * MEMORY_SLOT_SIZE)
-	if _, err := w.Write([]byte{OpPush1, offset}); err != nil {
+	offset := int(m.GetLength()) * MEMORY_SLOT_SIZE
+	if _, err := WritePush2(w, offset); err != nil {
 		return 0, err
 	}
 	if _, err := w.Write([]byte{OpMemoryStore}); err != nil {
@@ -87,8 +91,7 @@ func WriteIdent(w io.Writer, m IdentOffsetMapper, ident []byte) (int, error) {
 }
 
 func WriteLoad(w io.Writer, m IdentOffsetMapper, left []byte) (int, error) {
-	offset := m.GetOffset(left)
-	if _, err := w.Write([]byte{OpPush1, offset}); err != nil {
+	if _, err := WritePush2(w, m.GetOffset(left)); err != nil {
 		return 0, err
 	}
 	return w.Write([]byte{OpMemoryLoad})

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -116,36 +116,52 @@ func TestWriteSave(t *testing.T) {
 	}
 }
 
+// A name is stored in a slot of memory of its own, and the address goes in two bytes. It used
+// to go in one, and a slot is thirty-two wide, so the ninth name was given the address of the
+// first: 8 * 32 is 256, and one byte holds none of it.
 func TestWriteIdent(t *testing.T) {
-	bs := bytes.NewBuffer(make([]byte, 0))
-	identManager := NewIdentManager()
-	label := "test"
-	offset := byte(0x20)
-	identManager.SetOffset(label, offset)
-	if _, err := WriteIdent(bs, identManager, []byte(label)); err != nil {
-		t.Errorf("Error writing ident: %v", err)
-		return
+	cases := []struct {
+		name  string
+		names int
+		want  []byte
+	}{
+		{name: "the first name", names: 0, want: []byte{OpPush2, 0x00, 0x00}},
+		{name: "the second", names: 1, want: []byte{OpPush2, 0x00, 0x20}},
+		{name: "the ninth, which used to land on the first", names: 8, want: []byte{OpPush2, 0x01, 0x00}},
 	}
-	got := bs.Bytes()
-	expected := []byte{OpPush1, offset, OpMemoryStore}
-	if !bytes.Equal(got, expected) {
-		t.Errorf("Ident: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			manager := NewIdentManager()
+			for i := 0; i < tc.names; i++ {
+				manager.SetOffset(string(rune('a'+i)), i*MEMORY_SLOT_SIZE)
+			}
+
+			bs := bytes.NewBuffer(make([]byte, 0))
+			if _, err := WriteIdent(bs, manager, []byte("x")); err != nil {
+				t.Fatalf("writing the binding: %v", err)
+			}
+
+			expected := append(append([]byte{}, tc.want...), OpMemoryStore)
+			if got := bs.Bytes(); !bytes.Equal(got, expected) {
+				t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+			}
+		})
 	}
 }
 
 func TestWriteLoad(t *testing.T) {
+	manager := NewIdentManager()
+	manager.SetOffset("test", 0x120)
+
 	bs := bytes.NewBuffer(make([]byte, 0))
-	identManager := NewIdentManager()
-	identManager.SetOffset("test", 0x20)
-	left := []byte("test")
-	if _, err := WriteLoad(bs, identManager, left); err != nil {
-		t.Errorf("Error writing load: %v", err)
-		return
+	if _, err := WriteLoad(bs, manager, []byte("test")); err != nil {
+		t.Fatalf("writing the read: %v", err)
 	}
-	got := bs.Bytes()
-	expected := []byte{OpPush1, 0x20, OpMemoryLoad}
-	if !bytes.Equal(got, expected) {
-		t.Errorf("Load: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+
+	expected := []byte{OpPush2, 0x01, 0x20, OpMemoryLoad}
+	if got := bs.Bytes(); !bytes.Equal(got, expected) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 	}
 }
 

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -181,36 +181,39 @@ func TestWriteReturn(t *testing.T) {
 	}
 }
 
+// One entry of the dispatcher: read the selector out of the calldata, compare it with the one
+// this scope answers to, jump to the body when they match. The address goes in two bytes, so
+// a body past byte 255 of the runtime can be named.
 func TestWriteDispatcher(t *testing.T) {
 	cases := []struct {
-		Name       string
-		FnExpected func() []byte
+		name   string
+		jumpTo int
+		want   []byte
 	}{
-		{
-			"sample_dispatcher_1",
-			func() []byte {
-				expected := []byte{OpPush1, 0x00}
-				expected = append(expected, OpCallDataLoad)
-				expected = append(expected, []byte{OpPush1, 0xe0}...)
-				expected = append(expected, OpShiftRight)
-				expected = append(expected, []byte{OpPush4, 0x9c, 0x22, 0xff, 0x5f}...)
-				expected = append(expected, OpEqual)
-				expected = append(expected, []byte{OpPush1, 0x0a}...)
-				expected = append(expected, OpJumpIf)
-				return expected
-			},
-		},
+		{name: "a body near the top", jumpTo: 10, want: []byte{OpPush2, 0x00, 0x0a}},
+		{name: "a body past a byte", jumpTo: 300, want: []byte{OpPush2, 0x01, 0x2c}},
 	}
 
-	for _, c := range cases {
-		bs := bytes.NewBuffer(make([]byte, 0))
-		if _, err := WriteDispatcher(bs, "test", 10); err != nil {
-			t.Errorf("%v: %v", c.Name, err)
-			return
-		}
-		if got, expected := bs.Bytes(), c.FnExpected(); !bytes.Equal(got, expected) {
-			t.Errorf("EVM dispatcher: name: %v, got: %v, expected: %v", c.Name, byteutil.ToUpperHex(got), byteutil.ToUpperHex(c.FnExpected()))
-		}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bs := bytes.NewBuffer(make([]byte, 0))
+			if _, err := WriteDispatcher(bs, "test", tc.jumpTo); err != nil {
+				t.Fatalf("writing the dispatcher: %v", err)
+			}
+
+			expected := []byte{OpPush1, 0x00, OpCallDataLoad, OpPush1, 0xe0, OpShiftRight,
+				OpPush4, 0x9c, 0x22, 0xff, 0x5f, OpEqual}
+			expected = append(expected, tc.want...)
+			expected = append(expected, OpJumpIf)
+
+			got := bs.Bytes()
+			if !bytes.Equal(got, expected) {
+				t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+			}
+			if len(got) != DISPATCHER_BYTES_SIZE {
+				t.Errorf("it measures %d and the offsets are counted from %d", len(got), DISPATCHER_BYTES_SIZE)
+			}
+		})
 	}
 }
 

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -283,3 +283,22 @@ ident three = defer { feed(0) + feed(1) * 7 - feed(0) / 2; };`
 
 	agree(t, source, "one", []string{"6", "7"}, 0)
 }
+
+// A dispatcher pushed the address of its body in one byte, so a scope living past byte 255 of
+// the runtime was jumped to at an address that had been truncated: a contract with twelve
+// scopes answered for the first and refused the third with "invalid jump destination". The
+// body was there; the dispatcher could not name it.
+func TestAScopePastAByteIsReachedOnChainToo(t *testing.T) {
+	var source strings.Builder
+	for i := 0; i < 12; i++ {
+		fmt.Fprintf(&source, "ident scope%d = defer { feed(0) + feed(1) * %d - feed(0) / 2; };\n", i, i+1)
+	}
+
+	// The first is reachable whatever the size of the push, so the ones that say anything
+	// are the ones further in.
+	for _, name := range []string{"scope0", "scope2", "scope11"} {
+		t.Run(name, func(t *testing.T) {
+			agree(t, source.String(), name, []string{"6", "7"}, 0)
+		})
+	}
+}

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -302,3 +302,18 @@ func TestAScopePastAByteIsReachedOnChainToo(t *testing.T) {
 		})
 	}
 }
+
+// A name is kept in a slot of memory of its own, thirty-two bytes wide, and the address used
+// to go in one byte — so the ninth name in a contract was given the address of the first and
+// the two wrote over each other. Nine names is an ordinary scope.
+func TestManyNamesInAScopeAnswerTheSameOnChainAndOff(t *testing.T) {
+	var body strings.Builder
+	for i := 0; i < 9; i++ {
+		fmt.Fprintf(&body, "  ident n%d = feed(0) + %d;\n", i, i)
+	}
+	body.WriteString("  n0 + n8;\n")
+
+	source := "ident scope = defer {\n" + body.String() + "};"
+
+	agree(t, source, "scope", []string{"5"}, 0)
+}


### PR DESCRIPTION
Os dois tetos de `PUSH1` que sobraram, um commit cada. Com a #111, o `CLAUDE.md` deixa de ter o segundo dos dois problemas que puseram o backend em stand-by.

## `fix: a dispatcher reaches a scope past the first 255 bytes`

Cada entrada do dispatcher empurrava o endereço do corpo com `PUSH1`. Um escopo além do byte 255 do runtime era saltado num endereço cortado:

```
12 escopos:
  scope0   -> respondia
  scope2   -> invalid jump destination
  scope11  -> invalid jump destination
```

O corpo estava lá. **O dispatcher não conseguia nomeá-lo.**

E o `DISPATCHER_BYTES_SIZE` passou a ser somado das partes, porque **o endereço de todo corpo é contado a partir dele**: o push mudando de tamanho e a constante ficando para trás poria cada salto um byte fora, por entrada, em silêncio.

## `fix: the ninth name in a contract is not the first one again`

Um nome mora num slot de memória de 32 bytes, e o endereço ia num byte. `8 * 32` é **256**, que um byte não guarda — então o **nono nome recebia o endereço do primeiro**, e os dois escreviam um por cima do outro.

Nove nomes é um escopo comum, e nada avisava: o contrato fazia deploy, a chamada dava certo, e um dos dois valores era o que o outro tinha deixado ali.

## A prova

Casos de harness para os dois — mesmo fonte compilado, publicado numa EVM em memória, chamado, comparado com o evaluator:

```
TestAScopePastAByteIsReachedOnChainToo/scope0    PASS
TestAScopePastAByteIsReachedOnChainToo/scope2    PASS
TestAScopePastAByteIsReachedOnChainToo/scope11   PASS
TestManyNamesInAScopeAnswerTheSameOnChainAndOff  PASS
```

O do dispatcher chama o primeiro, o terceiro e o último de propósito: **o primeiro é alcançável com qualquer tamanho de push**, então os que dizem alguma coisa são os de dentro.

## O `CLAUDE.md`

O parágrafo que nomeava o teto passa a dizer que ele está fechado. O que resta é `if` e depois `call`, nessa ordem, e os dois precisam do que o lowering já mantém: um salto só é escrevível quando se sabe a pilha onde o código se divide.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)