### PR TITLE
A tape operation reaches the chain

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,15 +45,20 @@ tape at the far end — the same number the evaluator answers — and a field is
 mask. That is also its ceiling: a run past thirty-two bytes is refused rather than written
 short, which is four fields at the default tape.
 
-What is left of the backend is the tape operations. **Anything else in `builder/evm` still
-waits its turn**, and the turn is discussed first.
+The tape operations are written too, and with them **the backend carries every feature a
+program can use**. All four rest on one thing: how much of a value means something, which off
+a chain is the length of a slice and on one is worked out from the word by halving, five times,
+without branching. What a contract does not get is what was decided not to reach a chain — the
+logs — and three limits, each written down in `docs/roadmap.md`.
+
+**Anything else in `builder/evm` still waits its turn**, and the turn is discussed first.
 
 What the backend gained before stopping is the differential harness
 (`hosting/cli/evm_harness_test.go`) — the same source compiled, deployed to an EVM in memory,
 called, and compared against the evaluator — so whatever is written next is provable rather
 than believed. What it proves today is arithmetic over arguments at any tape width, names
 bound inside a scope, branches, the comparisons and `and`/`or`, a scope calling another as
-deep as it nests, and shapes.
+deep as it nests, shapes, and the tape operations.
 
 A feature still does **not** need bytecode to be finished. `shape` and text-as-a-tape shipped
 without it.

--- a/README.md
+++ b/README.md
@@ -178,9 +178,10 @@ Manifest reference: **[docs/manifest.md](docs/manifest.md)** · tests and `asser
 
 ## What reaches the chain today
 
-The evaluator runs the whole language. The EVM backend is being written in slices, and
-`aurora build` **says what it could not carry**, once per feature, at the line that used it —
-a binary that does less than the source said is announced rather than silent.
+The evaluator runs the whole language, and the EVM backend carries all of it — everything
+except what is meant to be absent. `aurora build` still **says what it could not carry**, once
+per feature, at the line that used it: a binary that does less than the source said is
+announced rather than silent.
 
 | | on a chain |
 |---|---|
@@ -191,7 +192,7 @@ a binary that does less than the source said is announced rather than silent.
 | calling a scope from another | **yes**, nested as deep as it goes |
 | comparisons, `and`/`or`, `^` | **yes** |
 | `shape` | **yes**, while the run fits a word |
-| tape operations | not yet |
+| `pull` / `push` / `head` / `tail` | **yes**, at any tape width |
 | `printb` / `printd` / `printc` | **by decision** — a log has nowhere to go on a chain |
 | `assert` | **by decision** — it belongs to `aurora test` |
 

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -84,7 +84,7 @@ func produces(op byte) bool {
 	case ir.OpSave, ir.OpGetFeed, ir.OpLoad,
 		ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide, ir.OpExponential,
 		ir.OpEquals, ir.OpDiff, ir.OpBigger, ir.OpSmaller, ir.OpAnd, ir.OpOr,
-		ir.OpJoin, ir.OpField:
+		ir.OpJoin, ir.OpField, ir.OpPull, ir.OpPush, ir.OpHead, ir.OpTail:
 		return true
 	default:
 		return false

--- a/builder/evm/opcodes.go
+++ b/builder/evm/opcodes.go
@@ -122,7 +122,13 @@ const (
 
 const (
 	OpReturn byte = 0xf3 // Halt execution returning output data from the last call
-	OpSwap1  byte = 0x90 // Swap 1st and 2nd stack items
+	// Copying and exchanging what is on the stack. A machine with no addressing has these
+	// instead: reaching a value means bringing it to the top, and keeping one means copying
+	// it before whoever takes it does.
+	OpDup1  byte = 0x80 // Copy the 1st stack item
+	OpDup3  byte = 0x82 // Copy the 3rd stack item
+	OpSwap1 byte = 0x90 // Swap 1st and 2nd stack items
+	OpSwap2 byte = 0x91 // Swap 1st and 3rd stack items
 )
 
 func ToOpByte(op uint32) []byte {
@@ -338,8 +344,14 @@ func ResolveOpCode(op byte) string {
 		return "PUSH32"
 	case OpReturn:
 		return "RETURN"
+	case OpDup1:
+		return "DUP1"
+	case OpDup3:
+		return "DUP3"
 	case OpSwap1:
 		return "SWAP1"
+	case OpSwap2:
+		return "SWAP2"
 	}
 	return "Unknown"
 }

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -57,11 +57,15 @@ var offChain = map[byte]string{
 	ir.OpAssert:       "assert belongs to 'aurora test' and produces no bytecode, by decision",
 }
 
-// pending is what the builder does not write yet, named as the user wrote it. Instructions
-// that come from one feature share a name, so a feature is one warning rather than one per
-// opcode it lowers to.
+// pending is what the builder does not write yet, named as the user wrote it rather than as
+// the IR names it. Instructions that come from one feature share a name, so a feature is one
+// warning rather than one per opcode it lowers to.
 //
-// It is empty: every instruction the emitter produces reaches the bytecode now.
+// It is empty. Every instruction the emitter produces reaches the bytecode now, which is the
+// news — and it is also what makes the entry below matter more than it did: an opcode in
+// neither list is warned about under the name the IR gives it, rather than passed over. A gap
+// nobody remembered to write down here is still a gap, and the point of this file is that a
+// gap is never silent.
 var pending = map[byte]string{}
 
 // Warnings reports what a program uses that does not reach the bytecode.
@@ -86,9 +90,9 @@ func Warnings(insts []ir.Instruction) []diag.Warning {
 
 		message, ok := offChain[op]
 		if !ok {
-			name, pendingOp := pending[op]
-			if !pendingOp {
-				continue
+			name, named := pending[op]
+			if !named {
+				name = ir.ResolveOpCode(op)
 			}
 			message = fmt.Sprintf(
 				"%s does not reach the bytecode yet: a contract using it compiles and does nothing on chain", name)

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -42,6 +42,10 @@ var handled = map[byte]bool{
 	ir.OpCall:        true,
 	ir.OpJoin:        true,
 	ir.OpField:       true,
+	ir.OpPull:        true,
+	ir.OpPush:        true,
+	ir.OpHead:        true,
+	ir.OpTail:        true,
 }
 
 // offChain is what is meant to be absent from a chain. Saying so is still worth a line: a
@@ -54,23 +58,11 @@ var offChain = map[byte]string{
 }
 
 // pending is what the builder does not write yet, named as the user wrote it. Instructions
-// that come from one feature share a name, so an "if" is one warning rather than two.
-var pending = map[byte]string{
-	ir.OpIf:      "if",
-	ir.OpJump:    "if",
-	ir.OpPreCall: "calling a scope",
-	ir.OpDiff:    "a comparison",
-	ir.OpEquals:  "a comparison",
-	ir.OpBigger:  "a comparison",
-	ir.OpSmaller: "a comparison",
-	ir.OpAnd:     "and/or",
-	ir.OpOr:      "and/or",
-
-	ir.OpPull: "a tape operation",
-	ir.OpPush: "a tape operation",
-	ir.OpHead: "a tape operation",
-	ir.OpTail: "a tape operation",
-}
+// that come from one feature share a name, so a feature is one warning rather than one per
+// opcode it lowers to.
+//
+// It is empty: every instruction the emitter produces reaches the bytecode now.
+var pending = map[byte]string{}
 
 // Warnings reports what a program uses that does not reach the bytecode.
 //

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -50,6 +50,14 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			wantNone: true,
 		},
 		{
+			// Nothing the emitter produces is pending any more, so what this guards is the
+			// next thing added to the IR: an opcode the builder does not write and nobody
+			// named is warned about under the name the IR gives it, rather than passed over.
+			name:    "an instruction nobody wrote down",
+			opcodes: []byte{ir.OpPreCall},
+			want:    []string{"OpPreCall does not reach the bytecode yet"},
+		},
+		{
 			name:     "a shape, which reaches the bytecode now",
 			opcodes:  []byte{ir.OpJoin, ir.OpField},
 			wantNone: true,

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -45,9 +45,9 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			wantNone: true,
 		},
 		{
-			name:    "a tape operation",
-			opcodes: []byte{ir.OpPull, ir.OpHead},
-			want:    []string{"a tape operation does not reach the bytecode yet"},
+			name:     "a tape operation, which reaches the bytecode now",
+			opcodes:  []byte{ir.OpPull, ir.OpHead},
+			wantNone: true,
 		},
 		{
 			name:     "a shape, which reaches the bytecode now",
@@ -106,7 +106,7 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 // The same feature used twice is one thing to say, not two.
 func TestWarningsSayEachThingOnce(t *testing.T) {
 	warnings := Warnings(instructionsOf(
-		ir.OpPull, ir.OpHead, ir.OpPull, ir.OpHead, ir.OpPrintDecimal, ir.OpPrintDecimal,
+		ir.OpPrintDecimal, ir.OpAssert, ir.OpPrintDecimal, ir.OpAssert,
 	))
 
 	if len(warnings) != 2 {
@@ -117,7 +117,7 @@ func TestWarningsSayEachThingOnce(t *testing.T) {
 // They arrive in the order the program uses them, so the first thing a reader is told about
 // is the first thing that goes missing.
 func TestWarningsFollowTheProgram(t *testing.T) {
-	warnings := Warnings(instructionsOf(ir.OpPrintDecimal, ir.OpPull))
+	warnings := Warnings(instructionsOf(ir.OpPrintDecimal, ir.OpAssert))
 
 	if len(warnings) != 2 {
 		t.Fatalf("said %d things, want two", len(warnings))
@@ -131,8 +131,8 @@ func TestWarningsFollowTheProgram(t *testing.T) {
 // carries where every instruction came from now, so the backend points at the first line that
 // used what it cannot carry.
 func TestWarningsPointAtWhereTheFeatureWasUsed(t *testing.T) {
-	const source = `printb 1;
-ident t = [1, 2];`
+	const source = `ident t = [1, 2];
+printd t;`
 
 	tokens, err := lexer.New().GetFilledTokens([]byte(source))
 	if err != nil {
@@ -148,18 +148,18 @@ ident t = [1, 2];`
 	}
 
 	for _, warning := range Warnings(insts) {
-		if !strings.Contains(warning.Message, "a tape operation") {
+		if !strings.Contains(warning.Message, "printd") {
 			continue
 		}
 		if !warning.Positioned() {
-			t.Fatal("the warning about a tape operation has no place to point at")
+			t.Fatal("the warning about a log has no place to point at")
 		}
 		if warning.Line != 2 {
-			t.Errorf("it points at line %d, want the line the tape was written on", warning.Line)
+			t.Errorf("it points at line %d, want the line the log was written on", warning.Line)
 		}
 		return
 	}
-	t.Fatal("nothing warned about a tape operation")
+	t.Fatal("nothing warned about a log")
 }
 
 // Every feature the backend cannot carry names the line it was written on. A warning that
@@ -173,7 +173,7 @@ func TestEveryPendingFeatureNamesItsPlace(t *testing.T) {
 	}{
 		// A tape literal is itself a tape operation — it builds the run byte by byte — so
 		// the first place the program uses one is the literal, not the pull below it.
-		{name: "a tape operation", source: "printb 1;\nident t = [1];\nprintb pull t 2;", says: "a tape operation", line: 2},
+		{name: "a log", source: "ident t = 1;\nprintd t;", says: "printd", line: 2},
 	}
 
 	for _, tc := range cases {

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"math/big"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/guiferpa/aurora/byteutil"
@@ -214,6 +215,267 @@ func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal
 // in from a transaction ends the call.
 func WriteScopeEpilogue(w io.Writer) error {
 	_, err := WriteAnswer(w)
+	return err
+}
+
+// WriteSignificantLength answers, in bits, how much of the value on the stack is significant:
+// eight times the number of bytes it takes once the zeros in front of it are dropped, and
+// eight for a value that is nothing but zeros.
+//
+// Every tape operation is defined in terms of that number, because a tape is a shift register
+// and what enters it is the value's own bytes and not a fixed run. Off a chain it is the
+// length of a slice. On one there is nothing to ask: a value is a word, and how much of it
+// means something has to be worked out.
+//
+// It is worked out by halving. Five times over, the value is asked whether anything survives a
+// shift of sixteen bytes, then eight, then four, then two, then one; each answer is one or
+// zero, so multiplying the shift by it either takes that step or takes nothing, and the same
+// product is added to the running total. Nothing branches, which is what keeps this a run of
+// instructions rather than five jumps, and the total is exact for every word.
+//
+// The last byte is added at the end and is never asked about, which is what makes a value of
+// zero one byte long rather than none — the same answer the evaluator gives, and the one that
+// keeps "pull t 0" a shift by one place.
+func WriteSignificantLength(w io.Writer) error {
+	// The running total starts at nothing and goes under the value, which is where every step
+	// leaves it.
+	if _, err := w.Write([]byte{OpPush1, 0x00, OpSwap1}); err != nil {
+		return err
+	}
+
+	for _, step := range []int{16, 8, 4, 2, 1} {
+		bits := byte(step * BYTE_SIZE)
+		// The value is on top and the total under it, and both come back that way.
+		if _, err := w.Write([]byte{
+			OpDup1, OpPush1, bits, OpShiftRight, OpIsZero, OpIsZero, OpPush1, bits, OpMul,
+			OpDup1, OpSwap2, OpSwap1, OpShiftRight, OpSwap2, OpAdd, OpSwap1,
+		}); err != nil {
+			return err
+		}
+	}
+
+	// What is left of the value is under a byte, and that byte counts.
+	_, err := w.Write([]byte{OpPop, OpPush1, BYTE_SIZE, OpAdd})
+	return err
+}
+
+// staticLength answers how many bytes of an operand mean something, when that can be known
+// while compiling. It can when the program wrote the value down; it cannot when another
+// instruction works it out.
+func staticLength(operand ir.Operand, tapeSize int) (int, bool) {
+	if operand.Kind() != ir.KindImm {
+		return 0, false
+	}
+	return len(byteutil.ExtractSignificantBytes(byteutil.PaddingTape(operand.Bytes(), tapeSize))), true
+}
+
+// WriteTapePull shifts a tape left and lets values in at the right, one after another, keeping
+// the tape's width — so whatever reaches the left end falls off.
+//
+// Each value enters as its own significant bytes, so where the tape has to move by is how long
+// the value is. When the program wrote the values down, that is known while compiling and the
+// whole run of them collapses into one shift and one or: a tape literal costs two instructions
+// on a chain, however many values were written between the brackets.
+//
+// When another instruction works the value out, the length is worked out beside it. That is
+// the ordinary "pull t x", and it is written for one value: a literal built out of values a
+// program computes would need each of them brought to the top of the stack in turn, and that
+// is refused rather than written wrong.
+func WriteTapePull(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	values := valueOperands(inst)
+	tape, items := values[0], values[1:]
+
+	// The tape is on the stack when another instruction worked it out, and reaches it here
+	// when the program wrote it down.
+	if values[0].Kind() == ir.KindImm {
+		if _, err := WritePush(w, values[0].Bytes(), tapeSize); err != nil {
+			return err
+		}
+	}
+
+	entering := make([]byte, 0, len(items)*tapeSize)
+	shift := 0
+	for _, item := range items {
+		length, known := staticLength(item, tapeSize)
+		if !known {
+			return writeTapePullOver(w, tape, items, tapeSize)
+		}
+		entering = append(entering, byteutil.PaddingTape(item.Bytes(), tapeSize)[tapeSize-length:]...)
+		shift += length * BYTE_SIZE
+	}
+
+	if err := writeShiftBy(w, shift, OpShiftLeft); err != nil {
+		return err
+	}
+	if len(entering) > 0 {
+		if _, err := WritePush(w, byteutil.PaddingTape(entering, byteutil.TapeSize(len(entering))), len(entering)); err != nil {
+			return err
+		}
+		if _, err := w.Write([]byte{OpOr}); err != nil {
+			return err
+		}
+	}
+	_, err := WriteMask(w, tapeSize)
+	return err
+}
+
+// writeTapePullOver pulls one value a program works out, which is the only shape of that the
+// builder writes. The tape is under it on the stack and both are needed, so the length is
+// taken off a copy and the two change places around it.
+func writeTapePullOver(w io.Writer, tape ir.Operand, items []ir.Operand, tapeSize int) error {
+	if len(items) != 1 {
+		return fmt.Errorf(
+			"a tape built from %d values a program works out does not reach the bytecode yet: write them down, or pull them one at a time",
+			len(items))
+	}
+	if tape.Kind() != ir.KindRef {
+		return fmt.Errorf("pulling onto a tape a program works out is not written yet")
+	}
+
+	if _, err := w.Write([]byte{OpDup1}); err != nil {
+		return err
+	}
+	if err := WriteSignificantLength(w); err != nil {
+		return err
+	}
+	// The length is on top, the value under it and the tape under that. The tape has to be on
+	// top for the shift, and the length above it.
+	if _, err := w.Write([]byte{OpSwap2, OpSwap1, OpSwap2, OpShiftLeft, OpOr}); err != nil {
+		return err
+	}
+	_, err := WriteMask(w, tapeSize)
+	return err
+}
+
+// WriteTapePush shifts a tape right and lets a value in at the left, keeping the tape's width —
+// so whatever reaches the right end falls off.
+//
+// The value goes in front of the tape and the first tape-width of bytes is what is kept, which
+// on a chain is the value moved up by what is left of the tape's width and the tape moved down
+// by the value's own. A value is a tape, so it is never wider than one, and neither shift can
+// run backwards.
+func WriteTapePush(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	values := valueOperands(inst)
+	item := values[1]
+
+	// The tape is on the stack when another instruction worked it out, and reaches it here
+	// when the program wrote it down.
+	if values[0].Kind() == ir.KindImm {
+		if _, err := WritePush(w, values[0].Bytes(), tapeSize); err != nil {
+			return err
+		}
+	}
+
+	if length, known := staticLength(item, tapeSize); known {
+		if err := writeShiftBy(w, length*BYTE_SIZE, OpShiftRight); err != nil {
+			return err
+		}
+		entering := byteutil.PaddingTape(item.Bytes(), tapeSize)[tapeSize-length:]
+		if err := writeShiftedIn(w, entering, (tapeSize-length)*BYTE_SIZE); err != nil {
+			return err
+		}
+		_, err := WriteMask(w, tapeSize)
+		return err
+	}
+
+	if _, err := w.Write([]byte{OpDup1}); err != nil {
+		return err
+	}
+	if err := WriteSignificantLength(w); err != nil {
+		return err
+	}
+	// The tape moves down by the length, keeping a copy of the length for the other shift.
+	if _, err := w.Write([]byte{OpSwap2, OpDup3, OpShiftRight, OpSwap2}); err != nil {
+		return err
+	}
+	if _, err := WritePush2(w, tapeSize*BYTE_SIZE); err != nil {
+		return err
+	}
+	if _, err := w.Write([]byte{OpSub, OpShiftLeft, OpOr}); err != nil {
+		return err
+	}
+	_, err := WriteMask(w, tapeSize)
+	return err
+}
+
+// writeShiftedIn ors a value into the tape at a place known while compiling.
+func writeShiftedIn(w io.Writer, entering []byte, shift int) error {
+	if len(entering) == 0 {
+		return nil
+	}
+	value := new(big.Int).SetBytes(entering)
+	value.Lsh(value, uint(shift))
+	if _, err := WritePush(w, byteutil.PaddingTape(value.Bytes(), byteutil.MaxTapeSize), byteutil.MaxTapeSize); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{OpOr})
+	return err
+}
+
+// writeShiftBy moves what is on the stack by a number of bits known while compiling. A shift
+// of nothing is written as nothing.
+func writeShiftBy(w io.Writer, bits int, op byte) error {
+	if bits == 0 {
+		return nil
+	}
+	if bits > byteutil.MaxTapeSize*BYTE_SIZE {
+		bits = byteutil.MaxTapeSize * BYTE_SIZE
+	}
+	if _, err := WritePush2(w, bits); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{op})
+	return err
+}
+
+// WriteTapeHead keeps the first bytes of what a tape says, and WriteTapeTail drops them.
+//
+// Both count in significant bytes, so both start by asking how long the value is. What is kept
+// is measured from the other end: keeping the first n of s bytes means moving the tape down by
+// s minus n, and dropping them means keeping that many. The index is taken modulo the tape
+// width, so it can never be out of bounds, and it is held to the value's own length — asking
+// for more of a tape than it has gives all of it.
+func WriteTapeHead(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	if err := writeRemainingLength(w, inst, tapeSize); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{OpShiftRight})
+	return err
+}
+
+func WriteTapeTail(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	if err := writeRemainingLength(w, inst, tapeSize); err != nil {
+		return err
+	}
+	// Every bit below what is kept, which for a whole word comes out of the shift as zero and
+	// out of the subtraction as all ones — which is the tape untouched, and is what dropping
+	// none of it means.
+	_, err := w.Write([]byte{OpPush1, 0x01, OpSwap1, OpShiftLeft, OpPush1, 0x01, OpSwap1, OpSub, OpAnd})
+	return err
+}
+
+// writeRemainingLength leaves, above the tape, how many bits of it are past the index.
+func writeRemainingLength(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	at := int(byteutil.ToUint64(inst.GetRight().Bytes())) % tapeSize
+
+	if _, err := w.Write([]byte{OpDup1}); err != nil {
+		return err
+	}
+	if err := WriteSignificantLength(w); err != nil {
+		return err
+	}
+	if at == 0 {
+		return nil
+	}
+
+	// The index can be past the end of what the value says, and then there is nothing past it:
+	// the subtraction would run backwards, so it is multiplied by whether it should have
+	// happened at all.
+	bits := byte(at * BYTE_SIZE)
+	_, err := w.Write([]byte{
+		OpDup1, OpPush1, bits, OpGreaterThan, OpIsZero,
+		OpSwap1, OpPush1, bits, OpSwap1, OpSub, OpMul,
+	})
 	return err
 }
 
@@ -685,6 +947,20 @@ var comparisons = map[byte][]byte{
 	ir.OpAnd:     {OpIsZero, OpSwap1, OpIsZero, OpOr, OpIsZero},
 }
 
+// ordersItsOwn names the instructions that put their own written-down values on the stack.
+//
+// Most take a pair and the pair is enough for WriteImmediates to know where each one goes. An
+// instruction that takes as many values as it was given is not: which of them are on the stack
+// already and which are being written down is what decides the order, and only the instruction
+// knows what it does with them. A save is here for the older reason — it is the value.
+var ordersItsOwn = map[byte]bool{
+	ir.OpSave: true,
+	ir.OpCall: true,
+	ir.OpJoin: true,
+	ir.OpPull: true,
+	ir.OpPush: true,
+}
+
 // WriteImmediates puts on the stack the values an instruction carries inside itself.
 //
 // A Ref was already put there by whoever produced it, and the lowering saw to it that it
@@ -858,7 +1134,7 @@ func targetOf(inst ir.Instruction, at int, positions []int) int {
 func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, target int, scope Scope) error {
 	op := inst.GetOpCode()
 
-	if handled[op] && op != ir.OpSave && op != ir.OpCall && op != ir.OpJoin {
+	if handled[op] && !ordersItsOwn[op] {
 		if err := WriteImmediates(bs, inst, scope.TapeSize); err != nil {
 			return err
 		}
@@ -931,6 +1207,30 @@ func WriteInstruction(bs io.Writer, im *IdentManager, inst ir.Instruction, targe
 
 	if op == ir.OpCall {
 		if err := WriteCall(bs, inst, scope, target); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpPull {
+		if err := WriteTapePull(bs, inst, scope.TapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpPush {
+		if err := WriteTapePush(bs, inst, scope.TapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpHead {
+		if err := WriteTapeHead(bs, inst, scope.TapeSize); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpTail {
+		if err := WriteTapeTail(bs, inst, scope.TapeSize); err != nil {
 			return err
 		}
 	}

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -486,3 +486,42 @@ func TestAFieldCountsBackFromTheEndOfTheRun(t *testing.T) {
 		})
 	}
 }
+
+// A tape built out of values a program works out would need each of them brought to the top of
+// the stack in turn, and that is not written. It is refused rather than written wrong: the
+// values are on the stack in the order they appear and the fold needs them in the other one.
+func TestATapeBuiltFromWorkedOutValuesIsRefused(t *testing.T) {
+	inst := ir.NewInstructionOver([]byte("00"), ir.OpPull,
+		ir.RefTo([]byte("01")), ir.RefTo([]byte("02")), ir.RefTo([]byte("03")))
+
+	err := WriteTapePull(io.Discard, inst, 8)
+	if err == nil {
+		t.Fatal("it wrote a fold the stack cannot give it")
+	}
+	if !strings.Contains(err.Error(), "one at a time") {
+		t.Errorf("it says %q, and never says what to do instead", err)
+	}
+}
+
+// A tape literal collapses into one shift and one or, however many values were written between
+// the brackets: their lengths are known while compiling, so the whole run of them is a number.
+func TestATapeLiteralIsOneShiftAndOneOr(t *testing.T) {
+	items := []ir.Operand{ir.RefTo([]byte("01"))}
+	for _, value := range []uint64{1, 2, 3} {
+		items = append(items, ir.Imm(value, 8))
+	}
+
+	bs := bytes.NewBuffer(make([]byte, 0))
+	if err := WriteTapePull(bs, ir.NewInstructionOver([]byte("00"), ir.OpPull, items...), 8); err != nil {
+		t.Fatalf("writing the literal: %v", err)
+	}
+
+	// Three values of one byte each move the tape three places, and what enters is the three
+	// of them read as one number. The mask after it is what keeps the tape its own width,
+	// which is what makes whatever reached the left end fall off.
+	expected := []byte{OpPush2, 0x00, 24, OpShiftLeft, OpPush3, 0x01, 0x02, 0x03, OpOr,
+		OpPush8, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, OpAnd}
+	if got := bs.Bytes(); !bytes.Equal(got, expected) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+	}
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -116,21 +116,18 @@ longer a hope: an EVM is built in memory, the contract is deployed and called, a
 is compared against the evaluator. What it proves is arithmetic across a dispatcher at any
 tape width — a result that leaves the width is cut back to it, the way the evaluator does —
 names bound inside a scope, branches, the comparisons and `and`/`or`, a scope calling another
-as deep as it nests, and shapes.
+as deep as it nests, shapes, and the tape operations.
 
-What is left is narrower than it was, but it is still silent, which is the dangerous part: a
-contract using any of the following **compiles and does nothing on chain**. `aurora build`
-says so, once per feature, at the line that used it.
+Nothing a program can write is missing from it any more. What a contract does not get is what
+was decided not to reach a chain, and two limits that are written down:
 
-- The tape operations produce no bytecode. It is not a refusal — a tape is at most 32 bytes
-  and an EVM word is exactly 32, so each of them is a shift and a mask. They are simply not
-  written yet.
-- **A shape reaches the chain while its run fits a word.** A run is its tapes and nothing
-  else, so a shape of five fields at the default tape of eight is forty bytes and is refused
-  rather than written short. Four fields fill a word exactly.
-- **Only a scope bound at the top of a program can be called.** A scope bound inside another,
-  or reached through an alias, is refused by the builder rather than written: what would be
-  written is a jump to an address no scope has.
+- **A shape reaches the chain while its run fits a word.** A run is its tapes and nothing else,
+  so a shape of five fields at the default tape of eight is forty bytes and is refused rather
+  than written short. Four fields fill a word exactly.
+- **Only a scope bound at the top of a program can be called**, and **a tape literal built out
+  of values a program works out** is refused rather than written wrong — `pull t x` one value
+  at a time is written.
+
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -424,7 +424,7 @@ func emitCalleeLiteral(tc *int, insts *[]ir.Instruction, n ast.CalleeLiteral, ta
 func emitPrintStatement(tc *int, insts *[]ir.Instruction, n ast.PrintStatement, tapeSize int) ir.Label {
 	ll := operandFor(tc, insts, n.Param, tapeSize)
 	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, printOpCodes[n.Format], ll, ir.Nothing()))
+	*insts = append(*insts, ir.NewInstruction(l, printOpCodes[n.Format], ll, ir.Nothing()).At(originOf(n.Token)))
 	return l
 
 }

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -519,3 +519,100 @@ ident whole = defer { Point{feed(0), 20}; };`
 		t.Errorf("the chain answered %s, want the two tapes laid end to end, which is %s", got, want)
 	}
 }
+
+// A tape is a shift register, and the operations on it reach the chain. Each of them is
+// defined by how much of a value means something — its bytes once the zeros in front are
+// dropped — which off a chain is the length of a slice and on one has to be worked out from
+// the word itself.
+func TestTapeOperationsAnswerTheSameOnChainAndOff(t *testing.T) {
+	cases := []struct {
+		name     string
+		source   string
+		args     []string
+		tapeSize int
+	}{
+		{
+			name:   "a literal is pulled one value at a time",
+			source: "ident t = defer { ident tape = [1, 2, 3]; tape + feed(0); };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "an empty literal is a tape of zeros",
+			source: "ident t = defer { ident tape = []; tape + feed(0); };",
+			args:   []string{"5"},
+		},
+		{
+			name:   "a value the program works out enters at the right",
+			source: "ident t = defer { ident x = feed(0); pull [1, 2] x; };",
+			args:   []string{"7"},
+		},
+		{
+			name:   "and one written down",
+			source: "ident t = defer { pull [1, 2] 4; };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "a value wider than a byte enters as the bytes it takes",
+			source: "ident t = defer { ident x = feed(0); pull [1] x; };",
+			args:   []string{"300"},
+		},
+		{
+			name:   "pushing lets a value in at the left and the far byte falls off",
+			source: "ident t = defer { ident x = feed(0); push [1, 2, 3] x; };",
+			args:   []string{"5"},
+		},
+		{
+			name:   "and one written down",
+			source: "ident t = defer { push [1, 2, 3] 5; };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "head keeps the first significant bytes",
+			source: "ident t = defer { ident five = [1, 2, 3, 4, 5]; head five 2; };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "tail drops them",
+			source: "ident t = defer { ident five = [1, 2, 3, 4, 5]; tail five 2; };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "an index past the tape width wraps into it",
+			source: "ident t = defer { ident full = [1, 2, 3, 4, 5, 6, 7, 8]; tail full 18; };",
+			args:   []string{"0"},
+		},
+		{
+			name:   "an index past what the value says gives all of it, or none",
+			source: "ident t = defer { ident x = feed(0); head x 5; };",
+			args:   []string{"7"},
+		},
+		{
+			name:   "the same, dropping",
+			source: "ident t = defer { ident x = feed(0); tail x 5; };",
+			args:   []string{"7"},
+		},
+		{
+			name:   "a tape of zeros is one byte long, so pulling onto it moves one place",
+			source: "ident t = defer { ident x = feed(0); pull x 9; };",
+			args:   []string{"0"},
+		},
+		{
+			name:     "at one byte, everything happens inside a single place",
+			source:   "ident t = defer { ident x = feed(0); pull [1] x; };",
+			args:     []string{"9"},
+			tapeSize: 1,
+		},
+		{
+			name:     "and at the full width, where a shift reaches the end of a word",
+			source:   "ident t = defer { ident x = feed(0); head x 4; };",
+			args:     []string{"1000000"},
+			tapeSize: 32,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "t", tc.args, tc.tapeSize)
+		})
+	}
+}

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -883,15 +883,16 @@ var printFormats = map[string]ast.PrintFormat{
 	token.PRINTD: ast.PrintDecimal,
 }
 
-func (p *pr) ParsePrint(token string, format ast.PrintFormat) (ast.Node, error) {
-	if _, err := p.EatToken(token); err != nil {
+func (p *pr) ParsePrint(tokenName string, format ast.PrintFormat) (ast.Node, error) {
+	at, err := p.EatToken(tokenName)
+	if err != nil {
 		return nil, err
 	}
 	expr, err := p.ParseExpr()
 	if err != nil {
 		return nil, err
 	}
-	return ast.PrintStatement{Format: format, Param: expr}, nil
+	return ast.PrintStatement{Format: format, Param: expr, Token: at}, nil
 }
 
 func (p *pr) ParseAssert() (ast.Node, error) {

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -199,6 +199,7 @@ type PrintStatement struct {
 	mark
 	Format PrintFormat `json:"format"`
 	Param  Node        `json:"parameter"`
+	Token  token.Token `json:"-"`
 }
 
 // FeedExpression is "feed(n)": it reads the nth value applied to the running scope.


### PR DESCRIPTION
`pull`, `push`, `head` and `tail` compile to bytecode. With them **the backend has no feature left that a contract can use and not get.**

## The one thing all four rest on

Every tape operation is defined by *how much of a value means something* — its bytes once the zeros in front are dropped. Off a chain that is the length of a slice. On one there is nothing to ask: a value is a word.

So it is worked out from the word, by halving. Five times over the value is asked whether anything survives a shift of sixteen bytes, then eight, four, two, one. Each answer is one or zero, so multiplying the shift by it either takes that step or takes nothing — and the same product is added to a running total. **Nothing branches**, so it stays a run of instructions rather than five jumps, and it is exact for every word.

The last byte is added at the end and never asked about. That is what makes a value of zero **one** byte long rather than none — the same answer the evaluator gives, and the one that keeps `pull t 0` a shift by one place.

## What it costs, and when it costs nothing

When the program wrote the values down, none of that machinery is needed: the lengths are known while compiling. **A tape literal is one shift and one or on a chain**, however many values were written between the brackets.

```
[1, 2, 3]   ->   PUSH2 24  SHL  PUSH3 010203  OR  PUSH8 ff…ff  AND
```

## What is refused

A literal built out of values a program *works out* — `[a, b, c]` with three names. The fold runs from the first value and the stack offers the last, and bringing each of them up in turn is not written. `pull t x` for a single value is, which is the form the language reads anyway: the items of a bracket are numbers or names, and a name is a value already on the stack.

## Two things found on the way, each its own commit

**A print carried no line.** The three print builtins were the only nodes in the tree without the token they came from, so `printb writes a log, and a chain has nowhere to put one` pointed at line 0. That is precisely the warning someone wants to *find* in a file.

**A gap nobody wrote down was silent.** `Warnings` passed over any instruction it had not been told about. Harmless while the pending list was long — everything missing was on it. Not harmless now that the list is **empty**: the next opcode added to the IR reaches that file as something in neither list, and the answer was to say nothing. It now warns under the name the IR gives it (`OpPull` rather than `a tape operation`), which reads worse and is the right trade.

## Proof

`make check` — 0 issues. Fifteen new differential cases: literals, values written down and values worked out, entering at either end, a value wider than a byte, an index past the tape width and an index past what the value says — at tape widths of **one, eight and thirty-two**, where a shift reaches the end of a word and has to come out right anyway.

Plus the refusal and a unit case pinning the literal collapse.

While writing the tests I had several cases rejected by the parser rather than the backend: a tape target must be a bracket, a number, an identifier or another tape operation, so `pull t feed(0)` is not Aurora — the feed has to be bound to a name first. The cases now read the way the language does.

## Note

The builder learned `DUP1`, `DUP3` and `SWAP2`. A machine with no addressing has those instead: reaching a value means bringing it to the top, and keeping one means copying it before whoever takes it does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)