### PR TITLE
A scope calls another on chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,15 +30,26 @@ forward has an address; nothing is moved across a branch, so what an arm leaves 
 arm computed; and both arms leave one value, which is what makes an `if` an expression on a
 chain the way it is off one.
 
-What is left of that line is `call`, which needs a frame — the convention is in
-[rfcs/if_and_call.md](rfcs/if_and_call.md). **Anything else in `builder/evm` still waits its
-turn**, and the turn is discussed first.
+A call is written too, and that line of work is finished. It is a jump inside one contract,
+not a message call to itself, and what makes it a call rather than a jump is the frame: each
+scope keeps its own run of memory, so the callee's `feed(0)` means the callee's first value
+and not the caller's, and a scope can be entered while it is already running. A scope is
+written once and entered twice — a prologue for the way in from a transaction, which copies
+the calldata into the frame, and an entry past it for the way in from another scope, which
+finds the frame written. The convention is in [rfcs/if_and_call.md](rfcs/if_and_call.md).
+One limit is worth knowing: only a scope bound at the top of a program can be called, and
+anything else is refused rather than written.
+
+**Anything else in `builder/evm` still waits its turn**, and the turn is discussed first. What
+`shape` needs is what the frame already gives it: a run of memory where `base + i * tape_size`
+works.
 
 What the backend gained before stopping is the differential harness
 (`hosting/cli/evm_harness_test.go`) — the same source compiled, deployed to an EVM in memory,
 called, and compared against the evaluator — so whatever is written next is provable rather
-than believed. What it proves today is arithmetic over arguments, across a dispatcher, at any
-tape width.
+than believed. What it proves today is arithmetic over arguments at any tape width, names
+bound inside a scope, branches, the comparisons and `and`/`or`, and a scope calling another as
+deep as it nests.
 
 A feature still does **not** need bytecode to be finished. `shape` and text-as-a-tape shipped
 without it.

--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ a binary that does less than the source said is announced rather than silent.
 | a name bound inside a scope | **yes** |
 | a value written down, wherever it is used | **yes** |
 | a branch, and the value it answers with | **yes** |
-| calling a scope from another | not yet |
+| calling a scope from another | **yes**, nested as deep as it goes |
 | comparisons, `and`/`or`, `^` | **yes** |
 | tape operations, `shape` | not yet |
 | `printb` / `printd` / `printc` | **by decision** — a log has nowhere to go on a chain |

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -330,7 +330,7 @@ func TestBuildIsDeterministic(t *testing.T) {
 
 func TestWriteCodeEndsInStop(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	if _, err := WriteCode(buf, NewIdentManager(), nil, byteutil.DefaultTapeSize, 0, true); err != nil {
+	if _, err := WriteCode(buf, NewIdentManager(), nil, 0, ScopeOf(nil, byteutil.DefaultTapeSize, true)); err != nil {
 		t.Fatalf("WriteCode: %v", err)
 	}
 	got := buf.Bytes()

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -330,7 +330,7 @@ func TestBuildIsDeterministic(t *testing.T) {
 
 func TestWriteCodeEndsInStop(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	if _, err := WriteCode(buf, NewIdentManager(), nil, byteutil.DefaultTapeSize, 0); err != nil {
+	if _, err := WriteCode(buf, NewIdentManager(), nil, byteutil.DefaultTapeSize, 0, true); err != nil {
 		t.Fatalf("WriteCode: %v", err)
 	}
 	got := buf.Bytes()

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -83,7 +83,8 @@ func TestBuildAnnouncesTheRuntimeSize(t *testing.T) {
 // four bytes of calldata against the keccak of the name and jumps to its code.
 func TestBuildEmitsADispatcherPerCallable(t *testing.T) {
 	code := build(t, "ident add = defer { feed(0) + feed(1); };\n", byteutil.DefaultTapeSize)
-	runtime := code[INSTANTIATE_BLOCK_SIZE:]
+	// Past the constructor, and past the six bytes that say where the first frame begins.
+	runtime := code[INSTANTIATE_BLOCK_SIZE+FRAME_START_SIZE:]
 
 	if runtime[0] != OpPush1 || runtime[1] != 0x00 || runtime[2] != OpCallDataLoad {
 		t.Errorf("a dispatcher should start by loading calldata, got %s", byteutil.ToUpperHex(runtime[:3]))
@@ -105,7 +106,8 @@ func TestBuildEmitsOneDispatcherPerName(t *testing.T) {
 	code := build(t, `ident add = defer { feed(0) + feed(1); };
 ident sub = defer { feed(0) - feed(1); };
 `, byteutil.DefaultTapeSize)
-	runtime := code[INSTANTIATE_BLOCK_SIZE:]
+	// Past the constructor, and past the six bytes that say where the first frame begins.
+	runtime := code[INSTANTIATE_BLOCK_SIZE+FRAME_START_SIZE:]
 
 	for i := 0; i < 2; i++ {
 		at := i * DISPATCHER_BYTES_SIZE
@@ -121,7 +123,8 @@ ident sub = defer { feed(0) - feed(1); };
 // Without a callable there is nothing to dispatch on, so the runtime is the root code.
 func TestBuildWithoutCallables(t *testing.T) {
 	code := build(t, "ident a = 1 + 2;\n", byteutil.DefaultTapeSize)
-	runtime := code[INSTANTIATE_BLOCK_SIZE:]
+	// Past the constructor, and past the six bytes that say where the first frame begins.
+	runtime := code[INSTANTIATE_BLOCK_SIZE+FRAME_START_SIZE:]
 
 	if runtime[0] == OpPush1 && len(runtime) > 2 && runtime[2] == OpCallDataLoad {
 		t.Error("no dispatcher should be emitted when there is no callable")
@@ -155,22 +158,24 @@ func TestBuildFollowsTheTapeSize(t *testing.T) {
 	}
 }
 
+// Every runtime opens by saying where the first frame begins, whatever else it holds, so that
+// is in every count here.
 func TestGetRuntimeCodeLength(t *testing.T) {
 	cases := []struct {
 		name string
 		code *RuntimeCode
 		want int
 	}{
-		{name: "empty", code: &RuntimeCode{}, want: 0},
+		{name: "empty", code: &RuntimeCode{}, want: FRAME_START_SIZE},
 		{
 			name: "root only",
 			code: &RuntimeCode{Root: bytes.NewBuffer([]byte{1, 2, 3})},
-			want: 3,
+			want: FRAME_START_SIZE + 3,
 		},
 		{
 			name: "one dispatcher",
 			code: &RuntimeCode{Dispatchers: []Dispatcher{{Code: bytes.NewBuffer([]byte{1, 2})}}},
-			want: DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE + 2,
+			want: FRAME_START_SIZE + DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE + 2,
 		},
 		{
 			name: "dispatchers and root",
@@ -181,7 +186,7 @@ func TestGetRuntimeCodeLength(t *testing.T) {
 				},
 				Root: bytes.NewBuffer([]byte{4, 5, 6, 7}),
 			},
-			want: 2*DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE + 3 + 4,
+			want: FRAME_START_SIZE + 2*DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE + 3 + 4,
 		},
 	}
 
@@ -260,15 +265,16 @@ func TestWriteNoMatchDispatcher(t *testing.T) {
 	}
 }
 
-// Nothing to dispatch on means no dispatcher block and no no-match stop.
+// Nothing to dispatch on means no dispatcher block and no no-match stop — but every call
+// still opens by saying where its frame begins, whatever it goes on to do.
 func TestWriteDispatchersWithNone(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
 	written, err := WriteDispatchers(buf, nil)
 	if err != nil {
 		t.Fatalf("WriteDispatchers: %v", err)
 	}
-	if written != 0 || buf.Len() != 0 {
-		t.Errorf("wrote %d bytes, want none", buf.Len())
+	if written != FRAME_START_SIZE || buf.Len() != FRAME_START_SIZE {
+		t.Errorf("wrote %d bytes, want the %d that say where the frame begins", buf.Len(), FRAME_START_SIZE)
 	}
 }
 
@@ -284,7 +290,7 @@ func TestWriteDispatchersReportsItsSize(t *testing.T) {
 		t.Fatalf("WriteDispatchers: %v", err)
 	}
 
-	want := 2*DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE
+	want := FRAME_START_SIZE + 2*DISPATCHER_BYTES_SIZE + NO_MATCH_DISPATCHER_SIZE
 	if written != want {
 		t.Errorf("reported %d bytes, want %d", written, want)
 	}
@@ -298,7 +304,8 @@ func TestDispatcherSelectorsDiffer(t *testing.T) {
 	code := build(t, `ident add = defer { feed(0); };
 ident sub = defer { feed(0); };
 `, byteutil.DefaultTapeSize)
-	runtime := code[INSTANTIATE_BLOCK_SIZE:]
+	// Past the constructor, and past the six bytes that say where the first frame begins.
+	runtime := code[INSTANTIATE_BLOCK_SIZE+FRAME_START_SIZE:]
 
 	// The selector sits after PUSH1 00 CALLDATALOAD PUSH1 e0 SHR PUSH4.
 	const selectorAt = 8

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -330,7 +330,7 @@ func TestBuildIsDeterministic(t *testing.T) {
 
 func TestWriteCodeEndsInStop(t *testing.T) {
 	buf := bytes.NewBuffer(nil)
-	if _, err := WriteCode(buf, NewIdentManager(), nil, 0, ScopeOf(nil, byteutil.DefaultTapeSize, true)); err != nil {
+	if _, err := WriteCode(buf, NewIdentManager(), nil, 0, ScopeOf(nil, byteutil.DefaultTapeSize, nil, true)); err != nil {
 		t.Fatalf("WriteCode: %v", err)
 	}
 	got := buf.Bytes()

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -51,6 +51,8 @@ const (
 	// FRAME_START_SIZE is what writing where the first frame begins measures: a push of the
 	// address, a push of the slot, and the store.
 	FRAME_START_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
+	// ANSWER_SIZE is what handing a value to the chain measures.
+	ANSWER_SIZE = PUSH_ONE_SIZE + 1 + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1
 )
 
 type Dispatcher struct {
@@ -106,7 +108,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 	// a jump inside it carries an address in the contract, and that address depends on how
 	// many scopes come before it, which is not known until they have all been found.
 	code := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteCode(code, NewIdentManagerAt(FrameNamesAt(body)), body, b.tapeSize, 0); err != nil {
+	if err := WriteScope(code, body, b.tapeSize, 0); err != nil {
 		return nil, cursor, false
 	}
 
@@ -123,7 +125,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 	// Prepend OpJumpDestiny so the EVM can jump to this block when the selector matches.
 	d = &Dispatcher{
 		Selector: selector,
-		Code:     bytes.NewBuffer(append([]byte{OpJumpDestiny}, code.Bytes()...)),
+		Code:     code,
 		Offset:   offset,
 		Length:   code.Len(),
 		Body:     body,
@@ -140,7 +142,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 		inst := b.GetInstruction()
 		if d, nextCursor, ok := b.PickDeferAtCursor(b.cursor, offset); ok {
 			dispatchers = append(dispatchers, *d)
-			offset += 1 + d.Length
+			offset += d.Length
 			// Skip the OpIdent that assigns the defer to a variable; it has no EVM meaning (selector is already in the dispatcher).
 			b.cursor = nextCursor + 1
 			continue
@@ -161,18 +163,17 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	for at := range dispatchers {
 		d := &dispatchers[at]
 		code := bytes.NewBuffer(make([]byte, 0))
-		// One past the offset, because a scope opens with the JUMPDEST its dispatcher
-		// jumps to.
-		if _, err := WriteCode(code, NewIdentManagerAt(FrameNamesAt(d.Body)), d.Body, b.tapeSize, referenced+d.Offset+1); err != nil {
+		if err := WriteScope(code, d.Body, b.tapeSize, referenced+d.Offset); err != nil {
 			return nil, err
 		}
-		d.Code = bytes.NewBuffer(append([]byte{OpJumpDestiny}, code.Bytes()...))
+		d.Code = code
 	}
 
 	if len(rootinsts) > 0 {
 		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
-		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, b.tapeSize, referenced+offset); err != nil {
+		// Code no scope holds: nobody called it, so its return ends the call.
+		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, b.tapeSize, referenced+offset, true); err != nil {
 			return nil, err
 		}
 		return &RuntimeCode{Root: root, Dispatchers: dispatchers}, nil

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -39,6 +39,18 @@ const (
 	// it is refused rather than written, because writing it produces a binary that deploys
 	// and is not the program.
 	MAX_CONTRACT_SIZE = 24576
+	// FRAME_POINTER is the slot of memory holding where the running scope's frame starts.
+	// Everything a scope keeps — the values applied to it, and the names it binds — lives at
+	// an offset from there, so two activations of one scope do not share a place.
+	FRAME_POINTER = 0x00
+	// RETURN_SCRATCH is where a value is put to be handed to the chain. It is not part of a
+	// frame: it is written and returned in the same breath, and nothing reads it after.
+	RETURN_SCRATCH = 0x20
+	// FRAME_BASE is where the first frame starts, past the two slots above.
+	FRAME_BASE = 0x40
+	// FRAME_START_SIZE is what writing where the first frame begins measures: a push of the
+	// address, a push of the slot, and the store.
+	FRAME_START_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
 )
 
 type Dispatcher struct {
@@ -57,11 +69,10 @@ type RuntimeCode struct {
 }
 
 type Builder struct {
-	tapeSize     int
-	cursor       int
-	insts        []ir.Instruction
-	operands     [][]byte
-	identManager *IdentManager
+	tapeSize int
+	cursor   int
+	insts    []ir.Instruction
+	operands [][]byte
 }
 
 func (b *Builder) GetInstruction() ir.Instruction {
@@ -95,7 +106,7 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 	// a jump inside it carries an address in the contract, and that address depends on how
 	// many scopes come before it, which is not known until they have all been found.
 	code := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteCode(code, NewIdentManager(), body, b.tapeSize, 0); err != nil {
+	if _, err := WriteCode(code, NewIdentManagerAt(FrameNamesAt(body)), body, b.tapeSize, 0); err != nil {
 		return nil, cursor, false
 	}
 
@@ -141,16 +152,18 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	// Where each scope lands is known only now, since it depends on how many there are: the
 	// dispatcher block comes first and every entry of it is the same size. So they are
 	// written again, this time with the address they will have.
-	referenced := DISPATCHER_BYTES_SIZE*len(dispatchers) + NO_MATCH_DISPATCHER_SIZE
-	if len(dispatchers) == 0 {
-		referenced = 0
+	// The runtime opens by saying where the first frame begins, and the scopes come after
+	// the dispatcher, so both are ahead of every body.
+	referenced := FRAME_START_SIZE
+	if len(dispatchers) > 0 {
+		referenced += DISPATCHER_BYTES_SIZE*len(dispatchers) + NO_MATCH_DISPATCHER_SIZE
 	}
 	for at := range dispatchers {
 		d := &dispatchers[at]
 		code := bytes.NewBuffer(make([]byte, 0))
 		// One past the offset, because a scope opens with the JUMPDEST its dispatcher
 		// jumps to.
-		if _, err := WriteCode(code, b.identManager, d.Body, b.tapeSize, referenced+d.Offset+1); err != nil {
+		if _, err := WriteCode(code, NewIdentManagerAt(FrameNamesAt(d.Body)), d.Body, b.tapeSize, referenced+d.Offset+1); err != nil {
 			return nil, err
 		}
 		d.Code = bytes.NewBuffer(append([]byte{OpJumpDestiny}, code.Bytes()...))
@@ -159,7 +172,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	if len(rootinsts) > 0 {
 		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
-		if _, err := WriteCode(root, b.identManager, rootinsts, b.tapeSize, referenced+offset); err != nil {
+		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, b.tapeSize, referenced+offset); err != nil {
 			return nil, err
 		}
 		return &RuntimeCode{Root: root, Dispatchers: dispatchers}, nil
@@ -212,10 +225,9 @@ type NewBuilderOptions struct {
 
 func NewBuilder(insts []ir.Instruction, options NewBuilderOptions) *Builder {
 	return &Builder{
-		tapeSize:     byteutil.TapeSize(options.TapeSize),
-		operands:     make([][]byte, 0),
-		identManager: NewIdentManager(),
-		cursor:       0,
-		insts:        insts,
+		tapeSize: byteutil.TapeSize(options.TapeSize),
+		operands: make([][]byte, 0),
+		cursor:   0,
+		insts:    insts,
 	}
 }

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -143,12 +143,12 @@ func (b *Builder) pickScopes() (dispatchers []Dispatcher, root []ir.Instruction)
 // It measures by writing to something that only counts, rather than by writing the whole scope
 // into a buffer that is then thrown away — which is what this did, since where a scope lands
 // is not known until every scope has been found and the scope has to be written again anyway.
-func (b *Builder) measureScopes(dispatchers []Dispatcher) (int, error) {
+func (b *Builder) measureScopes(dispatchers []Dispatcher, entries map[string]int) (int, error) {
 	offset := 0
 	for at := range dispatchers {
 		d := &dispatchers[at]
 		var measured counter
-		if err := WriteScope(&measured, d.Body, b.tapeSize, 0); err != nil {
+		if err := WriteScope(&measured, d.Body, b.tapeSize, 0, entries); err != nil {
 			return 0, err
 		}
 		d.Offset, d.Length = offset, int(measured)
@@ -163,7 +163,16 @@ func (b *Builder) measureScopes(dispatchers []Dispatcher) (int, error) {
 func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	dispatchers, rootinsts := b.pickScopes()
 
-	offset, err := b.measureScopes(dispatchers)
+	// The names come before any address of one does: a call inside a scope has to be written
+	// while the scopes are still being measured, and what it needs then is only that the name
+	// it calls is a scope of this contract. The addresses are filled in below, into this same
+	// map, once there are addresses to fill in.
+	entries := make(map[string]int, len(dispatchers))
+	for at := range dispatchers {
+		entries[string(dispatchers[at].Selector)] = 0
+	}
+
+	offset, err := b.measureScopes(dispatchers, entries)
 	if err != nil {
 		return nil, err
 	}
@@ -177,8 +186,17 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 
 	for at := range dispatchers {
 		d := &dispatchers[at]
+		internal, err := ScopeInternalAt(referenced+d.Offset, d.Body, b.tapeSize)
+		if err != nil {
+			return nil, err
+		}
+		entries[string(d.Selector)] = internal
+	}
+
+	for at := range dispatchers {
+		d := &dispatchers[at]
 		code := bytes.NewBuffer(make([]byte, 0))
-		if err := WriteScope(code, d.Body, b.tapeSize, referenced+d.Offset); err != nil {
+		if err := WriteScope(code, d.Body, b.tapeSize, referenced+d.Offset, entries); err != nil {
 			return nil, err
 		}
 		d.Code = code
@@ -188,7 +206,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
 		// Code no scope holds: nobody called it, so its return ends the call.
-		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, referenced+offset, ScopeOf(rootinsts, b.tapeSize, true)); err != nil {
+		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, referenced+offset, ScopeOf(rootinsts, b.tapeSize, entries, true)); err != nil {
 			return nil, err
 		}
 		return &RuntimeCode{Root: root, Dispatchers: dispatchers}, nil

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -81,12 +81,18 @@ func (b *Builder) GetInstruction() ir.Instruction {
 	return b.insts[b.cursor]
 }
 
-// PickDeferAtCursor tries to parse a deferred scope at the given cursor.
-// If insts[cursor] is OpDefer with a valid body and the next instruction is OpIdent,
-// it returns the Dispatcher (with Offset and Length set), the cursor position after
-// the defer body (pointing at the OpIdent), and true. Otherwise returns (nil, cursor, false).
-// Does not mutate b.cursor.
-func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, nextCursor int, ok bool) {
+// PickDeferAtCursor answers the scope written at this cursor, if one is: the instructions of
+// its body and the name it was bound to.
+//
+// It finds the scope and does not write it. Where a scope lands depends on how many come
+// before it, and none of that is known while they are still being found — so writing here
+// meant writing every scope twice, throwing the first away, and reporting a failure to write
+// as "there is no scope here", which is a different thing and hid the reason.
+//
+// A scope reaches the chain as an entry in the dispatcher, and what the dispatcher matches on
+// is the name it was bound to. So the binding that follows the body is part of finding one: a
+// scope nothing was bound to is nothing a transaction can reach.
+func (b *Builder) PickDeferAtCursor(cursor int) (d *Dispatcher, nextCursor int, ok bool) {
 	if cursor >= len(b.insts) {
 		return nil, cursor, false
 	}
@@ -98,68 +104,77 @@ func (b *Builder) PickDeferAtCursor(cursor int, offset int) (d *Dispatcher, next
 	// OpDefer layout: [OpDefer] [body of length N] [OpIdent]. Right operand = N (body length in instructions).
 	bodylength := byteutil.ToUint64(inst.GetRight().Bytes())
 	end := cursor + 1 + int(bodylength)
-	if end > len(b.insts) {
-		return nil, cursor, false
-	}
-	body := b.insts[cursor+1 : end]
-	body = Lowering(body, b.tapeSize)
-
-	// Written once to find out how long it is, and once more when where it lands is known —
-	// a jump inside it carries an address in the contract, and that address depends on how
-	// many scopes come before it, which is not known until they have all been found.
-	code := bytes.NewBuffer(make([]byte, 0))
-	if err := WriteScope(code, body, b.tapeSize, 0); err != nil {
-		return nil, cursor, false
-	}
-
-	// Defer must be assigned to an ident (e.g. "ident f = defer { ... }"); that OpIdent is the selector.
 	if end >= len(b.insts) {
 		return nil, cursor, false
 	}
+
 	selectorInst := b.insts[end]
 	if selectorInst.GetOpCode() != ir.OpIdent {
 		return nil, cursor, false
 	}
-	selector := selectorInst.GetLeft().Bytes()
 
-	// Prepend OpJumpDestiny so the EVM can jump to this block when the selector matches.
-	d = &Dispatcher{
-		Selector: selector,
-		Code:     code,
-		Offset:   offset,
-		Length:   code.Len(),
-		Body:     body,
-	}
-	return d, end, true
+	body := Lowering(b.insts[cursor+1:end], b.tapeSize)
+	return &Dispatcher{Selector: selectorInst.GetLeft().Bytes(), Body: body}, end, true
 }
 
-func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
-	dispatchers := make([]Dispatcher, 0)
-	rootinsts := make([]ir.Instruction, 0)
-	offset := 0
+// pickScopes separates the scopes a transaction can reach from the code that is not held by
+// one, which is the top of the program.
+func (b *Builder) pickScopes() (dispatchers []Dispatcher, root []ir.Instruction) {
+	dispatchers = make([]Dispatcher, 0)
+	root = make([]ir.Instruction, 0)
 
 	for b.cursor < len(b.insts) {
-		inst := b.GetInstruction()
-		if d, nextCursor, ok := b.PickDeferAtCursor(b.cursor, offset); ok {
+		if d, nextCursor, ok := b.PickDeferAtCursor(b.cursor); ok {
 			dispatchers = append(dispatchers, *d)
-			offset += d.Length
-			// Skip the OpIdent that assigns the defer to a variable; it has no EVM meaning (selector is already in the dispatcher).
+			// Skip the binding that named the scope: it is the dispatcher's selector and
+			// has no meaning of its own on chain.
 			b.cursor = nextCursor + 1
 			continue
 		}
-		rootinsts = append(rootinsts, inst)
+		root = append(root, b.GetInstruction())
 		b.cursor++
 	}
 
-	// Where each scope lands is known only now, since it depends on how many there are: the
-	// dispatcher block comes first and every entry of it is the same size. So they are
-	// written again, this time with the address they will have.
-	// The runtime opens by saying where the first frame begins, and the scopes come after
-	// the dispatcher, so both are ahead of every body.
+	return dispatchers, root
+}
+
+// measureScopes answers how long each scope is and where it falls among them.
+//
+// It measures by writing to something that only counts, rather than by writing the whole scope
+// into a buffer that is then thrown away — which is what this did, since where a scope lands
+// is not known until every scope has been found and the scope has to be written again anyway.
+func (b *Builder) measureScopes(dispatchers []Dispatcher) (int, error) {
+	offset := 0
+	for at := range dispatchers {
+		d := &dispatchers[at]
+		var measured counter
+		if err := WriteScope(&measured, d.Body, b.tapeSize, 0); err != nil {
+			return 0, err
+		}
+		d.Offset, d.Length = offset, int(measured)
+		offset += d.Length
+	}
+	return offset, nil
+}
+
+// PickRuntimeCode assembles the runtime in passes, each of which needs the one before it:
+// the scopes are found, then measured, and only then written — a jump inside a scope carries
+// an address in the contract, and that address depends on how many scopes come before it.
+func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
+	dispatchers, rootinsts := b.pickScopes()
+
+	offset, err := b.measureScopes(dispatchers)
+	if err != nil {
+		return nil, err
+	}
+
+	// The runtime opens by saying where the first frame begins, and the scopes come after the
+	// dispatcher, so both are ahead of every body.
 	referenced := FRAME_START_SIZE
 	if len(dispatchers) > 0 {
 		referenced += DISPATCHER_BYTES_SIZE*len(dispatchers) + NO_MATCH_DISPATCHER_SIZE
 	}
+
 	for at := range dispatchers {
 		d := &dispatchers[at]
 		code := bytes.NewBuffer(make([]byte, 0))

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -173,7 +173,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 		rootinsts = Lowering(rootinsts, b.tapeSize)
 		root := bytes.NewBuffer(make([]byte, 0))
 		// Code no scope holds: nobody called it, so its return ends the call.
-		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, b.tapeSize, referenced+offset, true); err != nil {
+		if _, err := WriteCode(root, NewIdentManagerAt(FrameNamesAt(rootinsts)), rootinsts, referenced+offset, ScopeOf(rootinsts, b.tapeSize, true)); err != nil {
 			return nil, err
 		}
 		return &RuntimeCode{Root: root, Dispatchers: dispatchers}, nil

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -96,7 +96,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				WritePush(want, byteutil.FromUint64(4294967295), byteutil.DefaultTapeSize)
 				WriteAdd(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
-				WriteReturn(want)
+				WriteAnswer(want)
 				// The scope reads no position, so its names begin at the frame.
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)
@@ -113,7 +113,7 @@ func TestPickRuntimeCode(t *testing.T) {
 			func(got []byte) error {
 				want := bytes.NewBuffer(make([]byte, 0))
 				WritePush(want, byteutil.TrueTape(byteutil.DefaultTapeSize), byteutil.DefaultTapeSize)
-				WriteReturn(want)
+				WriteAnswer(want)
 				// The scope reads no position, so its names begin at the frame.
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)
@@ -133,7 +133,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				WriteGetArg(want, byteutil.FromUint64(0), byteutil.DefaultTapeSize)
 				WriteSubtract(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
-				WriteReturn(want)
+				WriteAnswer(want)
 				// The scope reads two positions, so its names begin past them.
 				WriteIdent(want, NewIdentManagerAt(2*MEMORY_SLOT_SIZE), []byte("a"))
 				WriteStop(want)

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -97,6 +97,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				WriteAdd(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
 				WriteReturn(want)
+				// The scope reads no position, so its names begin at the frame.
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)
 				if !bytes.Equal(got, want.Bytes()) {
@@ -113,6 +114,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want := bytes.NewBuffer(make([]byte, 0))
 				WritePush(want, byteutil.TrueTape(byteutil.DefaultTapeSize), byteutil.DefaultTapeSize)
 				WriteReturn(want)
+				// The scope reads no position, so its names begin at the frame.
 				WriteIdent(want, NewIdentManager(), []byte("a"))
 				WriteStop(want)
 				if !bytes.Equal(got, want.Bytes()) {
@@ -132,7 +134,8 @@ func TestPickRuntimeCode(t *testing.T) {
 				WriteSubtract(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
 				WriteReturn(want)
-				WriteIdent(want, NewIdentManager(), []byte("a"))
+				// The scope reads two positions, so its names begin past them.
+				WriteIdent(want, NewIdentManagerAt(2*MEMORY_SLOT_SIZE), []byte("a"))
 				WriteStop(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -180,15 +180,13 @@ func TestPickRuntimeCode(t *testing.T) {
 
 func TestPickDeferAtCursor(t *testing.T) {
 	cases := []struct {
-		Name                 string
-		Insts                []ir.Instruction
-		Cursor               int
-		Offset               int
-		WantOK               bool
-		WantNextCursor       int
-		WantSelector         string // only checked when WantOK
-		WantDispatcherOffset int    // only checked when WantOK
-		WantCodeNonEmpty     bool   // only checked when WantOK
+		Name           string
+		Insts          []ir.Instruction
+		Cursor         int
+		WantOK         bool
+		WantNextCursor int
+		WantSelector   string // only checked when WantOK
+		WantBodyLength int    // only checked when WantOK
 	}{
 		{
 			Name: "valid_defer",
@@ -198,13 +196,11 @@ func TestPickDeferAtCursor(t *testing.T) {
 				ir.NewInstruction([]byte("2"), ir.OpReturn, ir.RefTo(nil), ir.RefTo(nil)),
 				ir.NewInstruction([]byte("3"), ir.OpIdent, ir.NameOf("f"), ir.RefTo([]byte("0"))),
 			},
-			Cursor:               0,
-			Offset:               0,
-			WantOK:               true,
-			WantNextCursor:       3,
-			WantSelector:         "f",
-			WantDispatcherOffset: 0,
-			WantCodeNonEmpty:     true,
+			Cursor:         0,
+			WantOK:         true,
+			WantNextCursor: 3,
+			WantSelector:   "f",
+			WantBodyLength: 2,
 		},
 		{
 			Name: "not_op_defer",
@@ -212,7 +208,6 @@ func TestPickDeferAtCursor(t *testing.T) {
 				ir.NewInstruction(nil, ir.OpBeginScope, ir.Nothing(), ir.Nothing()),
 			},
 			Cursor:         0,
-			Offset:         0,
 			WantOK:         false,
 			WantNextCursor: 0,
 		},
@@ -225,7 +220,6 @@ func TestPickDeferAtCursor(t *testing.T) {
 				ir.NewInstruction(nil, ir.OpAdd, ir.RefTo(nil), ir.RefTo(nil)),
 			},
 			Cursor:         0,
-			Offset:         0,
 			WantOK:         false,
 			WantNextCursor: 0,
 		},
@@ -234,7 +228,7 @@ func TestPickDeferAtCursor(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.Name, func(t *testing.T) {
 			b := NewBuilder(c.Insts, NewBuilderOptions{})
-			d, nextCursor, ok := b.PickDeferAtCursor(c.Cursor, c.Offset)
+			d, nextCursor, ok := b.PickDeferAtCursor(c.Cursor)
 			if ok != c.WantOK {
 				t.Errorf("ok = %v, want %v", ok, c.WantOK)
 			}
@@ -250,11 +244,12 @@ func TestPickDeferAtCursor(t *testing.T) {
 			if c.WantSelector != "" && string(d.Selector) != c.WantSelector {
 				t.Errorf("selector = %q, want %q", d.Selector, c.WantSelector)
 			}
-			if d.Offset != c.WantDispatcherOffset {
-				t.Errorf("Offset = %d, want %d", d.Offset, c.WantDispatcherOffset)
+			if len(d.Body) != c.WantBodyLength {
+				t.Errorf("body is %d instructions, want %d", len(d.Body), c.WantBodyLength)
 			}
-			if c.WantCodeNonEmpty && (d.Code == nil || d.Code.Len() == 0) {
-				t.Error("expected dispatcher code to be non-empty")
+			// Finding a scope does not write it: where it lands is not known yet.
+			if d.Code != nil {
+				t.Error("a scope was written while it was being found")
 			}
 		})
 	}

--- a/builder/evm/getter.go
+++ b/builder/evm/getter.go
@@ -1,7 +1,8 @@
 package evm
 
 func GetRuntimeCodeLength(rc *RuntimeCode) int {
-	l := 0
+	// Every call opens by saying where its frame begins.
+	l := FRAME_START_SIZE
 	// Dispatcher block (selector checks + no-match STOP) is written before body code.
 	if len(rc.Dispatchers) > 0 {
 		l += DISPATCHER_BYTES_SIZE*len(rc.Dispatchers) + NO_MATCH_DISPATCHER_SIZE

--- a/builder/evm/ident.go
+++ b/builder/evm/ident.go
@@ -1,7 +1,19 @@
 package evm
 
+// An IdentManager gives each name of one scope a place in that scope's frame.
+//
+// It belongs to a scope and not to a contract. It used to belong to the contract, so two
+// scopes binding a name each were given the same place — and two activations of one scope
+// were as well, which is what kept a scope from calling itself.
 type IdentManager struct {
 	offsetIdents map[string]int
+	base         int
+}
+
+// Base is how far into the frame this scope's names begin: past the places the values applied
+// to it are kept.
+func (m *IdentManager) Base() int {
+	return m.base
 }
 
 func (m *IdentManager) GetOffset(ident []byte) int {
@@ -17,5 +29,10 @@ func (m *IdentManager) GetLength() uint {
 }
 
 func NewIdentManager() *IdentManager {
-	return &IdentManager{offsetIdents: make(map[string]int)}
+	return NewIdentManagerAt(0)
+}
+
+// NewIdentManagerAt makes one whose names begin at an offset of the frame.
+func NewIdentManagerAt(base int) *IdentManager {
+	return &IdentManager{offsetIdents: make(map[string]int), base: base}
 }

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -39,6 +39,7 @@ var handled = map[byte]bool{
 	ir.OpAnd:         true,
 	ir.OpOr:          true,
 	ir.OpExponential: true,
+	ir.OpCall:        true,
 }
 
 // offChain is what is meant to be absent from a chain. Saying so is still worth a line: a
@@ -55,7 +56,6 @@ var offChain = map[byte]string{
 var pending = map[byte]string{
 	ir.OpIf:      "if",
 	ir.OpJump:    "if",
-	ir.OpCall:    "calling a scope",
 	ir.OpPreCall: "calling a scope",
 	ir.OpDiff:    "a comparison",
 	ir.OpEquals:  "a comparison",

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -55,9 +55,9 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			want:    []string{"shape does not reach the bytecode yet"},
 		},
 		{
-			name:    "calling a scope",
-			opcodes: []byte{ir.OpCall},
-			want:    []string{"calling a scope does not reach the bytecode yet"},
+			name:     "calling a scope, which reaches the bytecode now",
+			opcodes:  []byte{ir.OpCall},
+			wantNone: true,
 		},
 		{
 			// A log is not a gap: it is absent on purpose, and the wording says so.
@@ -131,8 +131,8 @@ func TestWarningsFollowTheProgram(t *testing.T) {
 // carries where every instruction came from now, so the backend points at the first line that
 // used what it cannot carry.
 func TestWarningsPointAtWhereTheFeatureWasUsed(t *testing.T) {
-	const source = `ident sum = defer { feed(0) + feed(1); };
-printb sum(1, 2);`
+	const source = `printb 1;
+ident t = [1, 2];`
 
 	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
@@ -148,18 +148,18 @@ printb sum(1, 2);`
 	}
 
 	for _, warning := range Warnings(insts) {
-		if !strings.Contains(warning.Message, "calling a scope") {
+		if !strings.Contains(warning.Message, "a tape operation") {
 			continue
 		}
 		if !warning.Positioned() {
-			t.Fatal("the warning about calling a scope has no place to point at")
+			t.Fatal("the warning about a tape operation has no place to point at")
 		}
 		if warning.Line != 2 {
-			t.Errorf("it points at line %d, want the line the call was written on", warning.Line)
+			t.Errorf("it points at line %d, want the line the tape was written on", warning.Line)
 		}
 		return
 	}
-	t.Fatal("nothing warned about calling a scope")
+	t.Fatal("nothing warned about a tape operation")
 }
 
 // Every feature the backend cannot carry names the line it was written on. A warning that
@@ -171,7 +171,6 @@ func TestEveryPendingFeatureNamesItsPlace(t *testing.T) {
 		says   string
 		line   int
 	}{
-		{name: "a call", source: "ident f = defer { 1; };\nprintb f();", says: "calling a scope", line: 2},
 		// A tape literal is itself a tape operation — it builds the run byte by byte — so
 		// the first place the program uses one is the literal, not the pull below it.
 		{name: "a tape operation", source: "printb 1;\nident t = [1];\nprintb pull t 2;", says: "a tape operation", line: 2},

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -71,6 +71,9 @@ type IdentOffsetMapper interface {
 	GetOffset(ident []byte) int
 	SetOffset(ident string, offset int)
 	GetLength() uint
+	// Base is how far into the frame the names of this scope begin, past the places the
+	// values applied to it are kept.
+	Base() int
 }
 
 // WriteIdent stores a value under a name, in a slot of memory of its own.
@@ -79,8 +82,8 @@ type IdentOffsetMapper interface {
 // ninth name in a contract was given the address of the first — 8 * 32 is 256, and one byte
 // holds none of it. Two names became one piece of memory, and each wrote over the other.
 func WriteIdent(w io.Writer, m IdentOffsetMapper, ident []byte) (int, error) {
-	offset := int(m.GetLength()) * MEMORY_SLOT_SIZE
-	if _, err := WritePush2(w, offset); err != nil {
+	offset := m.Base() + int(m.GetLength())*MEMORY_SLOT_SIZE
+	if err := WriteFrameAddress(w, offset); err != nil {
 		return 0, err
 	}
 	if _, err := w.Write([]byte{OpMemoryStore}); err != nil {
@@ -91,7 +94,7 @@ func WriteIdent(w io.Writer, m IdentOffsetMapper, ident []byte) (int, error) {
 }
 
 func WriteLoad(w io.Writer, m IdentOffsetMapper, left []byte) (int, error) {
-	if _, err := WritePush2(w, m.GetOffset(left)); err != nil {
+	if err := WriteFrameAddress(w, m.GetOffset(left)); err != nil {
 		return 0, err
 	}
 	return w.Write([]byte{OpMemoryLoad})
@@ -99,14 +102,64 @@ func WriteLoad(w io.Writer, m IdentOffsetMapper, left []byte) (int, error) {
 
 // WriteReturn assumes the return value is on the stack (e.g. after ADD). It stores it at
 // mem[0] with MSTORE then returns 32 bytes from 0 so RETURN works without prior memory use.
+// WriteReturn hands the value on the stack to the chain.
+//
+// It goes through a slot of its own rather than through the first one, which now holds where
+// the running scope's frame starts: writing the answer there would lose the frame in the act
+// of answering.
 func WriteReturn(w io.Writer) (int, error) {
-	if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil {
+	if _, err := w.Write([]byte{OpPush1, RETURN_SCRATCH}); err != nil {
 		return 0, err
 	}
 	if _, err := w.Write([]byte{OpMemoryStore}); err != nil {
 		return 0, err
 	}
-	return w.Write([]byte{OpPush1, 0x20, OpPush1, 0x00, OpReturn})
+	return w.Write([]byte{OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn})
+}
+
+// WriteFrameAddress puts on the stack where something at this offset of the frame lives.
+//
+// A scope names its places by how far into its frame they are, and where the frame starts is
+// read at the moment it is used — which is what makes two activations of one scope keep their
+// own, and what a call will move.
+func WriteFrameAddress(w io.Writer, offset int) error {
+	if _, err := WritePush2(w, offset); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// FrameNamesAt answers how far into a frame the names of a scope begin.
+//
+// Before them sit the values applied to the scope, one slot each, and how many of those there
+// are is what the body says it reads: the highest position it feeds, plus one. It is the same
+// number the compiler warns a short call about, and it is known where the body is written.
+func FrameNamesAt(insts []ir.Instruction) int {
+	highest := -1
+	for _, inst := range insts {
+		if inst.GetOpCode() != ir.OpGetFeed {
+			continue
+		}
+		if at := int(byteutil.ToUint64(inst.GetLeft().Bytes())); at > highest {
+			highest = at
+		}
+	}
+	return (highest + 1) * MEMORY_SLOT_SIZE
+}
+
+// WriteFrameStart writes where the first frame begins, which every scope reads from until a
+// call moves it.
+func WriteFrameStart(w io.Writer) error {
+	if _, err := WritePush2(w, FRAME_BASE); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{OpPush1, FRAME_POINTER, OpMemoryStore}); err != nil {
+		return err
+	}
+	return nil
 }
 
 // WriteGetArg reads an argument out of the calldata and cuts it to the tape width.
@@ -210,10 +263,21 @@ func WriteDispatcher(bs io.Writer, id string, jumpTo int) (int, error) {
 	return bs.Write([]byte{OpJumpIf})
 }
 
+// WriteDispatchers emits what every call arrives at: where the first frame begins, and then
+// one entry per scope.
+//
+// The frame is set here rather than in the constructor because the constructor does not run
+// with the contract — it runs once, to deploy it, and what it writes to memory then is gone.
+// Every call starts from nothing and says where its frame is.
 func WriteDispatchers(bs io.Writer, ds []Dispatcher) (int, error) {
+	if err := WriteFrameStart(bs); err != nil {
+		return 0, err
+	}
+
 	dispatcherLen := DISPATCHER_BYTES_SIZE * len(ds)
-	// After dispatchers we have the no-match dispatcher (STOP); referenced code starts after it.
-	referencedStart := dispatcherLen + NO_MATCH_DISPATCHER_SIZE
+	// After dispatchers we have the no-match dispatcher (STOP); referenced code starts after
+	// it — and all of it after the frame.
+	referencedStart := FRAME_START_SIZE + dispatcherLen + NO_MATCH_DISPATCHER_SIZE
 
 	for _, d := range ds {
 		jumpTo := referencedStart + d.Offset
@@ -227,10 +291,10 @@ func WriteDispatchers(bs io.Writer, ds []Dispatcher) (int, error) {
 		if _, err := WriteNoMatchDispatcher(bs); err != nil {
 			return 0, err
 		}
-		return dispatcherLen + NO_MATCH_DISPATCHER_SIZE, nil
+		return FRAME_START_SIZE + dispatcherLen + NO_MATCH_DISPATCHER_SIZE, nil
 	}
 
-	return dispatcherLen, nil
+	return FRAME_START_SIZE + dispatcherLen, nil
 }
 
 func WriteBodyCode(bs io.Writer, ds []Dispatcher, root *bytes.Buffer) (int, error) {

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -100,14 +100,12 @@ func WriteLoad(w io.Writer, m IdentOffsetMapper, left []byte) (int, error) {
 	return w.Write([]byte{OpMemoryLoad})
 }
 
-// WriteReturn assumes the return value is on the stack (e.g. after ADD). It stores it at
-// mem[0] with MSTORE then returns 32 bytes from 0 so RETURN works without prior memory use.
-// WriteReturn hands the value on the stack to the chain.
+// WriteAnswer hands the value on the stack to the chain.
 //
-// It goes through a slot of its own rather than through the first one, which now holds where
-// the running scope's frame starts: writing the answer there would lose the frame in the act
-// of answering.
-func WriteReturn(w io.Writer) (int, error) {
+// It goes through a slot of its own rather than through the first one, which holds where the
+// running scope's frame starts: writing the answer there would lose the frame in the act of
+// answering.
+func WriteAnswer(w io.Writer) (int, error) {
 	if _, err := w.Write([]byte{OpPush1, RETURN_SCRATCH}); err != nil {
 		return 0, err
 	}
@@ -115,6 +113,17 @@ func WriteReturn(w io.Writer) (int, error) {
 		return 0, err
 	}
 	return w.Write([]byte{OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn})
+}
+
+// WriteReturn ends a scope: the value it answers with is on the stack, and the address to go
+// back to is under it.
+//
+// It goes back to whoever called and never to the chain, even when the caller is the way in
+// from a transaction. That is what lets one body serve both: a scope called by another has to
+// hand its value over and let that one carry on, and only the way in from a transaction ends
+// the call — which it does in the epilogue, where it belongs.
+func WriteReturn(w io.Writer) (int, error) {
+	return w.Write([]byte{OpSwap1, OpJump})
 }
 
 // WriteFrameAddress puts on the stack where something at this offset of the frame lives.
@@ -130,6 +139,120 @@ func WriteFrameAddress(w io.Writer, offset int) error {
 		return err
 	}
 	return nil
+}
+
+// WriteScopePrologue emits the way in from a transaction.
+//
+// A scope can be entered two ways, and they differ in exactly one thing: where the values
+// applied to it come from. A transaction brings them in the calldata; another scope has them
+// as values it just worked out. Everything after that is the same scope doing the same thing,
+// so it is written once and entered twice:
+//
+//	external:  JUMPDEST          <- the dispatcher jumps here
+//	           <prologue>        copies the calldata into the frame
+//	           PUSH2 <epilogue>  the address to come back to
+//	           PUSH2 <internal>
+//	           JUMP
+//	epilogue:  JUMPDEST          <- the body comes back here, value on the stack
+//	           <answer the chain>
+//	internal:  JUMPDEST          <- another scope jumps here, having written the frame
+//	           <body>            feed(n) reads the frame, whoever filled it
+//	           SWAP1; JUMP       back to whoever called
+//
+// The prologue is what makes the body have one shape. Without it the body would have to know
+// how it was entered — reading the calldata one way and the frame the other — and every
+// instruction that touches an applied value would carry that question. With it, the body
+// reads the frame and nothing else, and the two ways in differ only in who filled it.
+//
+// It copies as many positions as the body addresses, which is the highest it feeds plus one.
+// A position the calldata does not reach reads zero, which is what the language answers for
+// reading past what was applied: CALLDATALOAD past the end gives zeros, so the rule costs
+// nothing to keep.
+//
+// Each value is cut to the tape width on the way in rather than on every read. An argument
+// arrives as a thirty-two byte word whatever the tape is, and letting it through whole would
+// hand a contract a value its own language cannot hold.
+//
+// The body answers to whoever called it and never to the chain, even when the caller is the
+// prologue: answering the chain is what the epilogue does, and keeping it there is what lets
+// the same body serve a transaction and a scope.
+func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal int) error {
+	for at := 0; at < reads; at++ {
+		if _, err := w.Write([]byte{OpPush1, GetCalldataArgsOffset(uint64(at))}); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte{OpCallDataLoad}); err != nil {
+			return err
+		}
+		if _, err := WriteMask(w, tapeSize); err != nil {
+			return err
+		}
+		if err := WriteFrameAddress(w, at*MEMORY_SLOT_SIZE); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte{OpMemoryStore}); err != nil {
+			return err
+		}
+	}
+
+	if _, err := WritePush2(w, epilogue); err != nil {
+		return err
+	}
+	if _, err := WritePush2(w, internal); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{OpJump})
+	return err
+}
+
+// WriteScopeEpilogue emits what a transaction's way in comes back to: the value the scope
+// answered with is on the stack, and it goes to the chain.
+//
+// It is here and not at the end of the body because the body does not know who called it. A
+// scope called by another has to hand its value back and let that one carry on; only the way
+// in from a transaction ends the call.
+func WriteScopeEpilogue(w io.Writer) error {
+	_, err := WriteAnswer(w)
+	return err
+}
+
+// WriteScope emits a scope whole: the way in from a transaction, what that way comes back to,
+// and the body both ways share.
+//
+// The addresses inside it are worked out by measuring the prologue, which is the only part
+// whose length depends on the scope — one copy per position the body addresses. Every push is
+// a fixed size, so measuring once is enough.
+func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int) error {
+	reads := FrameNamesAt(body) / MEMORY_SLOT_SIZE
+
+	var measured counter
+	if err := WriteScopePrologue(&measured, reads, tapeSize, 0, 0); err != nil {
+		return err
+	}
+
+	// The way in opens with a JUMPDEST the dispatcher lands on; the prologue follows; what it
+	// comes back to and the way in from another scope each open with one of their own.
+	epilogue := base + 1 + int(measured)
+	internal := epilogue + 1 + ANSWER_SIZE
+
+	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
+		return err
+	}
+	if err := WriteScopePrologue(bs, reads, tapeSize, epilogue, internal); err != nil {
+		return err
+	}
+	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
+		return err
+	}
+	if err := WriteScopeEpilogue(bs); err != nil {
+		return err
+	}
+	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
+		return err
+	}
+
+	_, err := WriteCode(bs, NewIdentManagerAt(FrameNamesAt(body)), body, tapeSize, internal+1, false)
+	return err
 }
 
 // FrameNamesAt answers how far into a frame the names of a scope begin.
@@ -162,21 +285,20 @@ func WriteFrameStart(w io.Writer) error {
 	return nil
 }
 
-// WriteGetArg reads an argument out of the calldata and cuts it to the tape width.
+// WriteGetArg reads one of the values applied to the running scope.
 //
-// An argument arrives as a 32-byte word whatever the tape is, and the evaluator narrows it to
-// a tape on the way in (environ.NewEnviron). Reading the whole word here would let a caller
-// hand a contract a value its own language cannot hold.
+// It reads the frame, and never the calldata. Whoever entered the scope put them there: the
+// way in from a transaction copies them out of the calldata, and a scope calling another
+// writes the values it worked out. That is the whole of what the frame buys — a body that does
+// not know how it was entered.
+//
+// The narrowing to the tape width happened where the value came in, so there is none here.
 func WriteGetArg(w io.Writer, left []byte, size int) (int, error) {
-	index := byteutil.ToUint64(left)
-	offset := GetCalldataArgsOffset(index)
-	if _, err := w.Write([]byte{OpPush1, offset}); err != nil {
+	at := int(byteutil.ToUint64(left))
+	if err := WriteFrameAddress(w, at*MEMORY_SLOT_SIZE); err != nil {
 		return 0, err
 	}
-	if _, err := w.Write([]byte{OpCallDataLoad}); err != nil {
-		return 0, err
-	}
-	return WriteMask(w, size)
+	return w.Write([]byte{OpMemoryLoad})
 }
 
 func WriteStop(w io.Writer) (int, error) {
@@ -379,7 +501,7 @@ func (c *counter) Write(p []byte) (int, error) {
 //
 // The names are registered into a manager of its own and thrown away, since what is measured
 // is how many bytes an instruction takes and every push is a fixed size now.
-func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, arms map[string]bool) ([]int, error) {
+func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, arms map[string]bool, answers bool) ([]int, error) {
 	positions := make([]int, len(insts)+1)
 	im := NewIdentManager()
 	for at, inst := range insts {
@@ -387,7 +509,7 @@ func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, ar
 		if landings[at] {
 			measured++
 		}
-		if err := WriteInstruction(&measured, im, inst, tapeSize, 0, arms); err != nil {
+		if err := WriteInstruction(&measured, im, inst, tapeSize, 0, arms, answers); err != nil {
 			return nil, err
 		}
 		positions[at+1] = positions[at] + int(measured)
@@ -450,7 +572,11 @@ func targetOf(inst ir.Instruction, at int, positions []int) int {
 // Arms answers whether an OpReturn ends a branch rather than a scope. The two are the same
 // opcode: one says "the value of this scope" and the other "the value of this arm", and which
 // it is can be read — an arm names the OpIf it belongs to, and a scope names the OpBeginScope.
-func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, target int, arms map[string]bool) error {
+//
+// Answers says what the third kind does. Code that no scope holds — the top of a program, run
+// when a contract has no scope to dispatch to — has nobody to go back to, so its return ends
+// the call rather than handing a value over.
+func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, target int, arms map[string]bool, answers bool) error {
 	op := inst.GetOpCode()
 
 	if handled[op] && op != ir.OpSave {
@@ -496,7 +622,11 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		// The value of an arm is already on the stack, which is where whoever is under the
 		// branch finds it: there is nothing to write. Only a scope answers to the chain.
 		if !arms[byteutil.ToHex(inst.GetLeft().Bytes())] {
-			if _, err := WriteReturn(bs); err != nil {
+			write := WriteReturn
+			if answers {
+				write = WriteAnswer
+			}
+			if _, err := write(bs); err != nil {
 				return err
 			}
 		}
@@ -579,11 +709,11 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 // The base is where this scope lands in the runtime, since a jump carries an address in the
 // contract and not an offset into a scope. It is zero while a scope is being measured, and the
 // measurement does not depend on it.
-func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int, base int) (int, error) {
+func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int, base int, answers bool) (int, error) {
 	landings := landingsOf(insts)
 	arms := armsOf(insts)
 
-	positions, err := PositionsOf(insts, tapeSize, landings, arms)
+	positions, err := PositionsOf(insts, tapeSize, landings, arms, answers)
 	if err != nil {
 		return 0, err
 	}
@@ -594,7 +724,7 @@ func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize 
 				return 0, err
 			}
 		}
-		if err := WriteInstruction(bs, im, inst, tapeSize, base+targetOf(inst, at, positions), arms); err != nil {
+		if err := WriteInstruction(bs, im, inst, tapeSize, base+targetOf(inst, at, positions), arms, answers); err != nil {
 			return 0, err
 		}
 	}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"bytes"
+	"fmt"
 	"io"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -216,24 +217,151 @@ func WriteScopeEpilogue(w io.Writer) error {
 	return err
 }
 
+// WriteCall enters another scope of this contract and comes back with what it answered.
+//
+// It is a jump, and deliberately not a message call. A message call to your own contract is a
+// transaction against yourself: a frame of execution of its own, its own gas stipend, its own
+// view of storage, and an answer that comes back as returndata to be copied out. None of that
+// is what one scope calling another means, and paying for it would make a call inside a
+// program cost what a call between contracts costs.
+//
+// What a jump does not bring is anywhere for the callee to keep the values applied to it, and
+// that is what the frame is for. The callee's goes right after the caller's, so the two never
+// share a slot — which is also what lets a scope be entered while it is already running.
+//
+//	<put each applied value in the callee's frame>
+//	<move the frame pointer past this scope's frame>
+//	PUSH2 <back>        where to carry on once the callee answers
+//	PUSH2 <internal>    the callee, entered past its prologue: its frame is written already
+//	JUMP
+//	back: JUMPDEST
+//	<move the frame pointer back>
+//
+// The applied values reach the frame from two places, and the order matters. One the program
+// wrote down, and this is where it reaches the stack at all. One another instruction worked
+// out, and it is on the stack already — the lowering put its producer right in front of this
+// call. So the written-down ones are stored first, each pushed and put away in one breath, and
+// the worked-out ones are taken off the top afterwards, in reverse of the order they went on.
+//
+// The pointer is moved back by subtracting what moved it forward rather than by keeping a
+// copy, because a copy would have to be kept somewhere across the call — and the only
+// somewhere is the stack, under an answer the callee's own work is piled on top of.
+func WriteCall(w io.Writer, inst ir.Instruction, scope Scope, at int) error {
+	name := string(inst.GetLeft().Bytes())
+	internal, known := scope.Entries[name]
+	if !known {
+		return fmt.Errorf(
+			"a call to %q cannot be written: only a scope bound at the top of a program reaches the bytecode", name)
+	}
+
+	// Where to carry on is where this call ends, which is known by writing it: every push is
+	// a fixed size, so what is measured with a wrong address is what is written with the
+	// right one.
+	var measured counter
+	if err := writeCallOut(&measured, inst, scope, 0, internal); err != nil {
+		return err
+	}
+	if err := writeCallOut(w, inst, scope, at+int(measured), internal); err != nil {
+		return err
+	}
+
+	if _, err := w.Write([]byte{OpJumpDestiny}); err != nil {
+		return err
+	}
+	return writeFrameMove(w, scope.Frame, OpSub)
+}
+
+// writeCallOut fills the callee's frame, moves the pointer onto it, and goes.
+func writeCallOut(w io.Writer, inst ir.Instruction, scope Scope, back, internal int) error {
+	applied := valueOperands(inst)
+
+	for at, operand := range applied {
+		if operand.Kind() != ir.KindImm {
+			continue
+		}
+		if _, err := WritePush(w, operand.Bytes(), scope.TapeSize); err != nil {
+			return err
+		}
+		if err := writeFrameStore(w, scope.Frame+at*MEMORY_SLOT_SIZE); err != nil {
+			return err
+		}
+	}
+
+	for at := len(applied) - 1; at >= 0; at-- {
+		if applied[at].Kind() != ir.KindRef {
+			continue
+		}
+		if err := writeFrameStore(w, scope.Frame+at*MEMORY_SLOT_SIZE); err != nil {
+			return err
+		}
+	}
+
+	if err := writeFrameMove(w, scope.Frame, OpAdd); err != nil {
+		return err
+	}
+	if _, err := WritePush2(w, back); err != nil {
+		return err
+	}
+	if _, err := WritePush2(w, internal); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{OpJump})
+	return err
+}
+
+// writeFrameStore puts the value on top of the stack at this offset of the frame.
+func writeFrameStore(w io.Writer, offset int) error {
+	if err := WriteFrameAddress(w, offset); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{OpMemoryStore})
+	return err
+}
+
+// writeFrameMove moves the frame pointer by a number of bytes, onto the callee's frame with
+// ADD and back off it with SUB. Both read the pointer as it is now, so nested calls stack.
+func writeFrameMove(w io.Writer, by int, op byte) error {
+	if _, err := WritePush2(w, by); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{OpPush1, FRAME_POINTER, OpMemoryLoad, op}); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{OpPush1, FRAME_POINTER, OpMemoryStore}); err != nil {
+		return err
+	}
+	return nil
+}
+
+// ScopeInternalAt answers the byte another scope enters this one at: past the way in from a
+// transaction, and past what that way comes back to.
+//
+// It is measured rather than added up from a table of sizes, for the reason every address here
+// is: a table is a second description of the same bytes, and two descriptions drift.
+func ScopeInternalAt(base int, body []ir.Instruction, tapeSize int) (int, error) {
+	var measured counter
+	if err := WriteScopePrologue(&measured, FrameNamesAt(body)/MEMORY_SLOT_SIZE, tapeSize, 0, 0); err != nil {
+		return 0, err
+	}
+	// The way in opens with a JUMPDEST the dispatcher lands on; the prologue follows; what it
+	// comes back to opens with one of its own, and the way in from another scope with a third.
+	return base + 1 + int(measured) + 1 + ANSWER_SIZE, nil
+}
+
 // WriteScope emits a scope whole: the way in from a transaction, what that way comes back to,
 // and the body both ways share.
 //
 // The addresses inside it are worked out by measuring the prologue, which is the only part
 // whose length depends on the scope — one copy per position the body addresses. Every push is
 // a fixed size, so measuring once is enough.
-func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int) error {
+func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int, entries map[string]int) error {
 	reads := FrameNamesAt(body) / MEMORY_SLOT_SIZE
 
-	var measured counter
-	if err := WriteScopePrologue(&measured, reads, tapeSize, 0, 0); err != nil {
+	internal, err := ScopeInternalAt(base, body, tapeSize)
+	if err != nil {
 		return err
 	}
-
-	// The way in opens with a JUMPDEST the dispatcher lands on; the prologue follows; what it
-	// comes back to and the way in from another scope each open with one of their own.
-	epilogue := base + 1 + int(measured)
-	internal := epilogue + 1 + ANSWER_SIZE
+	epilogue := internal - 1 - ANSWER_SIZE
 
 	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
 		return err
@@ -251,7 +379,7 @@ func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int) error {
 		return err
 	}
 
-	_, err := WriteCode(bs, NewIdentManagerAt(FrameNamesAt(body)), body, internal+1, ScopeOf(body, tapeSize, false))
+	_, err = WriteCode(bs, NewIdentManagerAt(FrameNamesAt(body)), body, internal+1, ScopeOf(body, tapeSize, entries, false))
 	return err
 }
 
@@ -271,6 +399,21 @@ func FrameNamesAt(insts []ir.Instruction) int {
 		}
 	}
 	return (highest + 1) * MEMORY_SLOT_SIZE
+}
+
+// FrameSizeAt answers how much memory a scope keeps.
+//
+// The values applied to it come first, then the names it binds — one slot each, in the order
+// they are bound, which is what WriteIdent hands out. It is the whole of what one activation
+// of a scope occupies, and it is what a call moves the frame pointer by.
+func FrameSizeAt(insts []ir.Instruction) int {
+	names := make(map[string]bool)
+	for _, inst := range insts {
+		if inst.GetOpCode() == ir.OpIdent {
+			names[string(inst.GetLeft().Bytes())] = true
+		}
+	}
+	return FrameNamesAt(insts) + len(names)*MEMORY_SLOT_SIZE
 }
 
 // WriteFrameStart writes where the first frame begins, which every scope reads from until a
@@ -511,14 +654,29 @@ type Scope struct {
 	// scope holds — the top of a program, run when a contract has no scope to dispatch to —
 	// has nobody to go back to.
 	Answers bool
+	// Frame is how much memory this scope keeps: the values applied to it, then the names it
+	// binds. A call puts the frame of whoever it calls right after this one, so the two never
+	// share a slot and a scope can be entered again while it is running.
+	Frame int
+	// Entries answers, for the name a scope was bound to, the byte another scope enters it
+	// at. The names are known before any address of one is, so it is filled with zeros while
+	// the scopes are measured and with addresses before they are written — a call measures
+	// the same either way, since every push is a fixed size.
+	Entries map[string]int
 }
 
 // ScopeOf answers what the writer needs to know about a body of instructions.
 //
 // What it derives is derived once, here, rather than at each of the places that reads it:
 // working the arms out twice is how the writing pass and the measuring pass come to disagree.
-func ScopeOf(insts []ir.Instruction, tapeSize int, answers bool) Scope {
-	return Scope{TapeSize: tapeSize, Arms: armsOf(insts), Answers: answers}
+func ScopeOf(insts []ir.Instruction, tapeSize int, entries map[string]int, answers bool) Scope {
+	return Scope{
+		TapeSize: tapeSize,
+		Arms:     armsOf(insts),
+		Answers:  answers,
+		Frame:    FrameSizeAt(insts),
+		Entries:  entries,
+	}
 }
 
 // PositionsOf answers the byte each instruction of a scope starts at, and where the scope ends.
@@ -587,6 +745,10 @@ func targetOf(inst ir.Instruction, at int, positions []int) int {
 		ahead = int(byteutil.ToUint64(inst.GetRight().Bytes()))
 	case ir.OpJump:
 		ahead = int(byteutil.ToUint64(inst.GetLeft().Bytes()))
+	case ir.OpCall:
+		// A call carries its own landing rather than jumping to another instruction: it comes
+		// back to the byte right after it went, which it works out from where it begins.
+		return positions[at]
 	default:
 		return 0
 	}
@@ -608,7 +770,7 @@ func targetOf(inst ir.Instruction, at int, positions []int) int {
 func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, target int, scope Scope) error {
 	op := inst.GetOpCode()
 
-	if handled[op] && op != ir.OpSave {
+	if handled[op] && op != ir.OpSave && op != ir.OpCall {
 		if err := WriteImmediates(bs, inst, scope.TapeSize); err != nil {
 			return err
 		}
@@ -675,6 +837,12 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, targe
 
 	if op == ir.OpLoad {
 		if _, err := WriteLoad(bs, im, inst.GetLeft().Bytes()); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpCall {
+		if err := WriteCall(bs, inst, scope, target); err != nil {
 			return err
 		}
 	}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -251,7 +251,7 @@ func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int) error {
 		return err
 	}
 
-	_, err := WriteCode(bs, NewIdentManagerAt(FrameNamesAt(body)), body, tapeSize, internal+1, false)
+	_, err := WriteCode(bs, NewIdentManagerAt(FrameNamesAt(body)), body, internal+1, ScopeOf(body, tapeSize, false))
 	return err
 }
 
@@ -492,6 +492,35 @@ func (c *counter) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 
+// A Scope is what writing an instruction needs to know beyond the instruction itself: the
+// facts that belong to the scope it is written inside rather than to the instruction written.
+//
+// They used to be threaded one at a time, so every fact the backend learned about a scope
+// widened four signatures at once and every call site had to be visited to say the same thing
+// again. They travel together because they are read together — each of them is a fact about
+// the same scope, and no instruction is written without one.
+type Scope struct {
+	// TapeSize is how wide a value is, which is what every result is cut back to. It is the
+	// program's, not the machine's: the EVM works in words of thirty-two bytes whatever the
+	// tape says.
+	TapeSize int
+	// Arms holds the labels an "if" answers under, so a return naming one is known to end a
+	// branch rather than a scope. The two are the same opcode and which it is can be read.
+	Arms map[string]bool
+	// Answers says whether a return ends the call rather than handing its value back. Code no
+	// scope holds — the top of a program, run when a contract has no scope to dispatch to —
+	// has nobody to go back to.
+	Answers bool
+}
+
+// ScopeOf answers what the writer needs to know about a body of instructions.
+//
+// What it derives is derived once, here, rather than at each of the places that reads it:
+// working the arms out twice is how the writing pass and the measuring pass come to disagree.
+func ScopeOf(insts []ir.Instruction, tapeSize int, answers bool) Scope {
+	return Scope{TapeSize: tapeSize, Arms: armsOf(insts), Answers: answers}
+}
+
 // PositionsOf answers the byte each instruction of a scope starts at, and where the scope ends.
 //
 // It measures by writing — to something that only counts — rather than by adding up a table of
@@ -501,7 +530,7 @@ func (c *counter) Write(p []byte) (int, error) {
 //
 // The names are registered into a manager of its own and thrown away, since what is measured
 // is how many bytes an instruction takes and every push is a fixed size now.
-func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, arms map[string]bool, answers bool) ([]int, error) {
+func PositionsOf(insts []ir.Instruction, landings map[int]bool, scope Scope) ([]int, error) {
 	positions := make([]int, len(insts)+1)
 	im := NewIdentManager()
 	for at, inst := range insts {
@@ -509,7 +538,7 @@ func PositionsOf(insts []ir.Instruction, tapeSize int, landings map[int]bool, ar
 		if landings[at] {
 			measured++
 		}
-		if err := WriteInstruction(&measured, im, inst, tapeSize, 0, arms, answers); err != nil {
+		if err := WriteInstruction(&measured, im, inst, 0, scope); err != nil {
 			return nil, err
 		}
 		positions[at+1] = positions[at] + int(measured)
@@ -576,11 +605,11 @@ func targetOf(inst ir.Instruction, at int, positions []int) int {
 // Answers says what the third kind does. Code that no scope holds — the top of a program, run
 // when a contract has no scope to dispatch to — has nobody to go back to, so its return ends
 // the call rather than handing a value over.
-func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeSize int, target int, arms map[string]bool, answers bool) error {
+func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, target int, scope Scope) error {
 	op := inst.GetOpCode()
 
 	if handled[op] && op != ir.OpSave {
-		if err := WriteImmediates(bs, inst, tapeSize); err != nil {
+		if err := WriteImmediates(bs, inst, scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -589,7 +618,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		if _, err := WriteAdd(bs); err != nil {
 			return err
 		}
-		if _, err := WriteMask(bs, tapeSize); err != nil {
+		if _, err := WriteMask(bs, scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -598,7 +627,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		if _, err := WriteMultiply(bs); err != nil {
 			return err
 		}
-		if _, err := WriteMask(bs, tapeSize); err != nil {
+		if _, err := WriteMask(bs, scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -607,7 +636,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		if _, err := WriteSubtract(bs); err != nil {
 			return err
 		}
-		if _, err := WriteMask(bs, tapeSize); err != nil {
+		if _, err := WriteMask(bs, scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -621,9 +650,9 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 	if op == ir.OpReturn {
 		// The value of an arm is already on the stack, which is where whoever is under the
 		// branch finds it: there is nothing to write. Only a scope answers to the chain.
-		if !arms[byteutil.ToHex(inst.GetLeft().Bytes())] {
+		if !scope.Arms[byteutil.ToHex(inst.GetLeft().Bytes())] {
 			write := WriteReturn
-			if answers {
+			if scope.Answers {
 				write = WriteAnswer
 			}
 			if _, err := write(bs); err != nil {
@@ -633,7 +662,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 	}
 
 	if op == ir.OpSave {
-		if _, err := WriteSave(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
+		if _, err := WriteSave(bs, inst.GetLeft().Bytes(), scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -651,7 +680,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 	}
 
 	if op == ir.OpGetFeed {
-		if _, err := WriteGetArg(bs, inst.GetLeft().Bytes(), tapeSize); err != nil {
+		if _, err := WriteGetArg(bs, inst.GetLeft().Bytes(), scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -668,7 +697,7 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 		if _, err := bs.Write([]byte{OpExp}); err != nil {
 			return err
 		}
-		if _, err := WriteMask(bs, tapeSize); err != nil {
+		if _, err := WriteMask(bs, scope.TapeSize); err != nil {
 			return err
 		}
 	}
@@ -709,11 +738,10 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, tapeS
 // The base is where this scope lands in the runtime, since a jump carries an address in the
 // contract and not an offset into a scope. It is zero while a scope is being measured, and the
 // measurement does not depend on it.
-func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize int, base int, answers bool) (int, error) {
+func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, base int, scope Scope) (int, error) {
 	landings := landingsOf(insts)
-	arms := armsOf(insts)
 
-	positions, err := PositionsOf(insts, tapeSize, landings, arms, answers)
+	positions, err := PositionsOf(insts, landings, scope)
 	if err != nil {
 		return 0, err
 	}
@@ -724,7 +752,7 @@ func WriteCode(bs io.Writer, im *IdentManager, insts []ir.Instruction, tapeSize 
 				return 0, err
 			}
 		}
-		if err := WriteInstruction(bs, im, inst, tapeSize, base+targetOf(inst, at, positions), arms, answers); err != nil {
+		if err := WriteInstruction(bs, im, inst, base+targetOf(inst, at, positions), scope); err != nil {
 			return 0, err
 		}
 	}

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -2,6 +2,8 @@ package evm
 
 import (
 	"bytes"
+	"io"
+	"strings"
 	"testing"
 
 	"github.com/guiferpa/aurora/byteutil"
@@ -364,7 +366,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 		ir.NewInstruction([]byte("04"), ir.OpLoad, ir.NameOf("x"), ir.Nothing()),
 	}
 
-	positions, err := PositionsOf(insts, nil, ScopeOf(insts, 8, true))
+	positions, err := PositionsOf(insts, nil, ScopeOf(insts, 8, nil, true))
 	if err != nil {
 		t.Fatalf("measuring: %v", err)
 	}
@@ -376,12 +378,53 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 	im := NewIdentManager()
 	for at, inst := range insts {
 		before := bs.Len()
-		if err := WriteInstruction(bs, im, inst, 0, ScopeOf(insts, 8, true)); err != nil {
+		if err := WriteInstruction(bs, im, inst, 0, ScopeOf(insts, 8, nil, true)); err != nil {
 			t.Fatalf("writing: %v", err)
 		}
 		if want := positions[at+1] - positions[at]; bs.Len()-before != want {
 			t.Errorf("%s measured %d bytes and wrote %d",
 				ir.ResolveOpCode(inst.GetOpCode()), want, bs.Len()-before)
 		}
+	}
+}
+
+// A call carries its own landing rather than jumping to the instruction after it: the address
+// it pushes to come back to is a JUMPDEST inside its own bytes. It is worked out by measuring
+// what it is about to write, which is why it stays right when what a call writes changes.
+func TestACallComesBackToItsOwnJumpDestiny(t *testing.T) {
+	const at = 100
+
+	bs := bytes.NewBuffer(make([]byte, 0))
+	inst := ir.NewInstructionOver([]byte("00"), ir.OpCall, ir.NameOf("f"), ir.Imm(1, 8))
+	if err := WriteCall(bs, inst, ScopeOf(nil, 8, map[string]int{"f": 0x1234}, false), at); err != nil {
+		t.Fatalf("writing the call: %v", err)
+	}
+
+	code := bs.Bytes()
+	landing := bytes.IndexByte(code, OpJumpDestiny)
+	if landing < 0 {
+		t.Fatal("a call went somewhere and left nowhere to come back to")
+	}
+	back := at + landing
+	if want := []byte{OpPush2, byte(back >> 8), byte(back)}; !bytes.Contains(code, want) {
+		t.Errorf("it comes back to %#x, and never pushes that address: %v", back, byteutil.ToUpperHex(code))
+	}
+	if want := []byte{OpPush2, 0x12, 0x34, OpJump}; !bytes.Contains(code, want) {
+		t.Errorf("it does not go to the scope it names: %v", byteutil.ToUpperHex(code))
+	}
+}
+
+// Only a scope bound at the top of a program is something a call can jump to. A call to
+// anything else is refused rather than written: what would be written is a jump to an address
+// no scope has, and that contract deploys and reverts when the call is reached.
+func TestACallToSomethingThatIsNotAScopeIsRefused(t *testing.T) {
+	inst := ir.NewInstructionOver([]byte("00"), ir.OpCall, ir.NameOf("nowhere"), ir.Imm(1, 8))
+
+	err := WriteCall(io.Discard, inst, ScopeOf(nil, 8, map[string]int{"elsewhere": 0x40}, false), 0)
+	if err == nil {
+		t.Fatal("it wrote a call to a scope that does not exist")
+	}
+	if !strings.Contains(err.Error(), "nowhere") {
+		t.Errorf("it says %q, and never names what was called", err)
 	}
 }

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -168,36 +168,62 @@ func TestWriteLoad(t *testing.T) {
 
 // An argument arrives as a whole 32-byte word and is cut to the tape on the way in, the same
 // as the evaluator does when it narrows the arguments it was handed.
+// Reading one of the values applied to the scope reads the frame, and never the calldata.
+// Whoever entered the scope put them there — the way in from a transaction copies them out of
+// the calldata, and a scope calling another writes what it worked out — which is the whole of
+// what the frame buys: a body that does not know how it was entered.
 func TestWriteGetArg(t *testing.T) {
-	bs := bytes.NewBuffer(make([]byte, 0))
-	index := byteutil.FromUint64(0)
-	if _, err := WriteGetArg(bs, index, byteutil.DefaultTapeSize); err != nil {
-		t.Errorf("Error writing get arg: %v", err)
-		return
+	cases := []struct {
+		name string
+		at   uint64
+		want []byte
+	}{
+		{name: "the first position", at: 0, want: []byte{OpPush2, 0x00, 0x00}},
+		{name: "the third", at: 2, want: []byte{OpPush2, 0x00, 0x40}},
 	}
-	got := bs.Bytes()
-	expected := []byte{OpPush1, 0x20, OpCallDataLoad, OpPush8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, OpAnd}
-	if !bytes.Equal(got, expected) {
-		t.Errorf("GetArg: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bs := bytes.NewBuffer(make([]byte, 0))
+			if _, err := WriteGetArg(bs, byteutil.FromUint64(tc.at), byteutil.DefaultTapeSize); err != nil {
+				t.Fatalf("writing the read: %v", err)
+			}
+
+			expected := append(append([]byte{}, tc.want...), OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd, OpMemoryLoad)
+			if got := bs.Bytes(); !bytes.Equal(got, expected) {
+				t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+			}
+		})
 	}
 }
 
+// Ending a scope goes back to whoever called it: the value is on the stack and the address to
+// go back to is under it. It never answers the chain — that is the epilogue's, and keeping it
+// there is what lets one body serve a transaction and a scope alike.
 func TestWriteReturn(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
 	if _, err := WriteReturn(bs); err != nil {
-		t.Errorf("Error writing return: %v", err)
-		return
+		t.Fatalf("writing the return: %v", err)
 	}
-	got := bs.Bytes()
-	// Through a slot of its own, not the first one: that holds where the running scope's
-	// frame begins, and writing the answer there would lose the frame in the act of
-	// answering.
-	expected := []byte{
-		OpPush1, RETURN_SCRATCH, OpMemoryStore,
-		OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn,
+	if got, want := bs.Bytes(), []byte{OpSwap1, OpJump}; !bytes.Equal(got, want) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(want))
 	}
-	if !bytes.Equal(got, expected) {
-		t.Errorf("Return: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+}
+
+// Answering the chain goes through a slot of its own, not the first one: that holds where the
+// running scope's frame begins, and writing the answer there would lose the frame in the act
+// of answering.
+func TestWriteAnswer(t *testing.T) {
+	bs := bytes.NewBuffer(make([]byte, 0))
+	if _, err := WriteAnswer(bs); err != nil {
+		t.Fatalf("writing the answer: %v", err)
+	}
+	expected := []byte{OpPush1, RETURN_SCRATCH, OpMemoryStore, OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn}
+	if got := bs.Bytes(); !bytes.Equal(got, expected) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+	}
+	if bs.Len() != ANSWER_SIZE {
+		t.Errorf("it measures %d and says it measures %d", bs.Len(), ANSWER_SIZE)
 	}
 }
 
@@ -338,7 +364,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 		ir.NewInstruction([]byte("04"), ir.OpLoad, ir.NameOf("x"), ir.Nothing()),
 	}
 
-	positions, err := PositionsOf(insts, 8, nil, nil)
+	positions, err := PositionsOf(insts, 8, nil, nil, true)
 	if err != nil {
 		t.Fatalf("measuring: %v", err)
 	}
@@ -350,7 +376,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 	im := NewIdentManager()
 	for at, inst := range insts {
 		before := bs.Len()
-		if err := WriteInstruction(bs, im, inst, 8, 0, nil); err != nil {
+		if err := WriteInstruction(bs, im, inst, 8, 0, nil, true); err != nil {
 			t.Fatalf("writing: %v", err)
 		}
 		if want := positions[at+1] - positions[at]; bs.Len()-before != want {

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -126,9 +126,9 @@ func TestWriteIdent(t *testing.T) {
 		names int
 		want  []byte
 	}{
-		{name: "the first name", names: 0, want: []byte{OpPush2, 0x00, 0x00}},
-		{name: "the second", names: 1, want: []byte{OpPush2, 0x00, 0x20}},
-		{name: "the ninth, which used to land on the first", names: 8, want: []byte{OpPush2, 0x01, 0x00}},
+		{name: "the first name", names: 0, want: []byte{OpPush2, 0x00, 0x00, OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd}},
+		{name: "the second", names: 1, want: []byte{OpPush2, 0x00, 0x20, OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd}},
+		{name: "the ninth, which used to land on the first", names: 8, want: []byte{OpPush2, 0x01, 0x00, OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd}},
 	}
 
 	for _, tc := range cases {
@@ -160,7 +160,7 @@ func TestWriteLoad(t *testing.T) {
 		t.Fatalf("writing the read: %v", err)
 	}
 
-	expected := []byte{OpPush2, 0x01, 0x20, OpMemoryLoad}
+	expected := []byte{OpPush2, 0x01, 0x20, OpPush1, FRAME_POINTER, OpMemoryLoad, OpAdd, OpMemoryLoad}
 	if got := bs.Bytes(); !bytes.Equal(got, expected) {
 		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 	}
@@ -189,9 +189,12 @@ func TestWriteReturn(t *testing.T) {
 		return
 	}
 	got := bs.Bytes()
+	// Through a slot of its own, not the first one: that holds where the running scope's
+	// frame begins, and writing the answer there would lose the frame in the act of
+	// answering.
 	expected := []byte{
-		OpPush1, 0x00, OpMemoryStore, // store stack top at mem[0]
-		OpPush1, 0x20, OpPush1, 0x00, OpReturn,
+		OpPush1, RETURN_SCRATCH, OpMemoryStore,
+		OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn,
 	}
 	if !bytes.Equal(got, expected) {
 		t.Errorf("Return: got: %v, expected: %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -364,7 +364,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 		ir.NewInstruction([]byte("04"), ir.OpLoad, ir.NameOf("x"), ir.Nothing()),
 	}
 
-	positions, err := PositionsOf(insts, 8, nil, nil, true)
+	positions, err := PositionsOf(insts, nil, ScopeOf(insts, 8, true))
 	if err != nil {
 		t.Fatalf("measuring: %v", err)
 	}
@@ -376,7 +376,7 @@ func TestWhatIsMeasuredIsWhatIsWritten(t *testing.T) {
 	im := NewIdentManager()
 	for at, inst := range insts {
 		before := bs.Len()
-		if err := WriteInstruction(bs, im, inst, 8, 0, nil, true); err != nil {
+		if err := WriteInstruction(bs, im, inst, 0, ScopeOf(insts, 8, true)); err != nil {
 			t.Fatalf("writing: %v", err)
 		}
 		if want := positions[at+1] - positions[at]; bs.Len()-before != want {

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -113,26 +113,27 @@ considered and refused, with the reasoning in the design document.
 The point of the backend is that **the same program answers the same thing on a chain and off
 it**. Since the differential harness exists (`hosting/cli/evm_harness_test.go`) that is no
 longer a hope: an EVM is built in memory, the contract is deployed and called, and the answer
-is compared against the evaluator. Arithmetic across a dispatcher is proved, at any tape width
-— a result that leaves the width is cut back to it, the way the evaluator does — and
-everything below is not.
+is compared against the evaluator. What it proves is arithmetic across a dispatcher at any
+tape width — a result that leaves the width is cut back to it, the way the evaluator does —
+names bound inside a scope, branches, the comparisons and `and`/`or`, and a scope calling
+another as deep as it nests.
 
-The gap is wider than it looks, and it is silent, which is the dangerous part: a contract
-using any of the following **compiles successfully and does nothing on chain**.
+What is left is narrower than it was, but it is still silent, which is the dangerous part: a
+contract using any of the following **compiles and does nothing on chain**. `aurora build`
+says so, once per feature, at the line that used it.
 
-- `call`, `assert`, the tape operations and the shape instructions (`OpJoin`, `OpField`)
-  produce no bytecode at all. `WriteCode` covers arithmetic, the comparisons, `and`/`or`, `^`,
-  `OpSave`, `OpIdent`, `OpLoad`, `OpGetFeed`, `OpReturn` and the branch — `OpIf` and
-  `OpJump`. They are not refusals — a tape is at most 32 bytes and an EVM word is exactly 32, a
-  shape is a run of words in memory, and a call is a jump with a return address. They are
-  simply not written yet.
+- The tape operations and the shape instructions (`OpJoin`, `OpField`) produce no bytecode.
+  They are not refusals — a tape is at most 32 bytes and an EVM word is exactly 32, and a
+  shape is a run of words in memory, which is what a frame already gives them. They are simply
+  not written yet.
+- **Only a scope bound at the top of a program can be called.** A scope bound inside another,
+  or reached through an alias, is refused by the builder rather than written: what would be
+  written is a jump to an address no scope has.
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.
   On chain they are the only way a contract says anything, and they are the honest target for
   whatever Aurora ends up calling logging.
-- Jump targets and memory offsets are written with `PUSH1`, which caps a runtime at 256
-  bytes and identifiers at about seven memory slots. `PUSH2` lifts it.
 
 `aurora build` now **says what it could not carry**, once per feature, in the order the
 program uses it, and names the line the program first used it on — so a binary that does less

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -398,3 +398,18 @@ func TestComparisonsFollowTheTapeWidth(t *testing.T) {
 		})
 	}
 }
+
+// A name lives in the frame of the scope that bound it, not at an address of its own in the
+// contract. Two scopes each binding a name used to be given the same place, since the offsets
+// were counted once for the whole binary — which is also what kept a scope from calling
+// itself, and is what the frame is for.
+func TestTwoScopesKeepTheirOwnNames(t *testing.T) {
+	const source = `ident first = defer { ident x = feed(0); x + 1; };
+ident second = defer { ident x = feed(0); x + 100; };`
+
+	for _, name := range []string{"first", "second"} {
+		t.Run(name, func(t *testing.T) {
+			agree(t, source, name, []string{"5"}, 0)
+		})
+	}
+}

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -413,3 +413,39 @@ ident second = defer { ident x = feed(0); x + 100; };`
 		})
 	}
 }
+
+// A scope calls another and comes back with what it answered.
+//
+// It is a jump inside one contract, not a message call to itself, and what makes that possible
+// is the frame: the callee keeps the values applied to it right after the caller's own, so
+// "feed(0)" inside the callee means the callee's first value and not the caller's — which is
+// what a plain jump would have got wrong, since the calldata belongs to whoever the
+// transaction named and every scope would have read the same one.
+func TestAScopeCallsAnotherOnChainToo(t *testing.T) {
+	const source = `ident b = defer { feed(0) + 1; };
+ident a = defer { b(10) + feed(0); };`
+
+	agree(t, source, "a", []string{"5"}, 0)
+}
+
+// What the caller was holding survives the call.
+//
+// The callee runs on the same stack, so a value the caller had already worked out sits under
+// the call while it happens. And the caller's own applied values have to still be there
+// afterwards: the frame pointer moves onto the callee's frame and has to come back off it.
+func TestACallLeavesTheCallerWhereItWas(t *testing.T) {
+	const source = `ident twice = defer { feed(0) * 2; };
+ident sum = defer { ident kept = feed(0) + 100; twice(feed(1)) + kept + feed(0); };`
+
+	agree(t, source, "sum", []string{"7", "3"}, 0)
+}
+
+// A call inside a call. Each activation takes the frame that follows the one it was entered
+// from, so three of them are three runs of memory and none of them writes over another.
+func TestCallsNestOnChainToo(t *testing.T) {
+	const source = `ident inner = defer { feed(0) + 1; };
+ident middle = defer { inner(feed(0)) * 2; };
+ident outer = defer { middle(feed(0)) + middle(1); };`
+
+	agree(t, source, "outer", []string{"4"}, 0)
+}


### PR DESCRIPTION
Calling a scope reaches the bytecode. It was the last thing named in the open line under `builder/evm`, and with it that line is finished.

## What it gives whoever writes Aurora

```aurora
ident b = defer { feed(0) + 1; };
ident a = defer { b(10) + feed(0); };
```

`a(5)` answers 16 on chain, which is what the evaluator answers. Until now it compiled, deployed, and did something else — the compiler said so, once, at the line that called.

Calls nest as deep as they go, and a caller's own applied values and half-finished work survive one.

## How

A jump inside one contract, deliberately not a message call. A message call to your own contract is a transaction against yourself — its own frame of execution, its own gas stipend, its own view of storage, an answer to copy out of returndata — and paying for that would make a call inside a program cost what a call between contracts costs.

What a jump does not bring is anywhere for the callee to keep the values applied to it. That is the frame, and it is why a plain jump would have been wrong: the calldata belongs to whoever the transaction named, so `feed(0)` inside `b` would have answered `a`'s first value and never the 10.

So a scope is written once and entered twice:

```
external:  JUMPDEST          <- the dispatcher jumps here
           <prologue>        copies the calldata into the frame
           PUSH2 <epilogue>
           PUSH2 <internal>
           JUMP
epilogue:  JUMPDEST          <- the body comes back here, value on the stack
           <answer the chain>
internal:  JUMPDEST          <- another scope jumps here, frame already written
           <body>            feed(n) reads the frame, whoever filled it
           SWAP1; JUMP       back to whoever called
```

The prologue is what makes the body have one shape. Without it every instruction that touches an applied value would carry the question of how the scope was entered.

A call fills the frame that follows its own, moves the pointer onto it, and moves it back when the callee answers. It carries its own landing rather than jumping to the next instruction, and works the address out by measuring what it is about to write.

## The limit this adds

**Only a scope bound at the top of a program can be called.** A scope bound inside another, or reached through an alias, is now *refused* by the builder rather than written — what would be written is a jump to an address no scope has, which deploys and reverts when reached. It is in the roadmap and in `CLAUDE.md`.

This is a refusal where the backend has otherwise warned. The reason for the difference: a warning works when the instruction can be skipped, and a call cannot be — skipping it leaves its arguments on the stack and corrupts everything after.

## The commits

| | |
|---|---|
| `a name lives in the frame of the scope that bound it` | names are per-activation, not per-contract |
| `a scope has two ways in, and one body` | the prologue, and the return that goes back rather than out |
| `the writer takes what it knows about a scope as one thing` | 7 parameters down to 5, no bytes changed |
| `finding a scope is not writing it` | every scope was written twice and the first thrown away; a write failure came back as "no scope here" |
| `a scope calls another on chain` | the call |
| `docs:` ×2 | the README table, the roadmap, the note |

Two of them are refactors that change no bytes, and they are separate because the call needed both: the names of every scope have to exist before any address of one does.

## Proof

`make check` — build, wasm, test, lint, 0 issues. Three new differential cases (`hosting/cli/evm_harness_test.go`): a scope calling another, a caller surviving a call, calls nested three deep. A unit case pinning that a call comes back to its own JUMPDEST, and the refusal above.

## Size

773 insertions, and a good share of it is comment — the prologue and the frame are the parts of this backend that will be read by whoever writes the next target, so they say why and not only what.

🤖 Generated with [Claude Code](https://claude.com/claude-code)