### PR TITLE
The evaluator runs blocks, and aurora run and aurora test use them

### DIFF
--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -68,6 +68,10 @@ type Printer interface {
 }
 
 type Evaluator struct {
+	// blocks is the program as blocks, when it was given as blocks. It is what a call reaches
+	// into: a name bound to a scope holds the number of a block, and running the scope is
+	// running from there.
+	blocks        []ir.Block
 	cursor        uint64
 	end           uint64
 	insts         []ir.Instruction
@@ -114,7 +118,9 @@ func (e *Evaluator) GetAssertErrors() []error {
 // value: the program wrote it down and there is nothing to look up. Everything a position
 // holding a value can be, and the only place that has to know it.
 func (e *Evaluator) value(operand ir.Operand) []byte {
-	if operand.Kind() == ir.KindImm {
+	// An immediate is the value, and a block is the number of a block — both are read off the
+	// operand rather than looked up. Everything else names something another instruction left.
+	if operand.Kind() == ir.KindImm || operand.Kind() == ir.KindBlock {
 		return operand.Bytes()
 	}
 	return e.environ.GetTemp(byteutil.ToHex(operand.Bytes()))
@@ -542,6 +548,35 @@ func (e *Evaluator) EvaluateCallOver(label []byte, operands []ir.Operand) error 
 		return fmt.Errorf("call: %s identifier not found", left)
 	}
 	index := byteutil.ToUint256(val, e.tapeSize).Uint64()
+
+	// A name bound to a scope holds the number of a block, and running the scope is running
+	// from there. It used to hold an index into a list of scopes, each of which recorded where
+	// its body sat as a stretch of the instructions being executed — so a call was a range,
+	// and the value it answered with had to be fetched afterwards from a key both sides agreed
+	// on. A block ends by answering, so the answer comes back from running it.
+	if e.blocks != nil {
+		args := make(map[uint64][]byte, len(operands)-1)
+		for at, operand := range operands[1:] {
+			args[uint64(at)] = e.value(operand)
+		}
+		next := environ.NewEnviron(environ.NewEnvironOptions{})
+		next.SetArguments(args)
+
+		outer := e.environ
+		e.environ = outer.Ahead(next)
+		answered, err := e.RunBlocks(e.blocks, ir.BlockID(index), nil)
+		e.environ = outer
+		if err != nil {
+			return err
+		}
+		if answered == nil {
+			answered = byteutil.FalseTape(e.tapeSize)
+		}
+		e.environ.SetTemp(byteutil.ToHex(label), answered)
+		e.IncrementCursor()
+		return nil
+	}
+
 	blob := home.GetLocalDefer(deferKey(index))
 	if blob == nil {
 		return fmt.Errorf("call: value is not a deferred scope")
@@ -720,6 +755,121 @@ func init() {
 		ir.OpPull: (*Evaluator).EvaluatePullOver,
 		ir.OpCall: (*Evaluator).EvaluateCallOver,
 	}
+}
+
+// RunBlocks runs from a block until it answers, or until control arrives somewhere the caller
+// wanted it to stop.
+//
+// A block is a run of instructions with one way in and one way out, so running one is running
+// its instructions in order and then reading its terminator. Nothing inside can send control
+// anywhere, which is why there is no cursor here: the old walk moved one because an "if"
+// carried how many instructions to skip, and a block names where it goes instead.
+//
+// Stopping is a place rather than a count for the same reason. A program made of several files
+// runs each of them with its own names, and where one ends is where the next begins — which is
+// a block, not an offset.
+func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.BlockID, until func(ir.BlockID) bool) ([]byte, error) {
+	held := e.blocks
+	e.blocks = blocks
+	defer func() { e.blocks = held }()
+
+	id := from
+	for {
+		if int(id) >= len(blocks) {
+			return nil, fmt.Errorf("no block numbered %d", id)
+		}
+		block := blocks[id]
+		for _, inst := range block.Insts {
+			if err := e.ExecuteInstruction(inst); err != nil {
+				return nil, err
+			}
+		}
+
+		term := block.Term
+		if term.Kind == ir.Ret {
+			return e.answered(term.Value), nil
+		}
+
+		target := term.Targets[0]
+		if term.Kind == ir.BrIf && !byteutil.ToBoolean(e.value(term.Cond)) {
+			target = term.Targets[1]
+		}
+		if until != nil && until(target.Block) {
+			return nil, nil
+		}
+		id = e.arrive(blocks[target.Block], target)
+	}
+}
+
+// answered reads what a terminator carries, and answers the neutral tape where there is
+// nothing to read. An empty block still has a value, and so does a scope whose last expression
+// bound a name rather than computing one.
+func (e *Evaluator) answered(operand ir.Operand) []byte {
+	if value := e.value(operand); value != nil {
+		return value
+	}
+	return byteutil.FalseTape(e.tapeSize)
+}
+
+// arrive goes to a block, opening or closing a place for names on the way.
+//
+// Arriving with values closes one. A branch hands the value of the arm that ran to where the
+// arms meet, and a block written inside an expression hands its value to where the run carries
+// on — and in both, what was bound inside is done with. The values are read before the place
+// closes and written down after, which is what lets the name a value is known by afterwards be
+// set in the place that will read it.
+//
+// Arriving with none opens one. That is going into an arm, or into a block written inside an
+// expression: what it binds is its own, so the "x" of an inner block is not the "x" of the one
+// around it. The values applied to the running scope come in with it, because a block is not
+// applied anything of its own and feed still means the enclosing vector.
+//
+// A scope's parameters are unnamed and nothing is written down for them: they arrive as the
+// vector applied to it, which whoever called it put in place.
+func (e *Evaluator) arrive(block ir.Block, target ir.Target) ir.BlockID {
+	if len(target.Args) == 0 {
+		next := environ.NewEnviron(environ.NewEnvironOptions{})
+		next.SetArguments(e.environ.GetArguments())
+		e.environ = e.environ.Ahead(next)
+		return target.Block
+	}
+
+	values := make([][]byte, 0, len(target.Args))
+	for _, arg := range target.Args {
+		values = append(values, e.answered(arg))
+	}
+
+	e.environ = e.environ.GetPrevious()
+	for at, value := range values {
+		if at >= len(block.Params) || len(block.Params[at]) == 0 {
+			continue
+		}
+		e.environ.SetTemp(byteutil.ToHex(block.Params[at]), value)
+	}
+	return target.Block
+}
+
+// EvaluateBlocks runs a program given as blocks, from a block, with names of its own when it
+// is a file of a program made of several.
+//
+// It is the way in for a runner that has a whole program in hand: aurora run and aurora test.
+// Where one file ends is where the next begins, so what stops it is arriving at that block.
+func (e *Evaluator) EvaluateBlocks(blocks []ir.Block, from ir.BlockID, until func(ir.BlockID) bool, id string) (eval.Returns, error) {
+	if id == "" {
+		if _, err := e.RunBlocks(blocks, from, until); err != nil {
+			return nil, err
+		}
+		return e.environ.GetTemps(), nil
+	}
+
+	outer := e.environ
+	e.environ = outer.OpenModule(id)
+	defer func() { e.environ = outer }()
+
+	if _, err := e.RunBlocks(blocks, from, until); err != nil {
+		return nil, err
+	}
+	return e.environ.GetTemps(), nil
 }
 
 // ExecuteInstruction runs one instruction: the opcode names the operation, and the operation

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -28,8 +28,8 @@ func (s *Session) Run(ctx context.Context, source string) error {
 	if err != nil {
 		return err
 	}
-	for _, each := range program.Ranges {
-		if _, err := ev.EvaluateModule(program.Instructions, each.From, each.To, string(each.Module)); err != nil {
+	for at, each := range program.Ranges {
+		if _, err := ev.EvaluateBlocks(program.Blocks, each.Top, program.StopsAt(at), string(each.Module)); err != nil {
 			return err
 		}
 	}

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -164,7 +164,7 @@ func findTests(root string) ([]string, error) {
 // against the test being run, which is what the reader is already looking at.
 func runRanges(ev *evaluator.Evaluator, program loader.Program) error {
 	for i, each := range program.Ranges {
-		_, err := ev.EvaluateModule(program.Instructions, each.From, each.To, string(each.Module))
+		_, err := ev.EvaluateBlocks(program.Blocks, each.Top, program.StopsAt(i), string(each.Module))
 		if err == nil {
 			continue
 		}

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -118,6 +118,19 @@ type Range struct {
 	Warnings []diag.Warning
 }
 
+// StopsAt answers where the file at this range ends: at the top of the one after it.
+//
+// A file carries on into the next, because a program made of several is one run through all of
+// them — so what says a file is over is arriving somewhere, not counting to somewhere. The last
+// one is over when it answers, and nothing stops it.
+func (p Program) StopsAt(at int) func(ir.BlockID) bool {
+	if at+1 >= len(p.Ranges) {
+		return nil
+	}
+	next := p.Ranges[at+1].Top
+	return func(id ir.BlockID) bool { return id == next }
+}
+
 // Emit compiles one tree. It is a port because the loader is a phase like any other and does
 // not know the emitter.
 type Emit func(ast.AST) (ir.Program, error)


### PR DESCRIPTION
The evaluator was the last consumer reading the instruction list. It reads blocks now, and `aurora run` and `aurora test` go through them. The REPL and the playground stay on the old path for the moment, which is the order agreed: get the runners to 100% first, and the REPL after.

## There is no cursor

The old walk moved a counter because an `if` carried how many instructions to skip and a scope's body carried how long it was. A block names where it goes, so running one is running its instructions in order and reading its terminator. **Nothing inside a block can send control anywhere**, which is the whole reason there is nothing to count.

## A call shrinks

| | |
|---|---|
| before | a name held an index into a list of scopes; each recorded its body as a stretch `(from, to)` of the instructions being executed, encoded in a blob with a return key; a call ran the range and then fetched the answer from that key |
| now | a name holds the number of a block; a block ends by answering, so the answer comes back from running it |

Where a file ends is a place rather than a count for the same reason: a program of several files runs each with names of its own, and where one ends is where the next begins — a block.

## Two rules that had to be carried across by hand

Both lived in the instructions rather than in the shapes, so neither came along for free.

**An empty block still has a value.** The old return answered the neutral tape where there was nothing to answer with. `ident empty = { };` in `examples/scopes.ar` is what said so.

**A place for names opens and closes, and which it is can be read off the arrival:**

- arriving **with** values closes one — a branch handing the value of the arm that ran to where the arms meet, a block handing its value to where the run carries on; in both, what was bound inside is done with
- arriving with **none** opens one — going into an arm, or into a block, so the `x` of an inner block is not the `x` of the one around it

`examples/scopes.ar` caught both, one after the other: first `identifier empty not found`, then `conflict between identifiers named x`.

## Proof

The whole suite, and for this one that is the point: **the evaluator is the reference implementation**, so anything that moved would have moved what a program answers. Nothing did — the examples, the module tests, the docs tests and the differential harness all pass unchanged.

`make check` — 0 issues.

## Next

The REPL and the playground, which need one thing this does not: stopping partway, at a `(block, index)` instead of at an offset. Then the flat list leaves `Program` and the five structure opcodes leave the IR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)