### PR TITLE
feat: a branch reaches the bytecode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,9 +25,14 @@ given the address of the first. They go in two bytes now, and there is no third 
 a deployed contract cannot pass 24,576 bytes, so two bytes cover every legal one. Past that the
 builder refuses rather than writing.
 
-What is left is `if` and then `call`, in that order, and both need what the lowering keeps: a
-jump is only writable when the stack is known where the code splits. **Anything else in
-`builder/evm` still waits its turn**, and the turn is discussed first.
+A branch is written now. The bytes of a scope are measured before they are written, so a jump
+forward has an address; nothing is moved across a branch, so what an arm leaves is what the
+arm computed; and both arms leave one value, which is what makes an `if` an expression on a
+chain the way it is off one.
+
+What is left of that line is `call`, which needs a frame — the convention is in
+[rfcs/if_and_call.md](rfcs/if_and_call.md). **Anything else in `builder/evm` still waits its
+turn**, and the turn is discussed first.
 
 What the backend gained before stopping is the differential harness
 (`hosting/cli/evm_harness_test.go`) — the same source compiled, deployed to an EVM in memory,

--- a/README.md
+++ b/README.md
@@ -187,7 +187,8 @@ a binary that does less than the source said is announced rather than silent.
 | arithmetic, and a scope called from a transaction | **yes**, at any tape width |
 | a name bound inside a scope | **yes** |
 | a value written down, wherever it is used | **yes** |
-| `if`, calling a scope from another | not yet |
+| a branch, and the value it answers with | **yes** |
+| calling a scope from another | not yet |
 | comparisons, `and`/`or`, `^` | not yet |
 | tape operations, `shape` | not yet |
 | `printb` / `printd` / `printc` | **by decision** — a log has nowhere to go on a chain |

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -323,7 +323,7 @@ func TestBuildIsDeterministic(t *testing.T) {
 
 func TestWriteCodeEndsInStop(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	if _, err := WriteCode(buf, NewIdentManager(), nil, byteutil.DefaultTapeSize); err != nil {
+	if _, err := WriteCode(buf, NewIdentManager(), nil, byteutil.DefaultTapeSize, 0); err != nil {
 		t.Fatalf("WriteCode: %v", err)
 	}
 	got := buf.Bytes()

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -46,6 +46,9 @@ type Dispatcher struct {
 	Offset   int
 	Length   int
 	Code     *bytes.Buffer
+	// Body is what the code was written from, kept so it can be written again once where it
+	// lands is known.
+	Body []ir.Instruction
 }
 
 type RuntimeCode struct {
@@ -88,9 +91,11 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 	body := b.insts[cursor+1 : end]
 	body = Lowering(body, b.tapeSize)
 
-	// Emit EVM bytecode for the defer body (OpBeginScope, ...exprs..., OpReturn).
+	// Written once to find out how long it is, and once more when where it lands is known —
+	// a jump inside it carries an address in the contract, and that address depends on how
+	// many scopes come before it, which is not known until they have all been found.
 	code := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteCode(code, b.identManager, body, b.tapeSize); err != nil {
+	if _, err := WriteCode(code, NewIdentManager(), body, b.tapeSize, 0); err != nil {
 		return nil, cursor, false
 	}
 
@@ -110,6 +115,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 		Code:     bytes.NewBuffer(append([]byte{OpJumpDestiny}, code.Bytes()...)),
 		Offset:   offset,
 		Length:   code.Len(),
+		Body:     body,
 	}
 	return d, end, true
 }
@@ -132,10 +138,28 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 		b.cursor++
 	}
 
+	// Where each scope lands is known only now, since it depends on how many there are: the
+	// dispatcher block comes first and every entry of it is the same size. So they are
+	// written again, this time with the address they will have.
+	referenced := DISPATCHER_BYTES_SIZE*len(dispatchers) + NO_MATCH_DISPATCHER_SIZE
+	if len(dispatchers) == 0 {
+		referenced = 0
+	}
+	for at := range dispatchers {
+		d := &dispatchers[at]
+		code := bytes.NewBuffer(make([]byte, 0))
+		// One past the offset, because a scope opens with the JUMPDEST its dispatcher
+		// jumps to.
+		if _, err := WriteCode(code, b.identManager, d.Body, b.tapeSize, referenced+d.Offset+1); err != nil {
+			return nil, err
+		}
+		d.Code = bytes.NewBuffer(append([]byte{OpJumpDestiny}, code.Bytes()...))
+	}
+
 	if len(rootinsts) > 0 {
 		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
-		if _, err := WriteCode(root, b.identManager, rootinsts, b.tapeSize); err != nil {
+		if _, err := WriteCode(root, b.identManager, rootinsts, b.tapeSize, referenced+offset); err != nil {
 			return nil, err
 		}
 		return &RuntimeCode{Root: root, Dispatchers: dispatchers}, nil

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -93,10 +93,57 @@ func Lowering(insts []ir.Instruction, tapeSize int) []ir.Instruction {
 //
 // A value nobody takes has nowhere to be moved to, so it stays where it was written. That is
 // the last expression of a scope, which is the scope's answer.
+// divides answers whether control can leave an instruction for somewhere other than the next
+// one, or arrive at it from somewhere other than the one before.
+//
+// Nothing is moved across one. A value held back is emitted right before whoever takes it,
+// which is sound while both sit on the same straight run of instructions — past a branch it is
+// not: the value would be produced only when that side runs, and whoever takes it may be
+// reached the other way. It is the rule every compiler keeps, and it is why a scheduler works
+// inside a block and never through one.
+func divides(op byte) bool {
+	switch op {
+	case ir.OpIf, ir.OpJump, ir.OpReturn, ir.OpBeginScope, ir.OpDefer, ir.OpCall:
+		return true
+	default:
+		return false
+	}
+}
+
+// ResolveOperandsOrder emits every value right before whoever takes it.
+//
+// An instruction that leaves a value is held back under its label rather than emitted where it
+// was written: the code that produces it belongs next to the code that eats it. Holding it
+// back is safe because everything held back is pure — a constant, an argument, a read of
+// memory, or arithmetic over those — so moving it moves nothing observable.
+//
+// It is held back only as far as the next place control can go. Anything still waiting when
+// one of those is reached is emitted first, in the order it was written, because past that
+// point there is no telling whether it would have run.
+//
+// A value nobody takes has nowhere to be moved to, so it stays where it was written. That is
+// the last expression of a scope, which is the scope's answer.
 func ResolveOperandsOrder(insts []ir.Instruction, tapeSize int) []ir.Instruction {
 	taken := labelsTaken(insts)
 	pending := make(map[string][]ir.Instruction)
+	// The order they were held back in, so flushing them keeps it.
+	waiting := make([]string, 0, len(insts))
 	out := make([]ir.Instruction, 0, len(insts))
+
+	flush := func() {
+		for _, label := range waiting {
+			if held, ok := pending[label]; ok {
+				out = append(out, held...)
+				delete(pending, label)
+			}
+		}
+		waiting = waiting[:0]
+	}
+
+	hold := func(label string, sequence []ir.Instruction) {
+		pending[label] = sequence
+		waiting = append(waiting, label)
+	}
 
 	for _, inst := range insts {
 		op := inst.GetOpCode()
@@ -113,10 +160,20 @@ func ResolveOperandsOrder(insts []ir.Instruction, tapeSize int) []ir.Instruction
 		}
 		sequence = append(sequence, inst)
 
+		if divides(op) {
+			// What this takes was just put in front of it, so it goes out whole — and
+			// everything else waiting goes out ahead of it, where it is still on the
+			// straight run it was written on.
+			held := sequence
+			flush()
+			out = append(out, held...)
+			continue
+		}
+
 		label := byteutil.ToHex(inst.GetLabel())
 		switch {
 		case produces(op) && taken[label] > 0:
-			pending[label] = sequence
+			hold(label, sequence)
 		case produces(op):
 			// Nobody takes it, so there is nowhere to move it to: it is the answer of the
 			// scope it was written in, and it stays where it was written.
@@ -126,7 +183,7 @@ func ResolveOperandsOrder(insts []ir.Instruction, tapeSize int) []ir.Instruction
 			// which is what the evaluator answers. On the stack that has to be pushed: the
 			// binding itself left nothing there.
 			sequence = append(sequence, ir.NewInstruction(inst.GetLabel(), ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
-			pending[label] = sequence
+			hold(label, sequence)
 		default:
 			out = append(out, sequence...)
 		}

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -267,3 +267,38 @@ func TestLowering(t *testing.T) {
 		})
 	}
 }
+
+// A value is held back until whoever takes it, and no further: past a branch there is no
+// telling whether it would have run. A push moved into an arm happens only when that arm is
+// taken, and whoever eats it may be reached the other way — so it goes out before the branch,
+// where it is still on the straight run it was written on.
+func TestNothingIsMovedAcrossABranch(t *testing.T) {
+	insts := []ir.Instruction{
+		// A value written before the branch, and read inside it.
+		ir.NewInstruction([]byte("00"), ir.OpSave, ir.Imm(1, 0), ir.Nothing()),
+		ir.NewInstruction([]byte("01"), ir.OpSave, ir.Imm(2, 0), ir.Nothing()),
+		ir.NewInstruction([]byte("02"), ir.OpIf, ir.RefTo([]byte("01")), ir.TargetAt(2)),
+		ir.NewInstruction([]byte("03"), ir.OpSave, ir.Imm(3, 0), ir.Nothing()),
+		ir.NewInstruction([]byte("04"), ir.OpAdd, ir.RefTo([]byte("00")), ir.RefTo([]byte("03"))),
+	}
+
+	lowered := ResolveOperandsOrder(insts, 0)
+
+	at := func(label string) int {
+		for i, inst := range lowered {
+			if string(inst.GetLabel()) == label {
+				return i
+			}
+		}
+		t.Fatalf("%s is not in the lowered scope:\n%s", label, ir.Format(lowered))
+		return -1
+	}
+
+	if at("00") > at("02") {
+		t.Errorf("the value written before the branch was moved past it:\n%s", ir.Format(lowered))
+	}
+	// And the test of the branch is still put right in front of it.
+	if at("01") != at("02")-1 {
+		t.Errorf("what the branch tests is not in front of it:\n%s", ir.Format(lowered))
+	}
+}

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -30,6 +30,8 @@ var handled = map[byte]bool{
 	ir.OpReturn:     true,
 	ir.OpDefer:      true,
 	ir.OpBeginScope: true,
+	ir.OpIf:         true,
+	ir.OpJump:       true,
 }
 
 // offChain is what is meant to be absent from a chain. Saying so is still worth a line: a

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -35,10 +35,9 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			wantNone: true,
 		},
 		{
-			name:    "a branch",
-			opcodes: []byte{ir.OpIf, ir.OpJump},
-			// Two instructions, one feature, one thing to say about it.
-			want: []string{"if does not reach the bytecode yet"},
+			name:     "a branch, which reaches the bytecode now",
+			opcodes:  []byte{ir.OpIf, ir.OpJump},
+			wantNone: true,
 		},
 		{
 			name:    "a comparison",
@@ -107,7 +106,7 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 // The same feature used twice is one thing to say, not two.
 func TestWarningsSayEachThingOnce(t *testing.T) {
 	warnings := Warnings(instructionsOf(
-		ir.OpIf, ir.OpJump, ir.OpIf, ir.OpJump, ir.OpBigger, ir.OpSmaller,
+		ir.OpPull, ir.OpHead, ir.OpPull, ir.OpHead, ir.OpBigger, ir.OpSmaller,
 	))
 
 	if len(warnings) != 2 {
@@ -118,7 +117,7 @@ func TestWarningsSayEachThingOnce(t *testing.T) {
 // They arrive in the order the program uses them, so the first thing a reader is told about
 // is the first thing that goes missing.
 func TestWarningsFollowTheProgram(t *testing.T) {
-	warnings := Warnings(instructionsOf(ir.OpPrintDecimal, ir.OpIf))
+	warnings := Warnings(instructionsOf(ir.OpPrintDecimal, ir.OpBigger))
 
 	if len(warnings) != 2 {
 		t.Fatalf("said %d things, want two", len(warnings))
@@ -172,7 +171,6 @@ func TestEveryPendingFeatureNamesItsPlace(t *testing.T) {
 		says   string
 		line   int
 	}{
-		{name: "an if", source: "printb 1;\nprintb if true { 1; };", says: "if", line: 2},
 		{name: "a call", source: "ident f = defer { 1; };\nprintb f();", says: "calling a scope", line: 2},
 		{name: "a comparison", source: "printb 1;\nprintb 2 bigger 1;", says: "a comparison", line: 2},
 		{name: "and or or", source: "printb 1;\nprintb true and false;", says: "and/or", line: 2},

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -294,12 +294,15 @@ func (c *counter) Write(p []byte) (int, error) {
 //
 // The names are registered into a manager of its own and thrown away, since what is measured
 // is how many bytes an instruction takes and every push is a fixed size now.
-func PositionsOf(insts []ir.Instruction, tapeSize int) ([]int, error) {
+func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, arms map[string]bool) ([]int, error) {
 	positions := make([]int, len(insts)+1)
 	im := NewIdentManager()
 	for at, inst := range insts {
 		var measured counter
-		if err := WriteInstruction(&measured, im, inst, tapeSize, nil); err != nil {
+		if landings[at] {
+			measured++
+		}
+		if err := WriteInstruction(&measured, im, inst, tapeSize, 0, arms); err != nil {
 			return nil, err
 		}
 		positions[at+1] = positions[at] + int(measured)
@@ -307,12 +310,62 @@ func PositionsOf(insts []ir.Instruction, tapeSize int) ([]int, error) {
 	return positions, nil
 }
 
+// landingsOf answers the instructions a jump arrives at.
+//
+// The IR counts its jumps in instructions, which is what the evaluator's cursor takes; the EVM
+// takes a byte, and it refuses one that is not a JUMPDEST. So the places that are arrived at
+// are worked out first, from the counts alone, and each of them opens with one.
+//
+// A landing one past the last instruction is the way out of an "if" that ends a scope, and it
+// gets a JUMPDEST of its own after everything.
+func landingsOf(insts []ir.Instruction) map[int]bool {
+	landings := make(map[int]bool)
+	for at, inst := range insts {
+		switch inst.GetOpCode() {
+		case ir.OpIf:
+			landings[at+1+int(byteutil.ToUint64(inst.GetRight().Bytes()))] = true
+		case ir.OpJump:
+			landings[at+1+int(byteutil.ToUint64(inst.GetLeft().Bytes()))] = true
+		}
+	}
+	return landings
+}
+
+// armsOf answers the labels an "if" answers under, so an OpReturn naming one is known to end a
+// branch rather than a scope.
+func armsOf(insts []ir.Instruction) map[string]bool {
+	arms := make(map[string]bool)
+	for _, inst := range insts {
+		if inst.GetOpCode() == ir.OpIf {
+			arms[byteutil.ToHex(inst.GetLabel())] = true
+		}
+	}
+	return arms
+}
+
+// targetOf answers the byte an instruction jumps to, or zero for one that does not jump.
+func targetOf(inst ir.Instruction, at int, positions []int) int {
+	var ahead int
+	switch inst.GetOpCode() {
+	case ir.OpIf:
+		ahead = int(byteutil.ToUint64(inst.GetRight().Bytes()))
+	case ir.OpJump:
+		ahead = int(byteutil.ToUint64(inst.GetLeft().Bytes()))
+	default:
+		return 0
+	}
+	return positions[at+1+ahead]
+}
+
 // WriteInstruction emits one instruction.
 //
-// Addresses answers where a label lives in the bytecode, for the instructions that jump. It is
-// nil while measuring, and a jump written then carries zeros — which measures the same, since
-// every push is a fixed size.
-func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, addresses map[string]int) error {
+// The target is the byte a jump goes to, for the two instructions that jump. It is zero while
+// measuring, and measures the same either way, since every push is a fixed size.
+//
+// Arms answers whether an OpReturn ends a branch rather than a scope. The two are the same
+// opcode: one says "the value of this scope" and the other "the value of this arm", and which
+// it is can be read — an arm names the OpIf it belongs to, and a scope names the OpBeginScope.
+func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, target int, arms map[string]bool) error {
 	op := inst.GetOpCode()
 
 	if handled[op] && op != ir.OpSave {
@@ -355,8 +408,12 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 	}
 
 	if op == ir.OpReturn {
-		if _, err := WriteReturn(bs); err != nil {
-			return err
+		// The value of an arm is already on the stack, which is where whoever is under the
+		// branch finds it: there is nothing to write. Only a scope answers to the chain.
+		if !arms[byteutil.ToHex(inst.GetLeft().Bytes())] {
+			if _, err := WriteReturn(bs); err != nil {
+				return err
+			}
 		}
 	}
 
@@ -384,12 +441,65 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		}
 	}
 
+	if op == ir.OpIf {
+		// The IR skips ahead when the test is false and the EVM jumps when what it pops is
+		// not zero, so the test is turned over first.
+		if _, err := bs.Write([]byte{OpIsZero}); err != nil {
+			return err
+		}
+		if _, err := WritePush2(bs, target); err != nil {
+			return err
+		}
+		if _, err := bs.Write([]byte{OpJumpIf}); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpJump {
+		if _, err := WritePush2(bs, target); err != nil {
+			return err
+		}
+		if _, err := bs.Write([]byte{OpJump}); err != nil {
+			return err
+		}
+	}
+
 	return nil
 }
 
-func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int) (int, error) {
-	for _, inst := range insts {
-		if err := WriteInstruction(bs, im, inst, tapeSize, nil); err != nil {
+// WriteCode emits a scope: measure, resolve, write.
+//
+// A jump forward needs the address of code that has not been written, so the bytes are
+// measured first and the addresses fall out of the measurement. Every push is a fixed size, so
+// one pass is enough — nothing here has to be measured again because an address turned out
+// longer than it was guessed.
+//
+// The base is where this scope lands in the runtime, since a jump carries an address in the
+// contract and not an offset into a scope. It is zero while a scope is being measured, and the
+// measurement does not depend on it.
+func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int, base int) (int, error) {
+	landings := landingsOf(insts)
+	arms := armsOf(insts)
+
+	positions, err := PositionsOf(insts, tapeSize, landings, arms)
+	if err != nil {
+		return 0, err
+	}
+
+	for at, inst := range insts {
+		if landings[at] {
+			if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
+				return 0, err
+			}
+		}
+		if err := WriteInstruction(bs, im, inst, tapeSize, base+targetOf(inst, at, positions), arms); err != nil {
+			return 0, err
+		}
+	}
+
+	// The way out of an "if" that ends a scope lands past the last instruction.
+	if landings[len(insts)] {
+		if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
 			return 0, err
 		}
 	}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -277,77 +277,120 @@ func WriteImmediates(w io.Writer, inst ir.Instruction, tapeSize int) error {
 	return nil
 }
 
+// counter is a writer that keeps how much was written to it and nothing else.
+type counter int
+
+func (c *counter) Write(p []byte) (int, error) {
+	*c += counter(len(p))
+	return len(p), nil
+}
+
+// PositionsOf answers the byte each instruction of a scope starts at, and where the scope ends.
+//
+// It measures by writing — to something that only counts — rather than by adding up a table of
+// sizes beside the writer. A table would be a second description of the same thing, and two
+// descriptions of one thing drift: this backend has been wrong that way more than once, and
+// the drift is silent because the bytes still come out, just at the wrong addresses.
+//
+// The names are registered into a manager of its own and thrown away, since what is measured
+// is how many bytes an instruction takes and every push is a fixed size now.
+func PositionsOf(insts []ir.Instruction, tapeSize int) ([]int, error) {
+	positions := make([]int, len(insts)+1)
+	im := NewIdentManager()
+	for at, inst := range insts {
+		var measured counter
+		if err := WriteInstruction(&measured, im, inst, tapeSize, nil); err != nil {
+			return nil, err
+		}
+		positions[at+1] = positions[at] + int(measured)
+	}
+	return positions, nil
+}
+
+// WriteInstruction emits one instruction.
+//
+// Addresses answers where a label lives in the bytecode, for the instructions that jump. It is
+// nil while measuring, and a jump written then carries zeros — which measures the same, since
+// every push is a fixed size.
+func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, addresses map[string]int) error {
+	op := inst.GetOpCode()
+
+	if handled[op] && op != ir.OpSave {
+		if err := WriteImmediates(bs, inst, tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpAdd {
+		if _, err := WriteAdd(bs); err != nil {
+			return err
+		}
+		if _, err := WriteMask(bs, tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpMultiply {
+		if _, err := WriteMultiply(bs); err != nil {
+			return err
+		}
+		if _, err := WriteMask(bs, tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpSubtract {
+		if _, err := WriteSubtract(bs); err != nil {
+			return err
+		}
+		if _, err := WriteMask(bs, tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpDivide {
+		if _, err := WriteDivide(bs); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpReturn {
+		if _, err := WriteReturn(bs); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpSave {
+		if _, err := WriteSave(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpIdent {
+		if _, err := WriteIdent(bs, im, inst.GetLeft().Bytes()); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpLoad {
+		if _, err := WriteLoad(bs, im, inst.GetLeft().Bytes()); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpGetFeed {
+		if _, err := WriteGetArg(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int) (int, error) {
 	for _, inst := range insts {
-		op := inst.GetOpCode()
-
-		if handled[op] && op != ir.OpSave {
-			if err := WriteImmediates(bs, inst, tapeSize); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpAdd {
-			if _, err := WriteAdd(bs); err != nil {
-				return 0, err
-			}
-			if _, err := WriteMask(bs, tapeSize); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpMultiply {
-			if _, err := WriteMultiply(bs); err != nil {
-				return 0, err
-			}
-			if _, err := WriteMask(bs, tapeSize); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpSubtract {
-			if _, err := WriteSubtract(bs); err != nil {
-				return 0, err
-			}
-			if _, err := WriteMask(bs, tapeSize); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpDivide {
-			if _, err := WriteDivide(bs); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpReturn {
-			if _, err := WriteReturn(bs); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpSave {
-			if _, err := WriteSave(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpIdent {
-			if _, err := WriteIdent(bs, im, inst.GetLeft().Bytes()); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpLoad {
-			if _, err := WriteLoad(bs, im, inst.GetLeft().Bytes()); err != nil {
-				return 0, err
-			}
-		}
-
-		if op == ir.OpGetFeed {
-			if _, err := WriteGetArg(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
-				return 0, err
-			}
+		if err := WriteInstruction(bs, im, inst, tapeSize, nil); err != nil {
+			return 0, err
 		}
 	}
 

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -335,7 +335,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 		ir.NewInstruction([]byte("04"), ir.OpLoad, ir.NameOf("x"), ir.Nothing()),
 	}
 
-	positions, err := PositionsOf(insts, 8)
+	positions, err := PositionsOf(insts, 8, nil, nil)
 	if err != nil {
 		t.Fatalf("measuring: %v", err)
 	}
@@ -347,7 +347,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 	im := NewIdentManager()
 	for at, inst := range insts {
 		before := bs.Len()
-		if err := WriteInstruction(bs, im, inst, 8, nil); err != nil {
+		if err := WriteInstruction(bs, im, inst, 8, 0, nil); err != nil {
 			t.Fatalf("writing: %v", err)
 		}
 		if want := positions[at+1] - positions[at]; bs.Len()-before != want {

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // The constructor copies the runtime out of the code being deployed and hands it to the chain.
@@ -319,5 +320,39 @@ func TestWriteMask(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// Measuring is writing to something that only counts, so what it says and what comes out
+// cannot disagree. That is the whole reason it is done this way rather than with a table of
+// sizes: a table is a second description, and two descriptions of one thing drift.
+func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
+	insts := []ir.Instruction{
+		ir.NewInstruction([]byte("00"), ir.OpGetFeed, ir.Const(0, 8), ir.Nothing()),
+		ir.NewInstruction([]byte("01"), ir.OpSave, ir.Imm(10, 8), ir.Nothing()),
+		ir.NewInstruction([]byte("02"), ir.OpAdd, ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))),
+		ir.NewInstruction([]byte("03"), ir.OpIdent, ir.NameOf("x"), ir.RefTo([]byte("02"))),
+		ir.NewInstruction([]byte("04"), ir.OpLoad, ir.NameOf("x"), ir.Nothing()),
+	}
+
+	positions, err := PositionsOf(insts, 8)
+	if err != nil {
+		t.Fatalf("measuring: %v", err)
+	}
+	if len(positions) != len(insts)+1 {
+		t.Fatalf("measured %d positions for %d instructions", len(positions), len(insts))
+	}
+
+	bs := bytes.NewBuffer(make([]byte, 0))
+	im := NewIdentManager()
+	for at, inst := range insts {
+		before := bs.Len()
+		if err := WriteInstruction(bs, im, inst, 8, nil); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		if want := positions[at+1] - positions[at]; bs.Len()-before != want {
+			t.Errorf("%s measured %d bytes and wrote %d",
+				ir.ResolveOpCode(inst.GetOpCode()), want, bs.Len()-before)
+		}
 	}
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -120,11 +120,12 @@ everything below is not.
 The gap is wider than it looks, and it is silent, which is the dangerous part: a contract
 using any of the following **compiles successfully and does nothing on chain**.
 
-- `if`, `jump`, `call`, `assert`, the tape operations, and the shape instructions (`OpJoin`,
-  `OpField`) produce no bytecode at all. `WriteCode` covers arithmetic, `OpSave`, `OpIdent`,
-  `OpLoad`, `OpGetFeed` and `OpReturn`. They are not refusals — a tape is at most 32 bytes and
-  an EVM word is exactly 32, a shape is a run of words in memory, and a call is a jump with a
-  return address. They are simply not written yet.
+- `call`, `assert`, the comparisons, `and`/`or`, `^`, the tape operations and the shape
+  instructions (`OpJoin`, `OpField`) produce no bytecode at all. `WriteCode` covers arithmetic,
+  `OpSave`, `OpIdent`, `OpLoad`, `OpGetFeed`, `OpReturn` and now the branch — `OpIf` and
+  `OpJump`. They are not refusals — a tape is at most 32 bytes and an EVM word is exactly 32, a
+  shape is a run of words in memory, and a call is a jump with a return address. They are
+  simply not written yet.
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -353,6 +353,14 @@ func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tape
 		for _, inst := range n.Else.Body {
 			eul = EmitInstruction(tc, &euze, inst, tapeSize)
 		}
+	} else {
+		// An if with no else answers with the neutral value on the path where the test
+		// fails, and the arm says so rather than leaving whoever reads the IR to know it.
+		// A consumer that has to put a value somewhere — a stack — has nothing to put
+		// there otherwise, and one that does not would be reading an operand naming
+		// nothing.
+		eul = GenerateLabel(tc)
+		euze = append(euze, ir.NewInstruction(eul, ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()).At(originOf(n.Token)))
 	}
 	euzelen := ir.TargetAt(uint64(len(euze)) + 1)
 

--- a/hosting/cli/build_test.go
+++ b/hosting/cli/build_test.go
@@ -159,11 +159,6 @@ func TestBuildSaysWhatTheBackendDoesNotCarry(t *testing.T) {
 		want   string
 	}{
 		{
-			name:   "a branch",
-			source: "ident pick = defer { if feed(0) bigger feed(1) { feed(0); } else { feed(1); }; };\n",
-			want:   "if does not reach the bytecode yet",
-		},
-		{
 			name:   "a comparison",
 			source: "ident same = defer { feed(0) equals feed(1); };\n",
 			want:   "a comparison does not reach the bytecode yet",

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -317,3 +317,32 @@ func TestManyNamesInAScopeAnswerTheSameOnChainAndOff(t *testing.T) {
 
 	agree(t, source, "scope", []string{"5"}, 0)
 }
+
+// A branch reaches the bytecode. The IR skips ahead when the test is false and the EVM jumps
+// when what it pops is not zero, so the test is turned over; both arms leave one value, which
+// is what makes an "if" an expression — whoever is under it finds a value without knowing
+// which way the program went.
+//
+// The test of each case is a value rather than a comparison, because a comparison does not
+// reach the bytecode yet and would be testing something that was never computed.
+func TestABranchAnswersTheSameOnChainAndOff(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		args   []string
+	}{
+		{name: "the then arm", source: `ident f = defer { if feed(0) { 42; } else { 7; }; };`, args: []string{"1"}},
+		{name: "the else arm", source: `ident f = defer { if feed(0) { 42; } else { 7; }; };`, args: []string{"0"}},
+		{name: "no else, taken", source: `ident f = defer { if feed(0) { 42; }; };`, args: []string{"1"}},
+		{name: "no else, not taken", source: `ident f = defer { if feed(0) { 42; }; };`, args: []string{"0"}},
+		{name: "the value is used after", source: `ident f = defer { ident r = if feed(0) { 42; } else { 7; }; r + 1; };`, args: []string{"1"}},
+		{name: "a branch inside a branch", source: `ident f = defer { if feed(0) { if feed(1) { 1; } else { 2; }; } else { 3; }; };`, args: []string{"1", "0"}},
+		{name: "arithmetic in both arms", source: `ident f = defer { if feed(0) { feed(1) + 1; } else { feed(1) * 2; }; };`, args: []string{"0", "5"}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "f", tc.args, 0)
+		})
+	}
+}


### PR DESCRIPTION
Um `if` compilava para **nada**. Um contrato que usasse um fazia deploy, respondia, e ignorava o desvio. Agora ele responde o que o evaluator responde.

Três commits, um por concern.

## `refactor: measuring is writing to something that only counts`

Salto para frente precisa do endereço de código que ainda não foi escrito, então os bytes são medidos antes.

**Quem mede é o próprio writer**, para algo que só guarda quanto entrou. A alternativa seria uma tabela de tamanhos ao lado dele — e tabela é uma **segunda descrição da mesma coisa**. Duas descrições divergem, e aqui a divergência é silenciosa: os bytes saem, nos endereços errados.

## `fix: the lowering does not move code across a branch`

Um valor é segurado e emitido logo antes de quem o toma, o que vale enquanto os dois estão no mesmo trecho reto. **Passando um desvio, não vale**: o valor só seria produzido se aquele lado rodasse, e quem o come pode ser alcançado pelo outro caminho.

É a regra que todo compilador guarda — um escalonador trabalha dentro de um bloco e nunca através dele. Aqui ela também mantém as contagens honestas: um `OpIf` carrega quantas instruções pular, e um push movido para dentro de um braço muda esse número sem dizer.

## `feat: a branch reaches the bytecode`

```
<teste>
ISZERO           ; o IR pula quando o teste e' falso; a EVM salta quando nao e' zero
PUSH2 <senao>
JUMPI
<entao>          ; deixa um valor
PUSH2 <fim>
JUMP
JUMPDEST         ; <senao>
<senao>          ; deixa um valor
JUMPDEST         ; <fim>
```

**Os dois braços deixam um valor**, e é isso que faz o `if` ser expressão: quem está embaixo encontra um valor sem saber por onde o programa passou.

Três coisas que apareceram fazendo:

**O `OpReturn` de um braço não escreve nada.** É o mesmo opcode que fecha um escopo — um diz *"o valor deste braço"* e o outro *"responda isto a quem chamou"* — e **dá para ler qual é**: um braço nomeia o `OpIf` a que pertence, um escopo nomeia o `OpBeginScope`. Era a pergunta 3 dos "Em aberto" da `if_and_call.md`, e a resposta estava no IR.

**Um `if` sem `else` passa a dizer o que responde.** O braço vazio nomeava nada, então um consumidor que precisa pôr um valor em algum lugar não tinha o que pôr — `stack underflow`. O emitter escreve o valor neutro ali, e deixa de ser caso que alguém precisa saber.

**Onde um escopo cai só se sabe depois de todos achados**, porque o dispatcher vem antes e cada entrada tem o mesmo tamanho. Então um escopo é escrito uma vez para medir e mais uma com o endereço que terá.

## A prova

```
TestABranchAnswersTheSameOnChainAndOff
  the then arm              PASS
  the else arm              PASS
  no else, taken            PASS
  no else, not taken        PASS
  the value is used after   PASS
  a branch inside a branch  PASS
  arithmetic in both arms   PASS
```

O teste de cada caso é um **valor** e não uma comparação, de propósito: comparação ainda não chega ao bytecode, e testar com uma seria testar algo que nunca foi computado.

`make check` verde, 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)