### PR TITLE
A block written inside an expression is an expression

### DIFF
--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -92,12 +92,16 @@ func TestPickRuntimeCode(t *testing.T) {
 			//nolint:errcheck
 			func(got []byte) error {
 				want := bytes.NewBuffer(make([]byte, 0))
-				// Every block opens with somewhere to arrive at.
-				want.Write([]byte{OpJumpDestiny})
+				// Three blocks: the run up to the block written inside, the block itself,
+				// and where the run carries on with its value in hand.
+				want.Write([]byte{OpJumpDestiny, OpJumpDestiny})
 				WritePush(want, byteutil.FromUint64(4294967295), byteutil.DefaultTapeSize)
 				WritePush(want, byteutil.FromUint64(4294967295), byteutil.DefaultTapeSize)
 				WriteAdd(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
+				want.Write([]byte{OpJumpDestiny})
+				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
+				WritePush(want, nil, byteutil.DefaultTapeSize)
 				WriteAnswer(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
@@ -111,9 +115,13 @@ func TestPickRuntimeCode(t *testing.T) {
 			//nolint:errcheck
 			func(got []byte) error {
 				want := bytes.NewBuffer(make([]byte, 0))
-				// Every block opens with somewhere to arrive at.
-				want.Write([]byte{OpJumpDestiny})
+				// Three blocks: the run up to the block written inside, the block itself,
+				// and where the run carries on with its value in hand.
+				want.Write([]byte{OpJumpDestiny, OpJumpDestiny})
 				WritePush(want, byteutil.TrueTape(byteutil.DefaultTapeSize), byteutil.DefaultTapeSize)
+				want.Write([]byte{OpJumpDestiny})
+				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
+				WritePush(want, nil, byteutil.DefaultTapeSize)
 				WriteAnswer(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
@@ -127,12 +135,16 @@ func TestPickRuntimeCode(t *testing.T) {
 			//nolint:errcheck
 			func(got []byte) error {
 				want := bytes.NewBuffer(make([]byte, 0))
-				// Every block opens with somewhere to arrive at.
-				want.Write([]byte{OpJumpDestiny})
+				// Three blocks: the run up to the block written inside, the block itself,
+				// and where the run carries on with its value in hand.
+				want.Write([]byte{OpJumpDestiny, OpJumpDestiny})
 				WriteGetArg(want, byteutil.FromUint64(1), byteutil.DefaultTapeSize)
 				WriteGetArg(want, byteutil.FromUint64(0), byteutil.DefaultTapeSize)
 				WriteSubtract(want)
 				WriteMask(want, byteutil.DefaultTapeSize)
+				want.Write([]byte{OpJumpDestiny})
+				WriteIdent(want, map[string]int{"a": 2 * MEMORY_SLOT_SIZE}, []byte("a"))
+				WritePush(want, nil, byteutil.DefaultTapeSize)
 				WriteAnswer(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -464,8 +464,16 @@ func (e *Evaluator) EvaluateJump(label []byte, left, right ir.Operand) error {
 	return nil
 }
 
+// EvaluateBeginScope opens a block: a place for names, inside whatever is running.
+//
+// It carries the values applied to the running scope in with it. A block is not applied
+// anything of its own — nothing calls it, control walks into it — so "the vector applied to
+// this scope" is still the enclosing one's, and feed reads it. An arm of an "if" already did
+// this; a block did not, so a block written inside a scope could not read what the scope was
+// called with, and answered as if it had been called with nothing.
 func (e *Evaluator) EvaluateBeginScope(label []byte, left, right ir.Operand) error {
 	next := environ.NewEnviron(environ.NewEnvironOptions{})
+	next.SetArguments(e.environ.GetArguments())
 	e.environ = e.environ.Ahead(next)
 	e.IncrementCursor()
 	return nil

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -781,3 +781,44 @@ func TestAProgramOfSeveralFilesReachesTheChain(t *testing.T) {
 		t.Errorf("twice answered %s, want 42", got)
 	}
 }
+
+// A block written inside an expression is an expression: control goes into it, it computes a
+// value, and control carries on with that value in hand.
+//
+// It used to end the scope instead. A block opens with the same instruction a scope's body
+// does and ends with the same return, so the derivation read the inner return as the outer
+// scope's — and everything written after the block was dropped, quietly, from a contract that
+// still deployed.
+func TestABlockInsideAnExpressionAnswersTheSameOnChainAndOff(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+	}{
+		{
+			name:   "its value is used after it",
+			source: "ident f = defer { ident a = { feed(0) + 1; }; a * 10; };",
+		},
+		{
+			name:   "and the scope answers with something else entirely",
+			source: "ident f = defer { ident a = { feed(0) + 1; }; feed(0) * 2; };",
+		},
+		{
+			name:   "a block whose value is the scope's answer",
+			source: "ident f = defer { { feed(0) + 1; }; };",
+		},
+		{
+			name:   "two of them",
+			source: "ident f = defer { ident a = { feed(0) + 1; }; ident b = { a * 2; }; b + a; };",
+		},
+		{
+			name:   "one inside a branch",
+			source: "ident f = defer { if feed(0) bigger 0 { ident a = { feed(0) + 1; }; a * 3; } else { 0; }; };",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "f", []string{"4"}, 0)
+		})
+	}
+}

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -21,7 +21,11 @@ import "github.com/guiferpa/aurora/byteutil"
 func BlocksOf(insts []Instruction) []Block {
 	b := &blocking{scopes: make(map[string]BlockID)}
 	top := b.reserve()
-	b.run(top, insts, 0, func() Terminator { return Ends(Nothing()) })
+	// The top of a program takes values the way a scope does. Nothing applies any to it — no
+	// transaction names it — so what it reads there is zeros, which is what reading past what
+	// was applied answers. Saying how many it addresses is still what keeps the names it binds
+	// from being kept in the same places.
+	b.run(top, insts, feedsRead(insts), func() Terminator { return Ends(Nothing()) })
 	return b.blocks
 }
 
@@ -69,14 +73,17 @@ func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
 
 		switch inst.GetOpCode() {
 		case OpBeginScope:
-			// The block is the scope. Nothing opens it but arriving at it.
+			// Whatever opened this run was taken off before it got here, so anything that
+			// opens now is a block written inside it.
+			b.inline(id, params, held, origin, insts, at, tail)
+			return
 
 		case OpDefer:
 			// The body is what this instruction says is its own, and it becomes a block.
 			length := int(byteutil.ToUint64(inst.GetRight().Bytes()))
 			body := insts[at+1 : at+1+length]
 			scope := b.reserve()
-			b.run(scope, body, feedsRead(body), func() Terminator { return Ends(Nothing()) })
+			b.run(scope, opened(body), feedsRead(body), func() Terminator { return Ends(Nothing()) })
 			b.scopes[byteutil.ToHex(inst.GetLabel())] = scope
 			at += length
 
@@ -90,7 +97,8 @@ func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
 			held = append(held, inst)
 
 		case OpReturn:
-			// A scope ends here, and answers with what the return names.
+			// Whatever this closes was taken off before it got here, so a return that
+			// arrives is one nothing claimed: the run ends, answering with what it names.
 			b.put(id, params, held, Ends(inst.GetRight()), origin)
 			return
 
@@ -104,6 +112,37 @@ func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
 	}
 
 	b.put(id, params, held, tail(), origin)
+}
+
+// inline splits a run at a block written inside it.
+//
+// A block is an expression: control goes into it, it computes a value, and control carries on
+// with that value in hand. So it is three blocks — the run up to it, the block itself, and
+// where the run carries on — and the value reaches the third the way the arms of a branch
+// reach where they meet: handed over, rather than left in a place both sides agree on.
+//
+// It used to end the scope instead. A block opens with the instruction a scope's body opens
+// with and ends with the same return, so the return of the inner one was read as the outer
+// one's, and everything written after it was dropped from a contract that still deployed. What
+// tells them apart is the name: a return names the thing it closes.
+func (b *blocking) inline(id BlockID, params int, held []Instruction, origin Origin, insts []Instruction, at int, tail ends) {
+	opened := byteutil.ToHex(insts[at].GetLabel())
+
+	closes := len(insts)
+	answer := Nothing()
+	for ahead := at + 1; ahead < len(insts); ahead++ {
+		if insts[ahead].GetOpCode() == OpReturn && byteutil.ToHex(insts[ahead].GetLeft().Bytes()) == opened {
+			closes, answer = ahead, insts[ahead].GetRight()
+			break
+		}
+	}
+
+	rest := b.reserve()
+	inside := b.reserve()
+	b.run(inside, insts[at+1:closes], 0, func() Terminator { return Goes(rest, answer) })
+	b.run(rest, insts[min(closes+1, len(insts)):], 1, tail)
+
+	b.put(id, params, held, Goes(inside), origin)
 }
 
 // branch splits a run at an "if" into the two arms and the block they meet at.
@@ -162,6 +201,16 @@ func (b *blocking) arm(insts []Instruction, meet BlockID) BlockID {
 	id := b.reserve()
 	b.run(id, insts, 0, func() Terminator { return Goes(meet, answer) })
 	return id
+}
+
+// opened answers a scope's body without the instruction that opened it. The block is the
+// scope, so what opened it has nothing left to do — and leaving it in would make the body look
+// like a block written inside itself.
+func opened(body []Instruction) []Instruction {
+	if len(body) > 0 && body[0].GetOpCode() == OpBeginScope {
+		return body[1:]
+	}
+	return body
 }
 
 // feedsRead answers how many positions a body addresses. A scope written inside it reads its


### PR DESCRIPTION
```aurora
ident f = defer { ident a = { feed(0) + 1; }; a * 10; };
```

The program answers **50**. The chain answered **5**. Everything written after the block was dropped from a contract that still deployed.

**I put this in when the blocks landed**, two pull requests ago (#123/#124). It slipped through because the builder's own tests pinned the shape the old backend produced, and the old backend got the same case wrong in the same way — so the expectation agreed with the bug.

## What was wrong

A block opens with the instruction a scope's body opens with and ends with the same return. The derivation read the inner return as the outer scope's and ended the scope there.

What tells them apart is that **a return names the thing it closes**. Rather than compare names, whatever opened a run is now taken off before the run is walked — so anything that opens *inside* it is a block written inside it, and there is nothing to compare.

## What a block is

Three blocks: the run up to it, the block itself, and where the run carries on. The value reaches the third the way the arms of a branch reach where they meet — handed over, rather than left in a place both sides agree on.

Which is to say **a block written inside an expression and an arm of a branch are the same shape**, and now they are the same code.

## A second bug, in the evaluator, older than any of this

Proving the fix turned it up. A block could not read what the scope it was written in was called with:

```aurora
ident f = defer { ident a = { feed(0) + 1; }; a * 10; };
```

answered **10** off the chain, as if `feed(0)` were zero. An arm of an `if` carried the applied values in with it; a block did not.

A block is not applied anything of its own — nothing calls it, control walks into it — so the vector is still the enclosing scope's, and `feed` reads it.

## And a first attempt that was wrong

My first fix claimed the run's own opener by position: "the one at index 0". Then the case *one inside a branch* failed, because **an arm can begin with a block** — so the arm's run claimed the inner block's opener as its own and ended there. That is why the opener is stripped by the caller now instead of recognised by the walk.

## Proof

Five differential cases: a block whose value is used after it, one whose value is thrown away, one that is the scope's whole answer, two in a row, and one inside the arm of a branch.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)