### PR TITLE
On a chain a print is the value it was given

### DIFF
--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -84,7 +84,10 @@ func produces(op byte) bool {
 	case ir.OpSave, ir.OpGetFeed, ir.OpLoad,
 		ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide, ir.OpExponential,
 		ir.OpEquals, ir.OpDiff, ir.OpBigger, ir.OpSmaller, ir.OpAnd, ir.OpOr,
-		ir.OpJoin, ir.OpField, ir.OpPull, ir.OpPush, ir.OpHead, ir.OpTail:
+		ir.OpJoin, ir.OpField, ir.OpPull, ir.OpPush, ir.OpHead, ir.OpTail,
+		// A print writes nothing on a chain and is worth what it was given, so it leaves a
+		// value like anything else — the same value, under a name of its own.
+		ir.OpPrintBytes, ir.OpPrintChars, ir.OpPrintDecimal:
 		return true
 	default:
 		return false

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -50,10 +50,15 @@ var handled = map[byte]bool{
 
 // offChain is what is meant to be absent from a chain. Saying so is still worth a line: a
 // program whose logs vanish should hear it from the compiler rather than from the silence.
+//
+// A print is ignored rather than refused, and what is left of it is the value it was given. It
+// is an expression like any other and is worth what it showed, so a print written into a
+// working program to see what a value is does not change what that program answers — on a
+// chain it is the identity, and off one it is the identity that also says something.
 var offChain = map[byte]string{
-	ir.OpPrintBytes:   "printb writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
-	ir.OpPrintChars:   "printc writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
-	ir.OpPrintDecimal: "printd writes a log, and a chain has nowhere to put one: it produces no bytecode, by decision",
+	ir.OpPrintBytes:   "printb is ignored in compiled code, by decision: a chain has nowhere to put a log, and the value it was given carries on",
+	ir.OpPrintChars:   "printc is ignored in compiled code, by decision: a chain has nowhere to put a log, and the value it was given carries on",
+	ir.OpPrintDecimal: "printd is ignored in compiled code, by decision: a chain has nowhere to put a log, and the value it was given carries on",
 	ir.OpAssert:       "assert belongs to 'aurora test' and produces no bytecode, by decision",
 }
 

--- a/builder/evm/support_test.go
+++ b/builder/evm/support_test.go
@@ -71,7 +71,7 @@ func TestWarningsNamesWhatDoesNotReachTheBytecode(t *testing.T) {
 			// A log is not a gap: it is absent on purpose, and the wording says so.
 			name:    "a print",
 			opcodes: []byte{ir.OpPrintDecimal},
-			want:    []string{"printd writes a log", "by decision"},
+			want:    []string{"printd is ignored in compiled code", "the value it was given carries on"},
 		},
 		{
 			name:    "an assertion",

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -915,6 +915,23 @@ var comparisons = map[byte][]byte{
 	ir.OpAnd:     {OpIsZero, OpSwap1, OpIsZero, OpOr, OpIsZero},
 }
 
+// passesThrough names the instructions that write nothing and are worth what they were given.
+//
+// A print is one. The log has nowhere to go on a chain — that is a decision, not a gap — but a
+// print is an expression like any other and is worth the value it showed, which is what lets it
+// be written into a program that is already working without changing what that program answers.
+// So on a chain it is the identity: nothing is written, and the value carries on.
+//
+// It carried on by accident before, and only sometimes. A value another instruction worked out
+// was already on the stack, so a print over it happened to leave the right thing there; a value
+// the program wrote down was never put on the stack at all, and the contract underflowed the
+// first time anything read what the print was worth.
+var passesThrough = map[byte]bool{
+	ir.OpPrintBytes:   true,
+	ir.OpPrintChars:   true,
+	ir.OpPrintDecimal: true,
+}
+
 // ordersItsOwn names the instructions that put their own written-down values on the stack.
 //
 // Most take a pair and the pair is enough for WriteImmediates to know where each one goes. An
@@ -1058,7 +1075,7 @@ func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[st
 func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, scope Scope, at int) error {
 	op := inst.GetOpCode()
 
-	if handled[op] && !ordersItsOwn[op] {
+	if (handled[op] || passesThrough[op]) && !ordersItsOwn[op] {
 		if err := WriteImmediates(bs, inst, scope.TapeSize); err != nil {
 			return err
 		}

--- a/hosting/cli/build_test.go
+++ b/hosting/cli/build_test.go
@@ -161,7 +161,7 @@ func TestBuildSaysWhatTheBackendDoesNotCarry(t *testing.T) {
 		{
 			name:   "a log",
 			source: "ident show = defer { printd feed(0); };\n",
-			want:   "printd writes a log",
+			want:   "printd is ignored in compiled code",
 		},
 	}
 

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -822,3 +822,53 @@ func TestABlockInsideAnExpressionAnswersTheSameOnChainAndOff(t *testing.T) {
 		})
 	}
 }
+
+// On a chain a print is the value it was given.
+//
+// The log has nowhere to go — that is a decision, not a gap — but a print is an expression like
+// any other and is worth what it showed, which is what lets one be written into a program that
+// already works without changing what that program answers.
+//
+// It carried on by accident before, and only sometimes: a value another instruction worked out
+// was already on the stack, so a print over it happened to leave the right thing there. A value
+// the program wrote down was never put on the stack at all, and the contract underflowed the
+// first time anything read what the print was worth.
+//
+// The evaluator prints as it goes and the chain does not, so what is compared here is only what
+// the scope answers with — the harness runs both and reads the last thing said.
+func TestAPrintIsTheValueItWasGivenOnChain(t *testing.T) {
+	cases := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "a value the program wrote down",
+			source: "ident f = defer { ident a = printd 5; a + 10; };",
+			want:   "15",
+		},
+		{
+			name:   "a value another instruction worked out",
+			source: "ident f = defer { ident a = printb feed(0); a + 10; };",
+			want:   "13",
+		},
+		{
+			name:   "read as text, which changes nothing about the value",
+			source: "ident f = defer { ident a = printc 26729; a + 1; };",
+			want:   "26730",
+		},
+		{
+			name:   "and one whose value nobody reads still answers for the scope",
+			source: "ident f = defer { printd feed(0); };",
+			want:   "3",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := decimalOf(onChain(t, tc.source, "f", []string{"3"}, 0)); got != tc.want {
+				t.Errorf("the chain answered %s, want %s", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
```aurora
ident f = defer { ident a = printd 5; a + 10; };
```

reverted on chain with a **stack underflow**.

Found in conversation: the maintainer described the print builtins as debug-natured — you drop one into a working program to see a value, and it hands the value back so the program keeps working. That is exactly what the language does and exactly what the backend was not doing.

## What was wrong

A print writes no bytecode. The log has nowhere to go on a chain, and that is a decision, not a gap. But a print is an expression like any other and is **worth what it showed**, and nothing put that value on the stack.

It carried on **by accident, and only sometimes**:

| | |
|---|---|
| `printd feed(0)` | the value was on the stack already, so writing nothing left the right thing there — worked |
| `printd 5` | nothing ever pushed it — underflow the first time anything read what the print was worth |

## What it does now

On a chain a print is the **identity**: the value it was given reaches the stack, and nothing else is written. That is what lets a print be dropped into a program that already works without changing what the program answers, which is the whole reason a print is worth something instead of nothing.

## The warning

It used to say the print *produced no bytecode* — true, and it reads as though the expression vanished along with the log. It now says the print is **ignored in compiled code, by decision**, and that the value it was given carries on.

## While proving it

`10 + printd fn(x, y)` — the form the maintainer had in mind — **does not parse**. A print is an expression, but the grammar does not let one be an operand of arithmetic, so its value is reachable only through a binding. Not changed here; worth knowing, since the debugging use it was designed for is half available.

Four differential cases: a value the program wrote down, a value another instruction worked out, one read as text, and a print whose value nobody reads still answering for the scope.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)