### PR TITLE
Two debts the RFC wrote down

### DIFF
--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -217,21 +217,3 @@ func labelsTaken(insts []ir.Instruction) map[string]int {
 	}
 	return taken
 }
-
-// StackDepth answers how deep the stack is after each instruction of a lowered scope, starting
-// at zero.
-//
-// It is what says a scope is balanced, and it is what a jump will need: the two sides of a
-// branch have to meet with the same stack under them.
-func StackDepth(insts []ir.Instruction) []int {
-	depth := make([]int, len(insts)+1)
-	for at, inst := range insts {
-		op := inst.GetOpCode()
-		after := depth[at] - len(consumes(inst))
-		if produces(op) {
-			after++
-		}
-		depth[at+1] = after
-	}
-	return depth
-}

--- a/builder/evm/lowering_test.go
+++ b/builder/evm/lowering_test.go
@@ -72,38 +72,6 @@ func TestSubtractionAndDivisionPushTheOtherWayRound(t *testing.T) {
 	}
 }
 
-// StackDepth answers for one lowered scope, and what it answers for is that the scope holds
-// together: the stack never goes under, because an instruction that takes a value has to find
-// it there, and it ends leaving exactly the one value the scope answers with.
-//
-// It is what a jump will need — the two sides of a branch have to meet with the same stack
-// under them — so it is worth pinning before anything depends on it.
-func TestStackDepthAnswersForAScope(t *testing.T) {
-	// feed(0) + feed(1), already in the order the stack needs.
-	insts := []ir.Instruction{
-		ir.NewInstruction([]byte("00"), ir.OpGetFeed, ir.Const(0, 8), ir.Nothing()),
-		ir.NewInstruction([]byte("01"), ir.OpGetFeed, ir.Const(1, 8), ir.Nothing()),
-		ir.NewInstruction([]byte("02"), ir.OpAdd, ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))),
-	}
-
-	depth := StackDepth(insts)
-	if want := []int{0, 1, 2, 1}; !reflect.DeepEqual(depth, want) {
-		t.Errorf("depth is %v, want %v", depth, want)
-	}
-}
-
-// An instruction taking a value nobody put there shows up as the stack going under, which is
-// the whole point of counting: it is a scope that would not run, said before it is written.
-func TestStackDepthShowsAValueNobodyPutThere(t *testing.T) {
-	insts := []ir.Instruction{
-		ir.NewInstruction([]byte("02"), ir.OpAdd, ir.RefTo([]byte("00")), ir.RefTo([]byte("01"))),
-	}
-
-	if got := StackDepth(insts); got[len(got)-1] >= 0 {
-		t.Errorf("depth is %v, want it to go under: it adds two values nobody pushed", got)
-	}
-}
-
 func TestResolveOperandsOrderFromSourceCode(t *testing.T) {
 	cases := []struct {
 		name   string

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -50,12 +50,12 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			wantNone: true,
 		},
 		{
-			// Nothing the emitter produces is pending any more, so what this guards is the
-			// next thing added to the IR: an opcode the builder does not write and nobody
-			// named is warned about under the name the IR gives it, rather than passed over.
+			// Every opcode the IR declares reaches the bytecode, so what this guards is the
+			// next one added: an instruction the builder does not write and nobody named is
+			// warned about rather than passed over.
 			name:    "an instruction nobody wrote down",
-			opcodes: []byte{ir.OpPreCall},
-			want:    []string{"OpPreCall does not reach the bytecode yet"},
+			opcodes: []byte{0xfe},
+			want:    []string{"does not reach the bytecode yet"},
 		},
 		{
 			name:     "a shape, which reaches the bytecode now",

--- a/evaluator/dispatch_test.go
+++ b/evaluator/dispatch_test.go
@@ -442,13 +442,15 @@ func TestExecuteInstructionCarriesAnErrorBack(t *testing.T) {
 	}
 }
 
-// An opcode with no operation behind it steps over and says nothing. OpPreCall is the one
-// declared and never emitted, which is exactly the shape of an opcode added tomorrow and not
-// yet wired: a running program does not stop because of it.
+// An opcode with no operation behind it steps over and says nothing. Every opcode the IR
+// declares has one today, so this one is not from the IR at all — which is exactly the shape
+// of an opcode added tomorrow and wired into one consumer before the other: a running program
+// does not stop because of it.
 func TestExecuteInstructionStepsOverAnOpcodeItDoesNotKnow(t *testing.T) {
 	e := New(NewEvaluatorOptions{})
 
-	inst := ir.NewInstruction([]byte("02"), ir.OpPreCall, ir.Nothing(), ir.Nothing())
+	const notAnOpcodeYet = byte(0xfe)
+	inst := ir.NewInstruction([]byte("02"), notAnOpcodeYet, ir.Nothing(), ir.Nothing())
 	if err := e.ExecuteInstruction(inst); err != nil {
 		t.Fatalf("executing: %v", err)
 	}
@@ -468,8 +470,6 @@ var coveredElsewhere = map[byte]bool{
 	ir.OpPrintDecimal: true,
 	ir.OpAssert:       true,
 	ir.OpCall:         true,
-	// Declared and never emitted; the step-over test is what covers it.
-	ir.OpPreCall: true,
 }
 
 // A new opcode is added to the emitter and wired into the evaluator in two separate places,

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -717,9 +717,10 @@ func init() {
 // ExecuteInstruction runs one instruction: the opcode names the operation, and the operation
 // moves the cursor itself, since where it lands is part of what the instruction does.
 //
-// An opcode with no operation behind it is stepped over rather than refused. OpPreCall is
-// declared and never emitted, and an instruction the evaluator does not know is exactly what
-// a half-wired new opcode looks like — a running program does not stop for it.
+// An opcode with no operation behind it is stepped over rather than refused. Every opcode the
+// IR declares has one today, so what this is for is the next one: an opcode added to the IR
+// and wired into one consumer before the other is exactly what a half-wired new opcode looks
+// like, and a running program does not stop for it.
 func (e *Evaluator) ExecuteInstruction(inst ir.Instruction) error {
 	if over, ok := runOperations[inst.GetOpCode()]; ok {
 		return over(e, inst.GetLabel(), inst.GetOperands())

--- a/rfcs/if_and_call.md
+++ b/rfcs/if_and_call.md
@@ -94,10 +94,20 @@ reler estas perguntas contra o código. A pergunta estava certa antes de o códi
 
 ## O que ficou por fazer
 
-**O `StackDepth` não virou recusa.** A proposta dizia que ele provaria que os dois braços de um
-desvio deixam a mesma pilha, "e vira uma recusa de compilação quando ela não valer". Ele existe
-em `builder/evm/lowering.go` e **nenhum código o chama** — só os testes. A afirmação continua
-verdadeira por construção e não por verificação.
+**O `StackDepth` não virou recusa, e foi removido.** A proposta dizia que ele provaria que os
+dois braços de um desvio deixam a mesma pilha, "e vira uma recusa de compilação quando ela não
+valer". Nunca virou: nenhum código o chamava, só os testes. E ao olhar de perto ele estava
+**errado** — `produces` não lista `OpCall`, então ele contava toda chamada como quem come os
+argumentos e não deixa nada, e cada chamada afundava a conta em um. Ninguém percebeu porque
+ninguém o chamava.
+
+Uma função errada e sem uso é pior que qualquer uma das duas coisas sozinha: ela parece uma
+garantia. E o desenho dela também não dava para o que foi prometido — ela anda em linha reta,
+então num `if` conta os dois braços em sequência, que é justamente o que ela deveria provar não
+acontecer.
+
+A invariante continua verdadeira **por construção**: o emitter não produz desvio desbalanceado.
+Quando isso deixar de ser óbvio, o que entra é uma verificação que conhece caminhos, e não esta.
 
 **Static link.** Um `defer` que lê nome do escopo onde foi escrito continua de fora, como a
 proposta já dizia. Hoje é mais do que de fora: um escopo escrito dentro de outro não é escrito.

--- a/rfcs/if_and_call.md
+++ b/rfcs/if_and_call.md
@@ -74,9 +74,10 @@ que a proposta não previu — o código que escopo nenhum segura, o topo de um 
 tem para quem voltar e por isso encerra a chamada. Esse não dá para ler da instrução, então é
 parâmetro.
 
-**4 · `OpPreCall`.** Continua sem uso e deve sair da lista. Os argumentos chegam à pilha pelo
-lowering, que os põe imediatamente antes da chamada, e é a própria chamada que os escreve no
-frame. Não sobrou lugar para ele.
+**4 · `OpPreCall`.** Saiu da lista. Os argumentos chegam à pilha pelo lowering, que os põe
+imediatamente antes da chamada, e é a própria chamada que os escreve no frame — não sobrou
+lugar para ele. Todo opcode que o IR declara agora tem operação atrás de si nos dois
+consumidores.
 
 **5 · Quem zera as posições que ninguém escreveu.** Quem chama, e sem nenhuma das duas saídas
 que a proposta via como únicas. Ela achava que quem chama não pode saber quantas posições o

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -44,9 +44,7 @@ const (
 	// in an ordinary tape.
 	OpBeginScope // opens a scope, and leaves the value its body ends with
 	OpDefer      // Ref, Target -> stores the scope that follows, and leaves its index
-	OpPreCall    // declared and never emitted; either it becomes where arguments are written,
-	//              or it goes
-	OpCall // Name -> runs the scope that name reaches, and leaves what it answered
+	OpCall       // Name -> runs the scope that name reaches, and leaves what it answered
 
 	// Control. Both operands are counted in instructions, which is what the evaluator's
 	// cursor takes and what stops any pass from reordering the list.

--- a/wire/ir/resolver.go
+++ b/wire/ir/resolver.go
@@ -34,8 +34,6 @@ func ResolveOpCode(op byte) string {
 		return "OpDefer"
 	case OpSave:
 		return "OpSave"
-	case OpPreCall:
-		return "OpPreCall"
 	case OpCall:
 		return "OpCall"
 	case OpPrintBytes:


### PR DESCRIPTION
`rfcs/if_and_call.md` closed with two things owed. Both are settled by removal.

## `StackDepth` was worse than unused

It was promised as a compile-time refusal — proof that both arms of a branch leave the same stack — and never became one. Nothing called it but its own tests.

Looking at it to decide whether to *finish* it turned up that it was also **wrong**:

```go
after := depth[at] - len(consumes(inst))
if produces(op) { after++ }
```

`produces` does not list `OpCall`. So it counted every call as consuming its arguments and leaving nothing, and each call sank the count by one. Any scope calling another had the wrong depth.

Nobody noticed because nobody called it — which is the whole problem. **A function that is wrong and unused is worse than either of those alone**, because it reads as a guarantee.

The design would not have carried the promise either: it walks in a straight line, so for an `if` it counts both arms one after the other, which is exactly what it was supposed to prove does not happen. Carrying that promise means a check that knows about paths, and this was not the start of one.

The invariant still holds **by construction** — the emitter does not produce an unbalanced branch. The RFC now says that, and says that when it stops being obvious what goes in is the check that knows paths, not this one restored.

(The missing `OpCall` in `produces` does not affect the lowering: `divides(OpCall)` is checked first and takes its own branch, so that switch is unreachable for a call. The bug was confined to the function nobody called.)

## `OpPreCall` goes

Declared and never emitted, with a comment saying it either becomes where arguments are written or it goes. It goes: arguments reach the stack through the lowering, which puts each producer right in front of the call, and the call writes them into the frame. No place left for it.

With it gone, **every opcode the IR declares has an operation behind it in both consumers.** The two tests that used it as their example of an unwired opcode now use a byte the IR does not declare, which is closer to what they actually guard: the next opcode added and wired into one consumer before the other.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)