### PR TITLE
A position a call did not fill reads zero

### DIFF
--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -176,7 +176,7 @@ func (b *Builder) pickScopes() (dispatchers []Dispatcher, root []ir.Instruction)
 // It measures by writing to something that only counts, rather than by writing the whole scope
 // into a buffer that is then thrown away — which is what this did, since where a scope lands
 // is not known until every scope has been found and the scope has to be written again anyway.
-func (b *Builder) measureScopes(dispatchers []Dispatcher, entries map[string]int) (int, error) {
+func (b *Builder) measureScopes(dispatchers []Dispatcher, entries map[string]Entry) (int, error) {
 	offset := 0
 	for at := range dispatchers {
 		d := &dispatchers[at]
@@ -200,9 +200,10 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	// while the scopes are still being measured, and what it needs then is only that the name
 	// it calls is a scope of this contract. The addresses are filled in below, into this same
 	// map, once there are addresses to fill in.
-	entries := make(map[string]int, len(dispatchers))
+	entries := make(map[string]Entry, len(dispatchers))
 	for at := range dispatchers {
-		entries[string(dispatchers[at].Selector)] = 0
+		d := &dispatchers[at]
+		entries[string(d.Selector)] = Entry{Reads: FrameNamesAt(d.Body) / MEMORY_SLOT_SIZE}
 	}
 
 	offset, err := b.measureScopes(dispatchers, entries)
@@ -223,7 +224,9 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 		if err != nil {
 			return nil, err
 		}
-		entries[string(d.Selector)] = internal
+		entry := entries[string(d.Selector)]
+		entry.At = internal
+		entries[string(d.Selector)] = entry
 	}
 
 	for at := range dispatchers {

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -598,7 +598,7 @@ func WriteField(w io.Writer, inst ir.Instruction, tapeSize int) error {
 // somewhere is the stack, under an answer the callee's own work is piled on top of.
 func WriteCall(w io.Writer, inst ir.Instruction, scope Scope, at int) error {
 	name := string(inst.GetLeft().Bytes())
-	internal, known := scope.Entries[name]
+	callee, known := scope.Entries[name]
 	if !known {
 		return fmt.Errorf(
 			"a call to %q cannot be written: only a scope bound at the top of a program reaches the bytecode", name)
@@ -608,10 +608,10 @@ func WriteCall(w io.Writer, inst ir.Instruction, scope Scope, at int) error {
 	// a fixed size, so what is measured with a wrong address is what is written with the
 	// right one.
 	var measured counter
-	if err := writeCallOut(&measured, inst, scope, 0, internal); err != nil {
+	if err := writeCallOut(&measured, inst, scope, 0, callee); err != nil {
 		return err
 	}
-	if err := writeCallOut(w, inst, scope, at+int(measured), internal); err != nil {
+	if err := writeCallOut(w, inst, scope, at+int(measured), callee); err != nil {
 		return err
 	}
 
@@ -622,7 +622,7 @@ func WriteCall(w io.Writer, inst ir.Instruction, scope Scope, at int) error {
 }
 
 // writeCallOut fills the callee's frame, moves the pointer onto it, and goes.
-func writeCallOut(w io.Writer, inst ir.Instruction, scope Scope, back, internal int) error {
+func writeCallOut(w io.Writer, inst ir.Instruction, scope Scope, back int, callee Entry) error {
 	applied := valueOperands(inst)
 
 	for at, operand := range applied {
@@ -646,13 +646,28 @@ func writeCallOut(w io.Writer, inst ir.Instruction, scope Scope, back, internal 
 		}
 	}
 
+	// A position the callee reads and this call did not fill has to answer with zeros, which
+	// is what the language answers for reading past what was applied. On the way in from a
+	// transaction that is free — the calldata gives zeros past its end — but a frame is
+	// memory an earlier activation already used, so what is left there is the last call's
+	// values. Two scopes reading two positions, one of them called with one, and the second
+	// read the first call's second value.
+	for at := len(applied); at < callee.Reads; at++ {
+		if _, err := w.Write([]byte{OpPush1, 0x00}); err != nil {
+			return err
+		}
+		if err := writeFrameStore(w, scope.Frame+at*MEMORY_SLOT_SIZE); err != nil {
+			return err
+		}
+	}
+
 	if err := writeFrameMove(w, scope.Frame, OpAdd); err != nil {
 		return err
 	}
 	if _, err := WritePush2(w, back); err != nil {
 		return err
 	}
-	if _, err := WritePush2(w, internal); err != nil {
+	if _, err := WritePush2(w, callee.At); err != nil {
 		return err
 	}
 	_, err := w.Write([]byte{OpJump})
@@ -704,7 +719,7 @@ func ScopeInternalAt(base int, body []ir.Instruction, tapeSize int) (int, error)
 // The addresses inside it are worked out by measuring the prologue, which is the only part
 // whose length depends on the scope — one copy per position the body addresses. Every push is
 // a fixed size, so measuring once is enough.
-func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int, entries map[string]int) error {
+func WriteScope(bs io.Writer, body []ir.Instruction, tapeSize, base int, entries map[string]Entry) error {
 	reads := FrameNamesAt(body) / MEMORY_SLOT_SIZE
 
 	internal, err := ScopeInternalAt(base, body, tapeSize)
@@ -1022,18 +1037,32 @@ type Scope struct {
 	// binds. A call puts the frame of whoever it calls right after this one, so the two never
 	// share a slot and a scope can be entered again while it is running.
 	Frame int
-	// Entries answers, for the name a scope was bound to, the byte another scope enters it
-	// at. The names are known before any address of one is, so it is filled with zeros while
-	// the scopes are measured and with addresses before they are written — a call measures
-	// the same either way, since every push is a fixed size.
-	Entries map[string]int
+	// Entries answers, for the name a scope was bound to, what a call needs to know about it.
+	// The names and what each reads are known before any address of one is, so the addresses
+	// are filled in before the scopes are written — a call measures the same either way,
+	// since every push is a fixed size and what does change its length is known from the
+	// start.
+	Entries map[string]Entry
+}
+
+// An Entry is what a call needs to know about the scope it calls: where to go in, and how many
+// values that scope reads.
+//
+// It reads a fixed number of positions — the highest it feeds, plus one — and that is a
+// property of the body, known where the body is. What a call applies is a property of the call.
+// The two need not agree, and where they do not is where the caller has work to do.
+type Entry struct {
+	// At is the byte another scope enters this one at, past its prologue.
+	At int
+	// Reads is how many positions the body addresses.
+	Reads int
 }
 
 // ScopeOf answers what the writer needs to know about a body of instructions.
 //
 // What it derives is derived once, here, rather than at each of the places that reads it:
 // working the arms out twice is how the writing pass and the measuring pass come to disagree.
-func ScopeOf(insts []ir.Instruction, tapeSize int, entries map[string]int, answers bool) Scope {
+func ScopeOf(insts []ir.Instruction, tapeSize int, entries map[string]Entry, answers bool) Scope {
 	return Scope{
 		TapeSize: tapeSize,
 		Arms:     armsOf(insts),

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -396,7 +396,7 @@ func TestACallComesBackToItsOwnJumpDestiny(t *testing.T) {
 
 	bs := bytes.NewBuffer(make([]byte, 0))
 	inst := ir.NewInstructionOver([]byte("00"), ir.OpCall, ir.NameOf("f"), ir.Imm(1, 8))
-	if err := WriteCall(bs, inst, ScopeOf(nil, 8, map[string]int{"f": 0x1234}, false), at); err != nil {
+	if err := WriteCall(bs, inst, ScopeOf(nil, 8, map[string]Entry{"f": {At: 0x1234}}, false), at); err != nil {
 		t.Fatalf("writing the call: %v", err)
 	}
 
@@ -420,7 +420,7 @@ func TestACallComesBackToItsOwnJumpDestiny(t *testing.T) {
 func TestACallToSomethingThatIsNotAScopeIsRefused(t *testing.T) {
 	inst := ir.NewInstructionOver([]byte("00"), ir.OpCall, ir.NameOf("nowhere"), ir.Imm(1, 8))
 
-	err := WriteCall(io.Discard, inst, ScopeOf(nil, 8, map[string]int{"elsewhere": 0x40}, false), 0)
+	err := WriteCall(io.Discard, inst, ScopeOf(nil, 8, map[string]Entry{"elsewhere": {At: 0x40}}, false), 0)
 	if err == nil {
 		t.Fatal("it wrote a call to a scope that does not exist")
 	}

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -655,3 +655,48 @@ func TestAScopeWrittenInsideAnotherDoesNotRunOnTheWayPast(t *testing.T) {
 		})
 	}
 }
+
+// A position a scope reads and the call did not fill answers with zeros, which is what the
+// language answers for reading past what was applied.
+//
+// On the way in from a transaction that is free: the calldata gives zeros past its end. A
+// frame is not free — it is memory an earlier activation already used, so what is left there
+// is the last call's values. Two scopes reading two positions, one of them called with one,
+// and the second read the first call's second value: the chain answered 501 where the program
+// answers 301.
+func TestAShortCallReadsZeroOnChainToo(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "a call short by one, after a call that filled the place",
+			source: `ident c = defer { feed(0) + feed(1); };
+ident b = defer { feed(0) + feed(1); };
+ident a = defer { c(100, 200) + b(1); };`,
+		},
+		{
+			name: "short by two",
+			source: `ident c = defer { feed(0) + feed(1) + feed(2); };
+ident b = defer { feed(0) + feed(1) + feed(2); };
+ident a = defer { c(100, 200, 300) + b(1); };`,
+		},
+		{
+			name: "the same scope, called long and then short",
+			source: `ident b = defer { feed(0) + feed(1); };
+ident a = defer { b(100, 200) + b(1); };`,
+		},
+		{
+			name: "a scope that reads nothing, called with values",
+			source: `ident c = defer { feed(0) + feed(1); };
+ident b = defer { 7; };
+ident a = defer { c(100, 200) + b(1, 2); };`,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "a", []string{"0"}, 0)
+		})
+	}
+}


### PR DESCRIPTION
```aurora
ident c = defer { feed(0) + feed(1); };
ident b = defer { feed(0) + feed(1); };
ident a = defer { c(100, 200) + b(1); };
```

The program answers **301**. The chain answered **501**.

`b` reads two positions and was called with one, and what it read for the second was the **200 that `c` had left in the same place**.

## Why it was wrong

Reading past what was applied answers the neutral tape — the language's rule since #92 — and the compiler already *warns* when a call is short of what a scope reads. The warning is not the guarantee: the program is legal, it has an answer, and the chain has to give the same one.

On the way in from a transaction this was already right, and free: the prologue copies as many positions as the body reads, and `CALLDATALOAD` past the end gives zeros.

A frame is not free. It is memory an earlier activation used, and the pointer goes up and comes back down — so a place nobody wrote **this** time holds what somebody wrote **last** time.

## How it was found

By going back to `rfcs/if_and_call.md` to mark it implemented, and reading its open questions against what actually shipped. This was open question 5, written before any of it was built:

> Uma posição que ninguém escreveu tem que ler zero. […] no frame não é, porque o ponteiro sobe e desce, então a memória de uma ativação já serviu a outra, e um argumento que não foi enviado leria o que sobrou lá.

It named the bug exactly, and the code did not answer it. Worth saying plainly: this shipped in #115 and I did not catch it there.

## The fix, and why the RFC thought it was harder

The RFC saw two bad options — a count travelling in a slot of the frame, or the caller zeroing a global ceiling on every call — because it assumed the caller could not know how many positions the callee reads:

> quem chama […] não sabe quantas posições o corpo lê, porque um `defer` é valor de primeira classe e pode ser chamado através de qualquer nome.

What was built refuses a call to anything but a scope bound at the top of a program. So **the name resolves while compiling**, and the scope it names says how many positions it reads — the same number its own prologue already uses. It travels beside the address a call needed anyway.

Nothing travels in the frame; no ceiling is zeroed. The caller writes exactly the places between what it applied and what the callee reads, which is **nothing at all** when the call is not short.

## Proof

Four differential cases: short by one after a call that filled the place, short by two, the same scope called long and then short, and a scope that reads nothing called with values.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)