### PR TITLE
A block names what it takes

### DIFF
--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -140,7 +140,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 	entries := make(map[string]Entry, len(dispatchers))
 	for at := range dispatchers {
 		d := &dispatchers[at]
-		entries[string(d.Selector)] = Entry{Reads: b.blocks[d.Entry].Params}
+		entries[string(d.Selector)] = Entry{Reads: len(b.blocks[d.Entry].Params)}
 	}
 
 	offset, err := b.measureScopes(dispatchers, entries)
@@ -157,7 +157,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 
 	for at := range dispatchers {
 		d := &dispatchers[at]
-		internal, err := ScopeInternalAt(referenced+d.Offset, b.blocks[d.Entry].Params, b.tapeSize)
+		internal, err := ScopeInternalAt(referenced+d.Offset, len(b.blocks[d.Entry].Params), b.tapeSize)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -1014,7 +1014,7 @@ type Entry struct {
 func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[string]Entry, answers bool) Scope {
 	params := 0
 	if len(order) > 0 {
-		params = blocks[order[0]].Params
+		params = len(blocks[order[0]].Params)
 	}
 
 	names := make(map[string]int)

--- a/emitter/blocks_test.go
+++ b/emitter/blocks_test.go
@@ -121,8 +121,15 @@ func TestBothArmsHandTheirValueToTheSameBlock(t *testing.T) {
 	if meetings[0] != meetings[1] {
 		t.Errorf("the arms meet at %d and %d, want one block", meetings[0], meetings[1])
 	}
-	if got := blocks[meetings[0]].Params; got != 1 {
-		t.Errorf("the block they meet at takes %d values, want the one each arm hands it", got)
+	meet := blocks[meetings[0]]
+	if len(meet.Params) != 1 {
+		t.Errorf("the block they meet at takes %d values, want the one each arm hands it", len(meet.Params))
+	}
+	// It names the one it takes, and that name is what the value is known as after the branch:
+	// here the scope answers with it, without knowing which arm computed it.
+	if len(meet.Params) == 1 && string(meet.Term.Value.Bytes()) != string(meet.Params[0]) {
+		t.Errorf("it answers with %q and takes %q, want them to be the same value",
+			meet.Term.Value.Bytes(), meet.Params[0])
 	}
 }
 
@@ -138,7 +145,7 @@ ident outer = defer { ident inner = defer { feed(0) + feed(1) + feed(2); }; feed
 
 	found := make(map[int]int)
 	for _, block := range blocks {
-		found[block.Params]++
+		found[len(block.Params)]++
 	}
 
 	// two takes 2, none takes 0, inner takes 3, outer takes 1 — and the top of the program

--- a/wire/ir/block.go
+++ b/wire/ir/block.go
@@ -18,9 +18,17 @@ type BlockID int
 // lets a jump name where it goes rather than count how far.
 type Block struct {
 	ID BlockID
-	// Params is how many values arrive with control. A scope's are the values applied to it;
-	// a block that two arms of a branch meet at takes the one value each of them computed.
-	Params int
+	// Params is what arrives with control, and what each of them is known as inside.
+	//
+	// A scope's are unnamed: they arrive as the vector applied to it, and feed reads a
+	// position of that vector rather than a name. A block reached from somewhere that hands a
+	// value over names the one it takes — where the arms of a branch meet, and where a block
+	// written inside an expression carries on — because whoever reads that value reads it
+	// under the name the value had before the split.
+	//
+	// Naming it is what makes the handover checkable. It used to be an agreement: off a chain
+	// a name in a map, on one a place on the stack, and nothing in the IR either way.
+	Params []Label
 	Insts  []Instruction
 	Term   Terminator
 	Origin Origin

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -25,7 +25,7 @@ func BlocksOf(insts []Instruction) []Block {
 	// transaction names it — so what it reads there is zeros, which is what reading past what
 	// was applied answers. Saying how many it addresses is still what keeps the names it binds
 	// from being kept in the same places.
-	b.run(top, insts, feedsRead(insts), func() Terminator { return Ends(Nothing()) })
+	b.run(top, insts, applied(feedsRead(insts)), func() Terminator { return Ends(Nothing()) })
 	return b.blocks
 }
 
@@ -49,7 +49,7 @@ func (b *blocking) reserve() BlockID {
 }
 
 // put fills a block that was reserved.
-func (b *blocking) put(id BlockID, params int, insts []Instruction, term Terminator, origin Origin) {
+func (b *blocking) put(id BlockID, params []Label, insts []Instruction, term Terminator, origin Origin) {
 	b.blocks[id] = Block{ID: id, Params: params, Insts: insts, Term: term, Origin: origin}
 }
 
@@ -61,7 +61,7 @@ type ends func() Terminator
 // It is one block until something splits it. A branch splits it into the run before, the two
 // arms, and the block they meet at — and each of those is a straight run again, so the same
 // walk handles a branch inside a branch without knowing that it is doing so.
-func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
+func (b *blocking) run(id BlockID, insts []Instruction, params []Label, tail ends) {
 	held := make([]Instruction, 0, len(insts))
 	origin := Origin{}
 	if len(insts) > 0 {
@@ -83,7 +83,7 @@ func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
 			length := int(byteutil.ToUint64(inst.GetRight().Bytes()))
 			body := insts[at+1 : at+1+length]
 			scope := b.reserve()
-			b.run(scope, opened(body), feedsRead(body), func() Terminator { return Ends(Nothing()) })
+			b.run(scope, opened(body), applied(feedsRead(body)), func() Terminator { return Ends(Nothing()) })
 			b.scopes[byteutil.ToHex(inst.GetLabel())] = scope
 			at += length
 
@@ -125,7 +125,7 @@ func (b *blocking) run(id BlockID, insts []Instruction, params int, tail ends) {
 // with and ends with the same return, so the return of the inner one was read as the outer
 // one's, and everything written after it was dropped from a contract that still deployed. What
 // tells them apart is the name: a return names the thing it closes.
-func (b *blocking) inline(id BlockID, params int, held []Instruction, origin Origin, insts []Instruction, at int, tail ends) {
+func (b *blocking) inline(id BlockID, params []Label, held []Instruction, origin Origin, insts []Instruction, at int, tail ends) {
 	opened := byteutil.ToHex(insts[at].GetLabel())
 
 	closes := len(insts)
@@ -139,8 +139,8 @@ func (b *blocking) inline(id BlockID, params int, held []Instruction, origin Ori
 
 	rest := b.reserve()
 	inside := b.reserve()
-	b.run(inside, insts[at+1:closes], 0, func() Terminator { return Goes(rest, answer) })
-	b.run(rest, insts[min(closes+1, len(insts)):], 1, tail)
+	b.run(inside, insts[at+1:closes], nil, func() Terminator { return Goes(rest, answer) })
+	b.run(rest, insts[min(closes+1, len(insts)):], []Label{insts[at].GetLabel()}, tail)
 
 	b.put(id, params, held, Goes(inside), origin)
 }
@@ -151,7 +151,7 @@ func (b *blocking) inline(id BlockID, params int, held []Instruction, origin Ori
 // the "if" says to skip, the other reaches to where the jump closing the first one lands, and
 // what is left is where both arrive. Those counts are read here and nowhere after — what comes
 // out of this names blocks.
-func (b *blocking) branch(id BlockID, params int, held []Instruction, origin Origin, insts []Instruction, at int, tail ends) {
+func (b *blocking) branch(id BlockID, params []Label, held []Instruction, origin Origin, insts []Instruction, at int, tail ends) {
 	inst := insts[at]
 	otherwise := at + 1 + int(byteutil.ToUint64(inst.GetRight().Bytes()))
 
@@ -171,7 +171,7 @@ func (b *blocking) branch(id BlockID, params int, held []Instruction, origin Ori
 	// arms meet at does: the branch is inside that run, not around it. A branch written inside
 	// an arm of another meets, and then carries on to where the outer arms meet — and getting
 	// that wrong ended the outer scope in the middle of it.
-	b.run(meet, insts[meeting:], 1, tail)
+	b.run(meet, insts[meeting:], []Label{inst.GetLabel()}, tail)
 
 	b.put(id, params, held, Chooses(inst.GetLeft(), To(whenTrue), To(whenFalse)), origin)
 }
@@ -199,8 +199,17 @@ func (b *blocking) arm(insts []Instruction, meet BlockID) BlockID {
 	}
 
 	id := b.reserve()
-	b.run(id, insts, 0, func() Terminator { return Goes(meet, answer) })
+	b.run(id, insts, nil, func() Terminator { return Goes(meet, answer) })
 	return id
+}
+
+// applied answers the parameters of a scope: as many as its body reads, and none of them
+// named. They arrive as the vector applied to the scope, and feed reads a position of it.
+func applied(reads int) []Label {
+	if reads == 0 {
+		return nil
+	}
+	return make([]Label, reads)
 }
 
 // opened answers a scope's body without the instruction that opened it. The block is the


### PR DESCRIPTION
A small, last change to the shape of the IR before the evaluator crosses.

A block that is handed a value said only **how many** it took. That is enough for a backend — it puts the value on the stack and finds it there — and not enough for a reader that keeps values under names, which is what the evaluator does and what the IR itself does everywhere else.

So a parameter is a name:

```
b0:              v0 = bigger feed(0), 0
                 brif v0 -> b1, b2
b1:              v1 = 10
                 br b3(v1)
b2:              v2 = 20
                 br b3(v2)
b3(v0):          ret v0
```

The name a meeting block takes is the one the value is known by afterwards — here the scope answers with it, **without knowing which arm computed it**. That is the `if`-is-an-expression property, now written down rather than agreed.

A scope's parameters stay unnamed, and that is not an omission: they arrive as the vector applied to the scope, and `feed` reads a position of it rather than a name.

## Why it matters beyond the evaluator

The handover used to be an agreement kept in two places and written down in neither — off a chain a name in a map, on a chain a place on the stack. An agreement nothing can check is one a consumer can break quietly, which is the failure this migration keeps finding.

The test now checks the meeting block answers with the same value it takes, rather than just counting to one.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)