### PR TITLE
The loader joins blocks

### DIFF
--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -91,14 +91,19 @@ func (b *Builder) PickScopes() []Dispatcher {
 		return dispatchers
 	}
 
-	for _, inst := range b.blocks[TOP_BLOCK].Insts {
-		if inst.GetOpCode() != ir.OpIdent || inst.GetRight().Kind() != ir.KindBlock {
-			continue
+	// Every block the program runs through, and not only the first: a program made of several
+	// files is one run through all of them, so a scope bound in the second is as reachable by
+	// a transaction as one bound in the first.
+	for _, id := range ir.Reaches(b.blocks, TOP_BLOCK) {
+		for _, inst := range b.blocks[id].Insts {
+			if inst.GetOpCode() != ir.OpIdent || inst.GetRight().Kind() != ir.KindBlock {
+				continue
+			}
+			dispatchers = append(dispatchers, Dispatcher{
+				Selector: inst.GetLeft().Bytes(),
+				Entry:    inst.GetRight().Block(),
+			})
 		}
-		dispatchers = append(dispatchers, Dispatcher{
-			Selector: inst.GetLeft().Bytes(),
-			Entry:    inst.GetRight().Block(),
-		})
 	}
 	return dispatchers
 }

--- a/hosting/cli/build.go
+++ b/hosting/cli/build.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/guiferpa/aurora/builder/evm"
 	"github.com/guiferpa/aurora/byteutil"
-	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // BuildReport is what a build produced.
@@ -53,7 +52,7 @@ func (s *Session) Build(ctx context.Context, source, outputPath string) (BuildRe
 
 	// Assembling and writing are two things, and the builder only does the first: it
 	// hands the bytecode back, and where it lands is decided here.
-	bytecode, err := evm.NewBuilder(ir.BlocksOf(program.Instructions), evm.NewBuilderOptions{
+	bytecode, err := evm.NewBuilder(program.Blocks, evm.NewBuilderOptions{
 		TapeSize: s.tapeSize,
 	}).Build()
 	if err != nil {

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -734,3 +734,50 @@ ident odd = defer { if feed(0) equals 0 { 0; } else { even(feed(0) - 1); }; };`
 		})
 	}
 }
+
+// A program of several files reaches the chain whole: a scope bound in one file is as callable
+// by a transaction as one bound in another.
+//
+// Each file is compiled on its own and numbers its blocks from zero, so joining them moves
+// everything the later ones name — and the program runs through all of them in the order their
+// dependencies were found, so a scope bound in any of them is reached the same way.
+func TestAProgramOfSeveralFilesReachesTheChain(t *testing.T) {
+	dir := projectOf(t, map[string]string{
+		"src/geometry.ar": "ident area = defer { feed(0) * feed(1); };",
+		"src/main.ar":     "use geometry as g;\nident twice = defer { g.area(feed(0), 2); };",
+	})
+
+	binary := filepath.Join(dir, "contract.bin")
+	if _, err := newSession(t, sessionOpts{}).Build(t.Context(), filepath.Join(dir, "src", "main.ar"), binary); err != nil {
+		t.Fatalf("building: %v", err)
+	}
+	bytecode, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("reading the binary: %v", err)
+	}
+
+	cfg := &runtime.Config{GasLimit: 10_000_000, Value: big.NewInt(0)}
+	_, address, _, err := runtime.Create(bytecode, cfg)
+	if err != nil {
+		t.Fatalf("deploying: %v", err)
+	}
+
+	// The scope bound in the file that was imported, called straight from a transaction. It
+	// answers to the name the module gave it, which is how a name crossing a file is written.
+	returned, _, err := runtime.Call(address, append(EncodeSelector("geometry.area"), ParseArgs([]string{"6", "7"})...), cfg)
+	if err != nil {
+		t.Fatalf("calling geometry.area: %v", err)
+	}
+	if got := decimalOf(returned); got != "42" {
+		t.Errorf("geometry.area answered %s, want 42", got)
+	}
+
+	// And the scope of the file that imported it, which reaches the other through a call.
+	returned, _, err = runtime.Call(address, append(EncodeSelector("twice"), ParseArgs([]string{"21"})...), cfg)
+	if err != nil {
+		t.Fatalf("calling twice: %v", err)
+	}
+	if got := decimalOf(returned); got != "42" {
+		t.Errorf("twice answered %s, want 42", got)
+	}
+}

--- a/loader/blocks_test.go
+++ b/loader/blocks_test.go
@@ -1,0 +1,65 @@
+package loader
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// Two files become one program. Each is compiled on its own and numbers its blocks from zero,
+// so everything the second one names has to move — and the first stops answering and carries
+// on into it, because a program made of several files is one run through all of them.
+func TestJoiningTwoFilesMovesTheSecondAndChainsTheFirst(t *testing.T) {
+	first := []ir.Block{
+		{ID: 0, Insts: []ir.Instruction{ir.NewInstruction([]byte("a"), ir.OpIdent, ir.NameOf("f"), ir.BlockOf(1))}, Term: ir.Ends(ir.Nothing())},
+		{ID: 1, Term: ir.Ends(ir.Imm(1, 8))},
+	}
+	second := []ir.Block{
+		{ID: 0, Insts: []ir.Instruction{ir.NewInstruction([]byte("b"), ir.OpIdent, ir.NameOf("g"), ir.BlockOf(1))}, Term: ir.Ends(ir.Nothing())},
+		{ID: 1, Term: ir.Ends(ir.Imm(2, 8))},
+	}
+
+	joined := ir.GoesOnTo(append([]ir.Block{}, first...), 0, 2)
+	joined = append(joined, ir.Shifted(second, 2)...)
+
+	if got := joined[0].Term.Kind; got != ir.Br {
+		t.Errorf("the first file ends with %v, want it carrying on into the second", got)
+	}
+	if got := joined[0].Term.Targets[0].Block; got != 2 {
+		t.Errorf("it carries on to block %d, want the second file's first", got)
+	}
+
+	// The scope of the first file still answers: a scope is named, not gone to, so joining
+	// files does not reach it.
+	if got := joined[1].Term.Kind; got != ir.Ret {
+		t.Errorf("the first file's scope ends with %v, want it answering", got)
+	}
+
+	// Everything the second file names moved with it.
+	if got := joined[2].Insts[0].GetRight().Block(); got != 3 {
+		t.Errorf("the second file binds block %d, want the one its scope moved to", got)
+	}
+	if got := joined[3].ID; got != 3 {
+		t.Errorf("the second file's scope is block %d, want 3", got)
+	}
+}
+
+// A scope is reached by being named, never by control arriving at it, so joining files leaves
+// every scope alone — including the last file's, which is the one nothing follows.
+func TestReachesStopsAtScopes(t *testing.T) {
+	blocks := []ir.Block{
+		{ID: 0, Insts: []ir.Instruction{ir.NewInstruction([]byte("a"), ir.OpIdent, ir.NameOf("f"), ir.BlockOf(1))}, Term: ir.Goes(2)},
+		{ID: 1, Term: ir.Ends(ir.Imm(1, 8))},
+		{ID: 2, Term: ir.Ends(ir.Nothing())},
+	}
+
+	reached := ir.Reaches(blocks, 0)
+	for _, id := range reached {
+		if id == 1 {
+			t.Error("the run reached a scope, which is named rather than gone to")
+		}
+	}
+	if len(reached) != 2 {
+		t.Errorf("the run is %d blocks, want the two it goes through", len(reached))
+	}
+}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -90,22 +90,31 @@ func listing(names map[string]bool) string {
 	return strings.Join(offered, ", ")
 }
 
-// A Program is what runs: one stream of instructions, and which module each range of it is.
+// A Program is what runs: one stream of instructions, the same program as blocks, and which
+// module each part of it is.
 //
 // The stream is never sliced. A deferred scope records where its body sits as positions in
 // the instructions being executed, so a call reaching into another module lands on a body
 // that has to be among them — what changes from range to range is where the names go, not
 // which instructions are there.
+//
+// The blocks say the same thing without positions. Each file is compiled on its own and
+// numbers its blocks from zero, so the ones after the first are renumbered as they are joined,
+// and each file's top carries on to the next — which is the order they have to run in, and the
+// order they were found in.
 type Program struct {
 	Instructions []ir.Instruction
+	Blocks       []ir.Block
 	Ranges       []Range
 }
 
-// A Range is one module's instructions inside the stream, and what compiling it had to say.
+// A Range is one module's part of the program, and what compiling it had to say.
 type Range struct {
 	Module   module.ID
 	Filename string
 	From, To uint64
+	// Top is the block this module begins at.
+	Top      ir.BlockID
 	Warnings []diag.Warning
 }
 
@@ -126,6 +135,7 @@ func Load(modules []module.Module, emit Emit) (Program, error) {
 
 	program := Program{
 		Instructions: make([]ir.Instruction, 0),
+		Blocks:       make([]ir.Block, 0),
 		Ranges:       make([]Range, 0, len(modules)),
 	}
 	for _, each := range modules {
@@ -133,13 +143,26 @@ func Load(modules []module.Module, emit Emit) (Program, error) {
 		if err != nil {
 			return Program{}, err
 		}
+
 		from := uint64(len(program.Instructions))
 		program.Instructions = append(program.Instructions, compiled.Instructions...)
+
+		// A file numbers its blocks from zero, so every one after the first moves. And the
+		// file before this one stops answering and carries on into it instead: a program made
+		// of several files is one run through all of them, in the order their dependencies
+		// were found.
+		top := ir.BlockID(len(program.Blocks))
+		if len(program.Ranges) > 0 {
+			program.Blocks = ir.GoesOnTo(program.Blocks, program.Ranges[len(program.Ranges)-1].Top, top)
+		}
+		program.Blocks = append(program.Blocks, ir.Shifted(compiled.Blocks, top)...)
+
 		program.Ranges = append(program.Ranges, Range{
 			Module:   each.ID,
 			Filename: each.Tree.Filename,
 			From:     from,
 			To:       uint64(len(program.Instructions)),
+			Top:      top,
 			Warnings: compiled.Warnings,
 		})
 	}

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -183,3 +183,92 @@ func feedsRead(insts []Instruction) int {
 	}
 	return highest + 1
 }
+
+// Shifted answers the same blocks, numbered from an offset.
+//
+// A file is compiled on its own and numbers its blocks from zero, so putting two files in one
+// program means one of them has to move. Everything that names a block moves with it: where a
+// terminator goes, and the value a binding holds when a name was bound to a scope.
+//
+// It is here rather than in whoever joins them because it is arithmetic over the IR and
+// nothing else. Getting it wrong is quiet — a block that exists, named by mistake.
+func Shifted(blocks []Block, by BlockID) []Block {
+	moved := make([]Block, 0, len(blocks))
+	for _, block := range blocks {
+		block.ID += by
+		block.Insts = shiftedInsts(block.Insts, by)
+		block.Term = shiftedTerm(block.Term, by)
+		moved = append(moved, block)
+	}
+	return moved
+}
+
+func shiftedInsts(insts []Instruction, by BlockID) []Instruction {
+	moved := make([]Instruction, 0, len(insts))
+	for _, inst := range insts {
+		operands := inst.GetOperands()
+		shifted := make([]Operand, 0, len(operands))
+		for _, operand := range operands {
+			if operand.Kind() == KindBlock {
+				operand = BlockOf(operand.Block() + by)
+			}
+			shifted = append(shifted, operand)
+		}
+		moved = append(moved, NewInstructionOver(
+			inst.GetLabel(), inst.GetOpCode(), shifted...).At(inst.GetOrigin()))
+	}
+	return moved
+}
+
+func shiftedTerm(term Terminator, by BlockID) Terminator {
+	targets := make([]Target, 0, len(term.Targets))
+	for _, target := range term.Targets {
+		target.Block += by
+		targets = append(targets, target)
+	}
+	term.Targets = targets
+	return term
+}
+
+// Reaches answers the blocks control can get to from one, itself included.
+//
+// A terminator is the only thing that moves control, so this is the whole answer — and a scope
+// written inside is not in it, because a binding names a block and naming is not going.
+func Reaches(blocks []Block, from BlockID) []BlockID {
+	seen := make(map[BlockID]bool, len(blocks))
+	reached := make([]BlockID, 0, len(blocks))
+
+	var walk func(id BlockID)
+	walk = func(id BlockID) {
+		if seen[id] || int(id) >= len(blocks) {
+			return
+		}
+		seen[id] = true
+		reached = append(reached, id)
+		for _, target := range blocks[id].Term.Targets {
+			walk(target.Block)
+		}
+	}
+	walk(from)
+	return reached
+}
+
+// GoesOnTo answers the same blocks, with everywhere the run from one of them ended now carrying
+// on to another.
+//
+// It is how one file follows another. Each is compiled as a program of its own and ends by
+// answering, and a program made of several runs them in the order their dependencies were
+// found — so every ending in the first is turned into going to the second, and only the last
+// file still answers.
+//
+// A scope is untouched by this: its blocks are not reached from the top of a file, because a
+// binding names a block and naming is not going. So a scope still ends by answering, which is
+// what a call needs it to do.
+func GoesOnTo(blocks []Block, from, next BlockID) []Block {
+	for _, id := range Reaches(blocks, from) {
+		if blocks[id].Term.Kind == Ret {
+			blocks[id].Term = Goes(next)
+		}
+	}
+	return blocks
+}


### PR DESCRIPTION
Third of the five steps. The loader stops being the last place that only knows instructions.

## Joining files

A file is compiled on its own and numbers its blocks from zero, so a program of several files has to move all but the first. **Everything that names a block moves with it**: where a terminator goes, and the value a binding holds when a name was bound to a scope. Getting that wrong is quiet — a block that exists, named by mistake — so it is arithmetic over the IR and lives in `wire/ir` beside the types.

The files are **chained**, not concatenated. Each is a program of its own and ends by answering; joining turns every ending in one into going to the next, and only the last still answers.

A scope is untouched by the chaining, and the reason is the whole point of a block: **a binding names a block and naming is not going**, so a scope is never reached from the top of a file. It still ends by answering, which is what a call needs it to do.

## One derivation less

The build path stops deriving blocks from the merged instruction stream and takes the ones the loader joined. That derivation was the *second* one in the program — the emitter already made blocks for each file — and two derivations of one thing is the shape of problem this whole migration is about.

## What it turned up

Finding the scopes a transaction can reach had to start following the chain rather than looking only at the first block: with the files joined, a scope bound in the second file lives in a block of its own.

Which is how I found that **a contract of several files was never proven on a chain at all**. There were plenty of module tests, and every one of them runs in the evaluator. Now there is one that deploys:

```aurora
# src/geometry.ar
ident area = defer { feed(0) * feed(1); };

# src/main.ar
use geometry as g;
ident twice = defer { g.area(feed(0), 2); };
```

Both are called from a transaction — the imported scope by the name its module gave it, `geometry.area`, and `twice`, which reaches the other through a call across the file boundary.

Writing that test I first called it `area` and got 0. The name a scope answers to across a file is qualified, and I had assumed it was not — the test was wrong, not the code.

`make check` — 0 issues.

## Next

The evaluator runs blocks, then the flat list goes, then the retrospective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)