### PR TITLE
A scope written inside another does not run on the way past

### DIFF
--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -113,8 +113,41 @@ func (b *Builder) PickDeferAtCursor(cursor int) (d *Dispatcher, nextCursor int, 
 		return nil, cursor, false
 	}
 
-	body := Lowering(b.insts[cursor+1:end], b.tapeSize)
+	body := Lowering(withoutNestedScopes(b.insts[cursor+1:end], b.tapeSize), b.tapeSize)
 	return &Dispatcher{Selector: selectorInst.GetLeft().Bytes(), Body: body}, end, true
+}
+
+// withoutNestedScopes takes the scopes written inside this one out of its body.
+//
+// A scope's body is code that runs when the scope is called, never where it was written. Left
+// in, the inner body was written straight into the outer one and ran on the way past: its
+// return fired in the middle of code that had not asked for it, so
+//
+//	ident outer = defer { ident inner = defer { 1; }; 2; };
+//
+// answered 1 on chain where the program answers 2. It compiled, it deployed, and it said
+// nothing — the worst way for a contract to be wrong.
+//
+// What replaces it is the neutral value, which is what the binding is worth here: a scope
+// written inside another is not something a transaction can reach, and calling one is already
+// refused, so on a chain the name it was bound to holds nothing. Replacing rather than dropping
+// is what keeps the binding, and a scope whose last expression is one still answers what it
+// answered.
+func withoutNestedScopes(insts []ir.Instruction, tapeSize int) []ir.Instruction {
+	out := make([]ir.Instruction, 0, len(insts))
+	for at := 0; at < len(insts); at++ {
+		inst := insts[at]
+		if inst.GetOpCode() != ir.OpDefer {
+			out = append(out, inst)
+			continue
+		}
+		// A scope written inside this one carries how long its body is, and a scope inside
+		// that one is inside those instructions, so stepping over them steps over every depth.
+		out = append(out, ir.NewInstruction(
+			inst.GetLabel(), ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
+		at += int(byteutil.ToUint64(inst.GetRight().Bytes()))
+	}
+	return out
 }
 
 // pickScopes separates the scopes a transaction can reach from the code that is not held by

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -288,3 +288,40 @@ func TestNewIdentManager(t *testing.T) {
 		}
 	})
 }
+
+// A scope written inside another is taken out of the body before it is written, at every
+// depth, and what stays in its place is the neutral value the binding is worth on a chain.
+func TestWithoutNestedScopes(t *testing.T) {
+	// outer { inner { deep { } } ; 2 }, as the emitter lays it out: a scope carries how long
+	// its body is, and a scope inside it lives inside those instructions.
+	insts := []ir.Instruction{
+		ir.NewInstruction([]byte("0"), ir.OpBeginScope, ir.Nothing(), ir.Nothing()),
+		ir.NewInstruction([]byte("1"), ir.OpDefer, ir.RefTo([]byte("2")), ir.TargetAt(5)),
+		ir.NewInstruction([]byte("2"), ir.OpBeginScope, ir.Nothing(), ir.Nothing()),
+		ir.NewInstruction([]byte("3"), ir.OpDefer, ir.RefTo([]byte("4")), ir.TargetAt(2)),
+		ir.NewInstruction([]byte("4"), ir.OpBeginScope, ir.Nothing(), ir.Nothing()),
+		ir.NewInstruction([]byte("5"), ir.OpReturn, ir.RefTo([]byte("4")), ir.RefTo([]byte("4"))),
+		ir.NewInstruction([]byte("6"), ir.OpReturn, ir.RefTo([]byte("2")), ir.RefTo([]byte("2"))),
+		ir.NewInstruction([]byte("7"), ir.OpIdent, ir.NameOf("inner"), ir.RefTo([]byte("1"))),
+		ir.NewInstruction([]byte("8"), ir.OpSave, ir.Imm(2, 8), ir.Nothing()),
+		ir.NewInstruction([]byte("9"), ir.OpReturn, ir.RefTo([]byte("0")), ir.RefTo([]byte("8"))),
+	}
+
+	kept := withoutNestedScopes(insts, 8)
+
+	wanted := []byte{ir.OpBeginScope, ir.OpSave, ir.OpIdent, ir.OpSave, ir.OpReturn}
+	if len(kept) != len(wanted) {
+		t.Fatalf("kept %d instructions, want %d: %v", len(kept), len(wanted), kept)
+	}
+	for at, want := range wanted {
+		if got := kept[at].GetOpCode(); got != want {
+			t.Errorf("instruction %d is %s, want %s", at, ir.ResolveOpCode(got), ir.ResolveOpCode(want))
+		}
+	}
+
+	// The binding still finds what it was bound to, so nothing that read the scope's label is
+	// left pointing at an instruction that is no longer there.
+	if got := string(kept[1].GetLabel()); got != "1" {
+		t.Errorf("what replaced the scope answers to %q, want the label the binding reads", got)
+	}
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -124,9 +124,11 @@ was decided not to reach a chain, and two limits that are written down:
 - **A shape reaches the chain while its run fits a word.** A run is its tapes and nothing else,
   so a shape of five fields at the default tape of eight is forty bytes and is refused rather
   than written short. Four fields fill a word exactly.
-- **Only a scope bound at the top of a program can be called**, and **a tape literal built out
-  of values a program works out** is refused rather than written wrong — `pull t x` one value
-  at a time is written.
+- **Only a scope bound at the top of a program can be called.** A scope written inside another
+  is not written at all: on a chain the name it was bound to holds the neutral value, and
+  calling it is refused rather than written as a jump to an address no scope has.
+- **A tape literal built out of values a program works out** is refused rather than written
+  wrong — `pull t x` one value at a time is written.
 
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -616,3 +616,42 @@ func TestTapeOperationsAnswerTheSameOnChainAndOff(t *testing.T) {
 		})
 	}
 }
+
+// A scope written inside another does not run where it was written.
+//
+// A body is code that runs when the scope is called, and that is as true of a scope written
+// inside another as of one written at the top. Its body used to be written straight into the
+// outer one and run on the way past — its return firing in the middle of code that had not
+// asked for it — so the first of these answered 1 on chain where the program answers 2. It
+// compiled, it deployed, and it said nothing.
+func TestAScopeWrittenInsideAnotherDoesNotRunOnTheWayPast(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "the outer scope answers its own last expression",
+			source: "ident outer = defer { ident inner = defer { 1; }; 2 + feed(0); };",
+		},
+		{
+			// A scope whose last expression is a binding answers the neutral value, which is
+			// what the binding is worth here: on a chain a scope is not a value.
+			name:   "even when the binding is the last thing in it",
+			source: "ident outer = defer { ident inner = defer { 1; }; };",
+		},
+		{
+			name:   "and at any depth",
+			source: "ident outer = defer { ident inner = defer { ident deep = defer { 9; }; 1; }; 2 + feed(0); };",
+		},
+		{
+			name:   "the names the outer scope binds are still its own",
+			source: "ident outer = defer { ident x = feed(0); ident inner = defer { 1; }; x + x; };",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "outer", []string{"3"}, 0)
+		})
+	}
+}


### PR DESCRIPTION
```aurora
ident outer = defer { ident inner = defer { 1; }; 2; };
```

The program answers **2**. The chain answered **1**. It compiled, it deployed, and it said nothing.

Found while auditing whether the backend really carries everything after #117 — the audit that prompted it was "does every opcode reach the bytecode", and every opcode did. This was hiding under that.

## What was wrong

A body is code that runs **when the scope is called**, never where it was written. That is as true of a scope written inside another as of one written at the top — but only the ones at the top were taken out of the instruction stream. An inner body was written straight into the outer one and ran on the way past, its `SWAP1; JUMP` firing in the middle of code that had not asked for it, so the contract answered the inner scope's value and stopped.

The other half of this case was already loud: calling a nested scope hits the refusal added in #115 (`only a scope bound at the top of a program reaches the bytecode`). It was the **uncalled** one that was silent — which is the more likely one to be written by accident.

## What it does now

Nested scopes are taken out of the body before it is written, at every depth. What stays in their place is the **neutral value**, which is what the binding is worth on a chain: a scope written inside another is not something a transaction can reach.

Replacing rather than dropping matters — it keeps the binding, so a scope whose last expression *is* the binding still answers the neutral value the way it did, and nothing that read the scope's label is left pointing at an instruction that is no longer there.

## Proof

Four differential cases: the outer scope answering its own last expression, answering when that last expression is the binding, a scope nested two deep, and the names the outer scope binds still being its own. Plus a unit case over the instruction stream at two levels of nesting.

`make check` — 0 issues.

## Not in this PR

The maintainer raised refusing programs that bind a name and never use it, which would have caught this one. It is left for later, and worth writing down why it needs care: **a top-level `ident add = defer { ... };` is never used by the program** — the transaction uses it — so the rule as stated would refuse every Aurora contract. A narrower version, about a binding inside a scope that nothing reads, is a real diagnostic and belongs beside the emitter's other warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)