### PR TITLE
The IR has blocks, and the emitter answers in them

### DIFF
--- a/emitter/blocks.go
+++ b/emitter/blocks.go
@@ -1,0 +1,184 @@
+package emitter
+
+import (
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// BlocksOf answers the same program as blocks with terminators.
+//
+// The instruction list says structure by counting: an "if" carries how many instructions to
+// skip, a deferred scope carries how long its body is, and where a scope ends is a return that
+// names where it began. So the structure lives in the order of the list and in arithmetic over
+// indices, and every consumer works it out again — the evaluator by moving a cursor, the
+// builder by slicing and measuring. Two ways of counting the same thing is two chances to
+// count it differently, and the builder has taken that chance more than once.
+//
+// This is the counting done once, where the structure was known in the first place. What comes
+// out has no counts in it: a branch names the two blocks it chooses between, a scope is a
+// block rather than a stretch of a list, and a block ends exactly one way.
+//
+// Five opcodes do not survive the crossing, because each of them was structure written as an
+// instruction: OpDefer, OpBeginScope, OpIf, OpJump and OpReturn. What is left inside a block
+// computes values and nothing else.
+func BlocksOf(insts []ir.Instruction) []ir.Block {
+	b := &blocking{scopes: make(map[string]ir.BlockID)}
+	top := b.reserve()
+	b.run(top, insts, 0, func() ir.Terminator { return ir.Ends(ir.Nothing()) })
+	return b.blocks
+}
+
+// blocking builds blocks as it walks, handing each the number it will be known by.
+//
+// A block is reserved before it is filled, because a branch names blocks that have not been
+// walked yet: the arms of an "if" are named by the terminator that chooses between them, and
+// that terminator is written before either arm is read.
+type blocking struct {
+	blocks []ir.Block
+	// scopes answers, for the label an OpDefer left, the block its body became — so the
+	// binding that follows it can name a block instead of an instruction that is gone.
+	scopes map[string]ir.BlockID
+}
+
+// reserve takes the next number and leaves a place for the block to be put in.
+func (b *blocking) reserve() ir.BlockID {
+	id := ir.BlockID(len(b.blocks))
+	b.blocks = append(b.blocks, ir.Block{ID: id})
+	return id
+}
+
+// put fills a block that was reserved.
+func (b *blocking) put(id ir.BlockID, params int, insts []ir.Instruction, term ir.Terminator, origin ir.Origin) {
+	b.blocks[id] = ir.Block{ID: id, Params: params, Insts: insts, Term: term, Origin: origin}
+}
+
+// ends says how a run finishes when it reaches the end without a return of its own.
+type ends func() ir.Terminator
+
+// run fills a reserved block from one straight run of instructions.
+//
+// It is one block until something splits it. A branch splits it into the run before, the two
+// arms, and the block they meet at — and each of those is a straight run again, so the same
+// walk handles a branch inside a branch without knowing that it is doing so.
+func (b *blocking) run(id ir.BlockID, insts []ir.Instruction, params int, tail ends) {
+	held := make([]ir.Instruction, 0, len(insts))
+	origin := ir.Origin{}
+	if len(insts) > 0 {
+		origin = insts[0].GetOrigin()
+	}
+
+	for at := 0; at < len(insts); at++ {
+		inst := insts[at]
+
+		switch inst.GetOpCode() {
+		case ir.OpBeginScope:
+			// The block is the scope. Nothing opens it but arriving at it.
+
+		case ir.OpDefer:
+			// The body is what this instruction says is its own, and it becomes a block.
+			length := int(byteutil.ToUint64(inst.GetRight().Bytes()))
+			body := insts[at+1 : at+1+length]
+			scope := b.reserve()
+			b.run(scope, body, feedsRead(body), func() ir.Terminator { return ir.Ends(ir.Nothing()) })
+			b.scopes[byteutil.ToHex(inst.GetLabel())] = scope
+			at += length
+
+		case ir.OpIdent:
+			// A binding whose value was a scope names the block instead of an instruction
+			// that is no longer there.
+			if scope, ok := b.scopes[byteutil.ToHex(inst.GetRight().Bytes())]; ok {
+				inst = ir.NewInstruction(
+					inst.GetLabel(), ir.OpIdent, inst.GetLeft(), ir.BlockOf(scope)).At(inst.GetOrigin())
+			}
+			held = append(held, inst)
+
+		case ir.OpReturn:
+			// A scope ends here, and answers with what the return names.
+			b.put(id, params, held, ir.Ends(inst.GetRight()), origin)
+			return
+
+		case ir.OpIf:
+			b.branch(id, params, held, origin, insts, at)
+			return
+
+		default:
+			held = append(held, inst)
+		}
+	}
+
+	b.put(id, params, held, tail(), origin)
+}
+
+// branch splits a run at an "if" into the two arms and the block they meet at.
+//
+// The counts say where each piece is: the arm taken when the test holds is the instructions
+// the "if" says to skip, the other reaches to where the jump closing the first one lands, and
+// what is left is where both arrive. Those counts are read here and nowhere after — what comes
+// out of this names blocks.
+func (b *blocking) branch(id ir.BlockID, params int, held []ir.Instruction, origin ir.Origin, insts []ir.Instruction, at int) {
+	inst := insts[at]
+	otherwise := at + 1 + int(byteutil.ToUint64(inst.GetRight().Bytes()))
+
+	// The arm taken when the test holds ends by jumping over the other one, and that jump is
+	// what says where the two meet.
+	meeting := len(insts)
+	if jump := otherwise - 1; jump >= 0 && jump < len(insts) && insts[jump].GetOpCode() == ir.OpJump {
+		meeting = min(jump+1+int(byteutil.ToUint64(insts[jump].GetLeft().Bytes())), len(insts))
+	}
+
+	// The block both arms arrive at is named before either of them is read, which is the whole
+	// reason a block is reserved apart from being filled.
+	meet := b.reserve()
+	whenTrue := b.arm(insts[at+1:otherwise], meet)
+	whenFalse := b.arm(insts[min(otherwise, meeting):meeting], meet)
+	b.run(meet, insts[meeting:], 1, func() ir.Terminator { return ir.Ends(ir.Nothing()) })
+
+	b.put(id, params, held, ir.Chooses(inst.GetLeft(), ir.To(whenTrue), ir.To(whenFalse)), origin)
+}
+
+// arm turns one side of a branch into a block that hands its value to the block the two meet
+// at.
+//
+// What it answers with is its own closing return — the one naming the "if" rather than a
+// scope, which used to mean "the value of this arm". It is taken off the end rather than
+// searched for, because a branch written inside this one has returns of its own and they
+// belong to it.
+//
+// Both arms answering with one value is what makes an "if" an expression. Saying it here, as a
+// value handed over, is what turns that from a convention two consumers each had to keep into
+// something written down.
+func (b *blocking) arm(insts []ir.Instruction, meet ir.BlockID) ir.BlockID {
+	answer := ir.Nothing()
+
+	if len(insts) > 0 && insts[len(insts)-1].GetOpCode() == ir.OpJump {
+		insts = insts[:len(insts)-1]
+	}
+	if len(insts) > 0 && insts[len(insts)-1].GetOpCode() == ir.OpReturn {
+		answer = insts[len(insts)-1].GetRight()
+		insts = insts[:len(insts)-1]
+	}
+
+	id := b.reserve()
+	b.run(id, insts, 0, func() ir.Terminator { return ir.Goes(meet, answer) })
+	return id
+}
+
+// feedsRead answers how many positions a body addresses. A scope written inside it reads its
+// own vector, so its feeds say nothing about this one.
+func feedsRead(insts []ir.Instruction) int {
+	highest := -1
+	for at := 0; at < len(insts); at++ {
+		inst := insts[at]
+		if inst.GetOpCode() == ir.OpDefer {
+			at += int(byteutil.ToUint64(inst.GetRight().Bytes()))
+			continue
+		}
+		if inst.GetOpCode() != ir.OpGetFeed {
+			continue
+		}
+		if read := int(byteutil.ToUint64(inst.GetLeft().Bytes())); read > highest {
+			highest = read
+		}
+	}
+	return highest + 1
+}

--- a/emitter/blocks_test.go
+++ b/emitter/blocks_test.go
@@ -1,0 +1,151 @@
+package emitter
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// structure names the opcodes that do not survive the crossing: each of them said where
+// control goes or how far something reached, which is what a block and a terminator say now.
+var structure = map[byte]bool{
+	ir.OpDefer:      true,
+	ir.OpBeginScope: true,
+	ir.OpIf:         true,
+	ir.OpJump:       true,
+	ir.OpReturn:     true,
+}
+
+// The blocks describe the same program: every instruction that computes a value is in exactly
+// one of them, and nothing else is.
+//
+// This is what makes the block form trustworthy while both forms exist. A derivation that
+// quietly dropped an instruction, or kept one twice, would still produce blocks that look
+// well-formed — and the consumer that noticed would be a contract answering the wrong thing.
+func TestBlocksHoldEveryInstructionThatComputesAValue(t *testing.T) {
+	const source = `shape Point { x, y };
+ident p = Point{10, 20};
+ident area = defer { ident q = feed(0) as Point; q.x * q.y; };
+ident t = [1, 2, 3];
+printb head t 2;
+ident answer = defer { if feed(0) bigger 0 { area(p) + 1; } else { 0; }; };
+printd answer(1);`
+
+	insts := compile(t, source).Instructions
+
+	wanted := make(map[string]int)
+	for _, inst := range insts {
+		if !structure[inst.GetOpCode()] {
+			wanted[byteutil.ToHex(inst.GetLabel())]++
+		}
+	}
+
+	found := make(map[string]int)
+	for _, block := range BlocksOf(insts) {
+		for _, inst := range block.Insts {
+			if structure[inst.GetOpCode()] {
+				t.Errorf("block %d holds %s, which is structure", block.ID, ir.ResolveOpCode(inst.GetOpCode()))
+			}
+			found[byteutil.ToHex(inst.GetLabel())]++
+		}
+	}
+
+	for label, times := range wanted {
+		if found[label] != times {
+			t.Errorf("the label %s is in the list %d times and in the blocks %d", label, times, found[label])
+		}
+	}
+	for label := range found {
+		if wanted[label] == 0 {
+			t.Errorf("the blocks hold %s, which the list does not", label)
+		}
+	}
+}
+
+// Every block a terminator names exists, and each kind of ending names as many blocks as it
+// chooses between: a return names none, going names one, choosing names two.
+func TestEveryTerminatorNamesBlocksThatExist(t *testing.T) {
+	const source = `ident sign = defer {
+  if feed(0) bigger 0 { 1; } else { if feed(0) smaller 0 { 2; } else { 0; }; };
+};
+printd sign(5);`
+
+	blocks := BlocksOf(compile(t, source).Instructions)
+
+	wanted := map[ir.TermKind]int{ir.Ret: 0, ir.Br: 1, ir.BrIf: 2}
+	for _, block := range blocks {
+		term := block.Term
+		if got := len(term.Targets); got != wanted[term.Kind] {
+			t.Errorf("block %d ends naming %d blocks, want %d", block.ID, got, wanted[term.Kind])
+		}
+		for _, target := range term.Targets {
+			if int(target.Block) < 0 || int(target.Block) >= len(blocks) {
+				t.Errorf("block %d goes to block %d, and there are %d", block.ID, target.Block, len(blocks))
+			}
+		}
+	}
+}
+
+// A branch becomes four blocks — the run before it, an arm each, and the one they meet at —
+// and both arms hand their value to the same block. That is what makes an "if" an expression,
+// said as structure rather than as a place two consumers agree on.
+func TestBothArmsHandTheirValueToTheSameBlock(t *testing.T) {
+	const source = `ident answer = defer { if feed(0) bigger 0 { 10; } else { 20; }; };`
+
+	blocks := BlocksOf(compile(t, source).Instructions)
+
+	var chose *ir.Block
+	for at := range blocks {
+		if blocks[at].Term.Kind == ir.BrIf {
+			chose = &blocks[at]
+		}
+	}
+	if chose == nil {
+		t.Fatal("no block chooses, and the program has an if")
+	}
+
+	arms := chose.Term.Targets
+	meetings := make([]ir.BlockID, 0, 2)
+	for _, arm := range arms {
+		term := blocks[arm.Block].Term
+		if term.Kind != ir.Br {
+			t.Fatalf("an arm ends with %v, want it going to where they meet", term.Kind)
+		}
+		if len(term.Targets[0].Args) != 1 {
+			t.Errorf("an arm hands over %d values, want the one it computed", len(term.Targets[0].Args))
+		}
+		meetings = append(meetings, term.Targets[0].Block)
+	}
+
+	if meetings[0] != meetings[1] {
+		t.Errorf("the arms meet at %d and %d, want one block", meetings[0], meetings[1])
+	}
+	if got := blocks[meetings[0]].Params; got != 1 {
+		t.Errorf("the block they meet at takes %d values, want the one each arm hands it", got)
+	}
+}
+
+// A scope is a block, and how many values it takes is what its body reads: the highest
+// position it feeds, plus one. A scope written inside it reads its own vector, so its feeds
+// say nothing about this one.
+func TestAScopeBlockTakesWhatItsBodyReads(t *testing.T) {
+	const source = `ident two = defer { feed(0) + feed(1); };
+ident none = defer { 7; };
+ident outer = defer { ident inner = defer { feed(0) + feed(1) + feed(2); }; feed(0); };`
+
+	blocks := BlocksOf(compile(t, source).Instructions)
+
+	found := make(map[int]int)
+	for _, block := range blocks {
+		found[block.Params]++
+	}
+
+	// two takes 2, none takes 0, inner takes 3, outer takes 1 — and the top of the program
+	// takes nothing.
+	for _, params := range []int{2, 3, 1} {
+		if found[params] == 0 {
+			t.Errorf("no block takes %d values, and a scope in the source reads that many", params)
+		}
+	}
+}

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -533,6 +533,7 @@ func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
 
 	return ir.Program{
 		Instructions: insts,
+		Blocks:       BlocksOf(insts),
 		Expressions:  exprs,
 		Warnings:     warnings,
 	}, nil

--- a/wire/ir/block.go
+++ b/wire/ir/block.go
@@ -1,0 +1,92 @@
+package ir
+
+// A BlockID names a block. It is a number and not a position: the whole point of a block is
+// that where it sits in a list says nothing about it.
+type BlockID int
+
+// A Block is a run of instructions with one way in and one way out.
+//
+// It is what the instruction list does not say. Today a scope is found by reading a length off
+// OpDefer and slicing, and a branch by reading a count off OpIf and adding — so the structure
+// of a program lives in the order of the list and in arithmetic over indices, and every
+// consumer works it out again, each in its own way. That is not a theoretical cost: the
+// builder found scopes by counting only at the top of the list, so a scope written inside
+// another escaped it and was written as if it were straight-line code.
+//
+// A block says it instead. Control arrives at the first instruction and leaves at the
+// terminator, and nowhere else — which is what makes every instruction in it movable, and what
+// lets a jump name where it goes rather than count how far.
+type Block struct {
+	ID BlockID
+	// Params is how many values arrive with control. A scope's are the values applied to it;
+	// a block that two arms of a branch meet at takes the one value each of them computed.
+	Params int
+	Insts  []Instruction
+	Term   Terminator
+	Origin Origin
+}
+
+// A TermKind is how a block ends. There are three, and there is no fourth: a block either
+// answers, goes somewhere, or chooses between two somewheres.
+type TermKind byte
+
+const (
+	// Ret ends the block and answers with Value. For a scope's last block that is the scope's
+	// answer.
+	Ret TermKind = iota
+	// Br goes to the one block in Targets.
+	Br
+	// BrIf goes to the first block in Targets when Cond is not the neutral tape, and to the
+	// second when it is.
+	BrIf
+)
+
+// A Terminator is how a block ends, and the only thing in the IR that decides where control
+// goes.
+//
+// Keeping it out of the instructions is the point. An instruction computes a value from its
+// operands and does nothing else, so a consumer may hold it back, move it next to whoever
+// takes it, or drop it when nobody does — none of which is safe for something that can send
+// control somewhere. The builder already learned this the hard way and has a list of opcodes
+// it refuses to move across; with a terminator there is nothing to list.
+type Terminator struct {
+	Kind TermKind
+	// Cond is what BrIf chooses on.
+	Cond Operand
+	// Value is what Ret answers with.
+	Value Operand
+	// Targets is where control goes: one block for Br, two for BrIf, none for Ret.
+	Targets []Target
+}
+
+// A Target is a block and the values handed to its parameters.
+//
+// The arms of a branch meet by each handing its value to the block they meet at, rather than
+// by agreeing on a place to leave it. Off a chain that place was a name in a map; on one it
+// was a position on the stack. Neither is in the IR, so neither could be checked — and a
+// consumer that got it wrong got it wrong quietly.
+type Target struct {
+	Block BlockID
+	Args  []Operand
+}
+
+// Ends answers a terminator that ends a block with a value.
+func Ends(value Operand) Terminator {
+	return Terminator{Kind: Ret, Value: value}
+}
+
+// Goes answers a terminator that hands control, and values, to one block.
+func Goes(to BlockID, args ...Operand) Terminator {
+	return Terminator{Kind: Br, Targets: []Target{{Block: to, Args: args}}}
+}
+
+// Chooses answers a terminator that goes one way when the condition holds and the other when
+// it does not. Both arms are named here, so neither is "the instructions that follow".
+func Chooses(cond Operand, whenTrue, whenFalse Target) Terminator {
+	return Terminator{Kind: BrIf, Cond: cond, Targets: []Target{whenTrue, whenFalse}}
+}
+
+// To answers a target: a block, and what is handed to its parameters.
+func To(block BlockID, args ...Operand) Target {
+	return Target{Block: block, Args: args}
+}

--- a/wire/ir/operand.go
+++ b/wire/ir/operand.go
@@ -60,6 +60,11 @@ const (
 	// which moving instructions becomes safe.
 	KindTarget
 
+	// Block names a block of the program: the scope a name was bound to. A Target says where
+	// control goes; a Block says which piece of the program is meant, and control does not
+	// move because of it.
+	KindBlock
+
 	// Text is bytes written for a person to read, and never a value. The message of an
 	// assertion is the only one so far. It exists so that nothing tries to do arithmetic on
 	// a sentence, and so that a tape width has no say over how long the sentence may be.
@@ -123,6 +128,13 @@ func TargetAt(n uint64) Operand { return Operand{KindTarget, byteutil.FromUint64
 // so far.
 func TextOf(text string) Operand { return Operand{KindText, []byte(text)} }
 
+// BlockOf answers an operand naming a block of the program: the scope a name was bound to, so
+// that binding a scope is an ordinary instruction taking an ordinary operand.
+func BlockOf(id BlockID) Operand { return Operand{KindBlock, byteutil.FromUint64(uint64(id))} }
+
+// Block answers which block this operand names.
+func (o Operand) Block() BlockID { return BlockID(byteutil.ToUint64(o.bytes)) }
+
 // Nothing is the operand of an instruction that only points at one thing, or at none.
 func Nothing() Operand { return Operand{KindEmpty, nil} }
 
@@ -137,6 +149,8 @@ func (k Kind) String() string {
 		return "const"
 	case KindName:
 		return "name"
+	case KindBlock:
+		return "block"
 	case KindTarget:
 		return "target"
 	case KindText:

--- a/wire/ir/program.go
+++ b/wire/ir/program.go
@@ -14,10 +14,18 @@ type Expression struct {
 	Label []byte
 }
 
-// Program is what a source file compiled to: the instruction stream, where each top-level
-// expression sits inside it, and anything worth saying that did not stop the compilation.
+// Program is what a source file compiled to: the instruction stream, the same program as
+// blocks, where each top-level expression sits inside the stream, and anything worth saying
+// that did not stop the compilation.
+//
+// The two forms describe the same program, and both are here while its consumers cross from
+// one to the other. The stream says structure by counting — how many instructions an "if"
+// skips, how long a scope's body is — so every consumer works the structure out again, each in
+// its own way, and two ways of counting one thing is two chances to count it differently. The
+// blocks say it once.
 type Program struct {
 	Instructions []Instruction
+	Blocks       []Block
 	Expressions  []Expression
 	Warnings     []diag.Warning
 }


### PR DESCRIPTION
First of the five steps taking the IR from a flat instruction list to blocks with terminators — stage 3 of `rfcs/ir.md`.

Steps 1 and 2 of the agreed cut are merged into this one: a type nobody builds is a type nobody has checked.

## The problem, concretely

This is a real `if`, from `emitter/testdata/wide.ir`:

```
OpBigger   imm 1  imm 0
OpIf       ref …  target 3      <- "skip 3 instructions"
OpSave     imm 1
OpReturn   ref …  ref …
OpJump     target 2             <- "skip 2"
OpSave     imm 0
OpReturn   ref …  ref …
```

`3` and `2` are counts of instructions. Nothing there says "the arm taken when the test holds", or "where the two meet". The structure lives in the **order of the list** and in arithmetic over indices.

So every consumer works it out again — the evaluator by moving a cursor, the builder by slicing and measuring. Two ways of counting one thing is two chances to count it differently, and that is not theoretical: **the builder found scopes by counting only at the top of the list**, so a scope written inside another escaped it and was written as straight-line code (fixed in #118). The evaluator never had that bug, because it counts differently.

## What a block says

```
b0:              v0 = bigger 1, 0
                 brif v0 -> b1, b2
b1:              v1 = 1
                 br b3(v1)
b2:              v2 = 0
                 br b3(v2)
b3(v3):          ...
```

Control arrives at the first instruction and leaves at the terminator and **nowhere else**. A jump names where it goes. A scope is a block.

Five opcodes do not survive the crossing, because each was structure written as an instruction: `OpDefer`, `OpBeginScope`, `OpIf`, `OpJump`, `OpReturn`. What is left inside a block computes values and nothing else — which is what makes every one of them movable, and what the builder's lowering has been relying on without being able to check (it keeps a list of opcodes it refuses to move across; with a terminator there is nothing to list).

**Both arms hand their value to the block they meet at.** That is what makes an `if` an expression, and until now it was a convention two consumers each had to keep — off a chain a name in a map, on a chain a place on the stack. Neither was in the IR, so neither could be checked.

## Nothing consumes them yet

Both forms sit on `Program` while the consumers cross. What keeps that honest is the equivalence test: **every instruction that computes a value is in exactly one block, and nothing else is.** A derivation that quietly dropped one, or kept one twice, would still produce blocks that look well-formed — and the consumer that noticed would be a contract answering the wrong thing.

Four tests: the equivalence above over a program with shapes, a scope, a tape literal, a branch and a call; every terminator naming blocks that exist, with the right number for its kind; both arms of a branch meeting at one block that takes one value; and a scope block taking what its body reads, without counting the feeds of a scope written inside it.

`make check` — 0 issues.

## Next

The builder reads blocks (and `withoutNestedScopes`, `landingsOf`, `armsOf`, `targetOf`, `PickDeferAtCursor` all go), then the evaluator, then the flat list goes. A written retrospective on the trade-off closes the migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)