### PR TITLE
The REPL and the playground run blocks

### DIFF
--- a/cmd/playground/main.go
+++ b/cmd/playground/main.go
@@ -14,6 +14,8 @@ import (
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/shared/printer"
 	"github.com/guiferpa/aurora/version"
+
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // defaultTapeSize is the width the playground starts at, and it is wider than the language's
@@ -86,8 +88,13 @@ func init() {
 			// One top-level expression at a time, reporting its value before moving on.
 			// Running everything and then walking the temp map put every printed line first and
 			// the values after, in no order at all — a map has none.
-			for _, expr := range program.Expressions {
-				temps, err := ev.EvaluateRange(program.Instructions, uint64(expr.From), uint64(expr.To))
+			for at, expr := range program.Expressions {
+				var until func(ir.Point) bool
+				if at+1 < len(program.Expressions) {
+					next := program.Expressions[at+1].At
+					until = func(point ir.Point) bool { return point == next }
+				}
+				temps, err := ev.EvaluateBlocks(program.Blocks, expr.At, until, "")
 				if err != nil {
 					errorWriter.Write([]byte(err.Error()))
 					return nil

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -514,6 +514,33 @@ func (e *emt) Emit(tree ast.AST) ([]ir.Instruction, error) {
 	return program.Instructions, nil
 }
 
+// placed answers where each top-level expression begins among the blocks.
+//
+// It is the first of the expression's instructions that landed somewhere the program runs
+// through. That last part is the whole of the care needed: an expression that writes a scope
+// has instructions inside the scope's own blocks, and those are reached by being called rather
+// than by the run arriving at them — so the place an expression begins is where its binding
+// landed, not where its body did.
+func placed(exprs []ir.Expression, insts []ir.Instruction, blocks []ir.Block, places map[string]ir.Point) []ir.Expression {
+	runs := make(map[ir.BlockID]bool)
+	for _, id := range ir.Reaches(blocks, 0) {
+		runs[id] = true
+	}
+
+	out := make([]ir.Expression, 0, len(exprs))
+	for _, expr := range exprs {
+		for at := expr.From; at < expr.To && at < len(insts); at++ {
+			point, known := places[byteutil.ToHex(insts[at].GetLabel())]
+			if known && runs[point.Block] {
+				expr.At = point
+				break
+			}
+		}
+		out = append(out, expr)
+	}
+	return out
+}
+
 // EmitProgram compiles ast and records where each top-level expression landed, so a caller
 // can run them one at a time and report each value as it is produced.
 func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
@@ -531,10 +558,12 @@ func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
 	warnings = append(warnings, checkAsserts(tree.Nodes)...)
 	warnings = append(warnings, checkAppliedValues(tree.Nodes)...)
 
+	blocks, places := ir.PlacedBlocksOf(insts)
+
 	return ir.Program{
 		Instructions: insts,
-		Blocks:       ir.BlocksOf(insts),
-		Expressions:  exprs,
+		Blocks:       blocks,
+		Expressions:  placed(exprs, insts, blocks, places),
 		Warnings:     warnings,
 	}, nil
 }

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -564,7 +564,7 @@ func (e *Evaluator) EvaluateCallOver(label []byte, operands []ir.Operand) error 
 
 		outer := e.environ
 		e.environ = outer.Ahead(next)
-		answered, err := e.RunBlocks(e.blocks, ir.BlockID(index), nil)
+		answered, err := e.RunBlocks(e.blocks, ir.Point{Block: ir.BlockID(index)}, nil)
 		e.environ = outer
 		if err != nil {
 			return err
@@ -768,19 +768,25 @@ func init() {
 // Stopping is a place rather than a count for the same reason. A program made of several files
 // runs each of them with its own names, and where one ends is where the next begins — which is
 // a block, not an offset.
-func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.BlockID, until func(ir.BlockID) bool) ([]byte, error) {
+func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.Point, until func(ir.Point) bool) ([]byte, error) {
 	held := e.blocks
 	e.blocks = blocks
 	defer func() { e.blocks = held }()
 
-	id := from
+	id, at := from.Block, from.At
 	for {
 		if int(id) >= len(blocks) {
 			return nil, fmt.Errorf("no block numbered %d", id)
 		}
 		block := blocks[id]
-		for _, inst := range block.Insts {
-			if err := e.ExecuteInstruction(inst); err != nil {
+		for ; at < len(block.Insts); at++ {
+			// Stopping is checked in front of each instruction rather than only on the way
+			// into a block, because where a run is meant to stop is where something else
+			// begins, and that can be halfway through one.
+			if until != nil && until(ir.Point{Block: id, At: at}) {
+				return nil, nil
+			}
+			if err := e.ExecuteInstruction(block.Insts[at]); err != nil {
 				return nil, err
 			}
 		}
@@ -794,10 +800,10 @@ func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.BlockID, until func(ir.
 		if term.Kind == ir.BrIf && !byteutil.ToBoolean(e.value(term.Cond)) {
 			target = term.Targets[1]
 		}
-		if until != nil && until(target.Block) {
+		if until != nil && until(ir.Point{Block: target.Block, At: 0}) {
 			return nil, nil
 		}
-		id = e.arrive(blocks[target.Block], target)
+		id, at = e.arrive(blocks[target.Block], target), 0
 	}
 }
 
@@ -854,7 +860,7 @@ func (e *Evaluator) arrive(block ir.Block, target ir.Target) ir.BlockID {
 //
 // It is the way in for a runner that has a whole program in hand: aurora run and aurora test.
 // Where one file ends is where the next begins, so what stops it is arriving at that block.
-func (e *Evaluator) EvaluateBlocks(blocks []ir.Block, from ir.BlockID, until func(ir.BlockID) bool, id string) (eval.Returns, error) {
+func (e *Evaluator) EvaluateBlocks(blocks []ir.Block, from ir.Point, until func(ir.Point) bool, id string) (eval.Returns, error) {
 	if id == "" {
 		if _, err := e.RunBlocks(blocks, from, until); err != nil {
 			return nil, err

--- a/hosting/cli/run.go
+++ b/hosting/cli/run.go
@@ -4,6 +4,8 @@ import (
 	"context"
 
 	"github.com/guiferpa/aurora/byteutil"
+
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // Run compiles the source and everything it imports, and evaluates it.
@@ -29,7 +31,7 @@ func (s *Session) Run(ctx context.Context, source string) error {
 		return err
 	}
 	for at, each := range program.Ranges {
-		if _, err := ev.EvaluateBlocks(program.Blocks, each.Top, program.StopsAt(at), string(each.Module)); err != nil {
+		if _, err := ev.EvaluateBlocks(program.Blocks, ir.Point{Block: each.Top}, program.StopsAt(at), string(each.Module)); err != nil {
 			return err
 		}
 	}

--- a/hosting/cli/test.go
+++ b/hosting/cli/test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/guiferpa/aurora/evaluator"
 	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/wire/eval"
+
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // TestExtension marks a test file, and marking it is all it does: a test file is a program
@@ -164,7 +166,7 @@ func findTests(root string) ([]string, error) {
 // against the test being run, which is what the reader is already looking at.
 func runRanges(ev *evaluator.Evaluator, program loader.Program) error {
 	for i, each := range program.Ranges {
-		_, err := ev.EvaluateBlocks(program.Blocks, each.Top, program.StopsAt(i), string(each.Module))
+		_, err := ev.EvaluateBlocks(program.Blocks, ir.Point{Block: each.Top}, program.StopsAt(i), string(each.Module))
 		if err == nil {
 			continue
 		}

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -116,7 +116,10 @@ type Session struct {
 	declarations *parser.Declarations
 	// Every line's instructions go into the same buffer, which is what keeps the range a
 	// defer recorded valid when it is called on a later line.
-	insts []ir.Instruction
+	// blocks is the session so far. A session is a file typed slowly, so it only grows: a
+	// scope written on one line is called from a later one, and what the name holds is the
+	// number of its block.
+	blocks []ir.Block
 
 	// resolver finds the files a line imports. Nil is a session that takes no use line,
 	// which is what a REPL with nowhere to read from is.
@@ -232,9 +235,8 @@ func (s *Session) load(tree ast.AST) error {
 		if err != nil {
 			return err
 		}
-		from := uint64(len(s.insts))
-		s.insts = append(s.insts, program.Instructions...)
-		if _, err := s.ev.EvaluateModule(s.insts, from, uint64(len(s.insts)), string(each.ID)); err != nil {
+		top := s.join(program)
+		if _, err := s.ev.EvaluateBlocks(s.blocks, ir.Point{Block: top}, nil, string(each.ID)); err != nil {
 			return err
 		}
 		s.loaded[each.ID] = each
@@ -248,16 +250,45 @@ func (s *Session) load(tree ast.AST) error {
 // evaluate runs the line's expressions one at a time, so a line holding several of them
 // answers where each one happens rather than all of them at the end.
 func (s *Session) evaluate(program ir.Program) {
-	offset := len(s.insts)
-	s.insts = append(s.insts, program.Instructions...)
+	top := s.join(program)
 
-	for _, expr := range program.Expressions {
-		temps, err := s.ev.EvaluateRange(s.insts, uint64(offset+expr.From), uint64(offset+expr.To))
+	for at, expr := range program.Expressions {
+		temps, err := s.ev.EvaluateBlocks(s.blocks, s.at(top, expr), s.stopsAt(top, program, at), "")
 		render(s.out, temps, byteutil.ToHex(expr.Label), err)
 		if err != nil {
 			return
 		}
 	}
+}
+
+// join adds a line's blocks to the session and answers where that line begins.
+//
+// A session is a file typed slowly, and its blocks only ever grow: a scope written on one line
+// is called from a later one, and what the name holds is the number of its block. Each line is
+// compiled on its own and numbers from zero, so every line but the first moves.
+func (s *Session) join(program ir.Program) ir.BlockID {
+	top := ir.BlockID(len(s.blocks))
+	s.blocks = append(s.blocks, ir.Shifted(program.Blocks, top)...)
+	return top
+}
+
+// at answers where an expression of a line begins, among the session's blocks.
+func (s *Session) at(top ir.BlockID, expr ir.Expression) ir.Point {
+	return ir.Point{Block: expr.At.Block + top, At: expr.At.At}
+}
+
+// stopsAt answers where an expression of a line ends: where the next one begins. The last one
+// on a line ends when the line does, and nothing stops it.
+//
+// Running one expression at a time is what puts each value next to the prints that came with
+// it. Running the line whole and reading the values afterwards put every printed line first
+// and the values after, in no order at all.
+func (s *Session) stopsAt(top ir.BlockID, program ir.Program, at int) func(ir.Point) bool {
+	if at+1 >= len(program.Expressions) {
+		return nil
+	}
+	next := s.at(top, program.Expressions[at+1])
+	return func(point ir.Point) bool { return point == next }
 }
 
 // remember records the line before it is evaluated, so a line that fails to compile is still

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -123,12 +123,12 @@ type Range struct {
 // A file carries on into the next, because a program made of several is one run through all of
 // them — so what says a file is over is arriving somewhere, not counting to somewhere. The last
 // one is over when it answers, and nothing stops it.
-func (p Program) StopsAt(at int) func(ir.BlockID) bool {
+func (p Program) StopsAt(at int) func(ir.Point) bool {
 	if at+1 >= len(p.Ranges) {
 		return nil
 	}
-	next := p.Ranges[at+1].Top
-	return func(id ir.BlockID) bool { return id == next }
+	next := ir.Point{Block: p.Ranges[at+1].Top}
+	return func(point ir.Point) bool { return point == next }
 }
 
 // Emit compiles one tree. It is a port because the loader is a phase like any other and does

--- a/wire/ir/block.go
+++ b/wire/ir/block.go
@@ -4,6 +4,16 @@ package ir
 // that where it sits in a list says nothing about it.
 type BlockID int
 
+// A Point is a place in a program: a block, and how far into it.
+//
+// It is what an offset into a list of instructions used to be, and it needs two numbers for
+// the reason the whole of this does: instructions that run one after another are not
+// necessarily written one after another, so where something is cannot be counted to.
+type Point struct {
+	Block BlockID
+	At    int
+}
+
 // A Block is a run of instructions with one way in and one way out.
 //
 // It is what the instruction list does not say. Today a scope is found by reading a length off

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -19,14 +19,25 @@ import "github.com/guiferpa/aurora/byteutil"
 // instruction: OpDefer, OpBeginScope, OpIf, OpJump and OpReturn. What is left inside a block
 // computes values and nothing else.
 func BlocksOf(insts []Instruction) []Block {
-	b := &blocking{scopes: make(map[string]BlockID)}
+	blocks, _ := PlacedBlocksOf(insts)
+	return blocks
+}
+
+// PlacedBlocksOf answers the same blocks, and where each instruction of the list ended up.
+//
+// Whoever compiled the list knows things about it in terms of the list — which stretch of it
+// each top-level expression is, so a runner can stop between them and answer where each one
+// happens rather than all of them at the end. Those stretches have to move with the
+// instructions, and an instruction's place is now two numbers rather than one.
+func PlacedBlocksOf(insts []Instruction) ([]Block, map[string]Point) {
+	b := &blocking{scopes: make(map[string]BlockID), places: make(map[string]Point)}
 	top := b.reserve()
 	// The top of a program takes values the way a scope does. Nothing applies any to it — no
 	// transaction names it — so what it reads there is zeros, which is what reading past what
 	// was applied answers. Saying how many it addresses is still what keeps the names it binds
 	// from being kept in the same places.
 	b.run(top, insts, applied(feedsRead(insts)), func() Terminator { return Ends(Nothing()) })
-	return b.blocks
+	return b.blocks, b.places
 }
 
 // blocking builds blocks as it walks, handing each the number it will be known by.
@@ -39,6 +50,8 @@ type blocking struct {
 	// scopes answers, for the label an OpDefer left, the block its body became — so the
 	// binding that follows it can name a block instead of an instruction that is gone.
 	scopes map[string]BlockID
+	// places answers where each instruction ended up, by the label it leaves its value under.
+	places map[string]Point
 }
 
 // reserve takes the next number and leaves a place for the block to be put in.
@@ -48,9 +61,12 @@ func (b *blocking) reserve() BlockID {
 	return id
 }
 
-// put fills a block that was reserved.
+// put fills a block that was reserved, and writes down where each of its instructions landed.
 func (b *blocking) put(id BlockID, params []Label, insts []Instruction, term Terminator, origin Origin) {
 	b.blocks[id] = Block{ID: id, Params: params, Insts: insts, Term: term, Origin: origin}
+	for at, inst := range insts {
+		b.places[byteutil.ToHex(inst.GetLabel())] = Point{Block: id, At: at}
+	}
 }
 
 // ends says how a run finishes when it reaches the end without a return of its own.

--- a/wire/ir/program.go
+++ b/wire/ir/program.go
@@ -9,8 +9,13 @@ import "github.com/guiferpa/aurora/wire/diag"
 // after the whole program has run cannot give it: the map has no order, and everything
 // written by print along the way has already been emitted.
 type Expression struct {
-	From  int // index of its first instruction
-	To    int // index one past its last instruction
+	From int // index of its first instruction
+	To   int // index one past its last instruction
+	// At is where the expression begins among the blocks. A runner that answers where each
+	// expression happens rather than all of them at the end runs from one of these to the
+	// next, and it is two numbers rather than one because instructions that run one after
+	// another are not written one after another.
+	At    Point
 	Label []byte
 }
 


### PR DESCRIPTION
The last two consumers of the instruction list.

## What they need that the runners did not

Both run **one top-level expression at a time**, so a line holding several answers where each one happens rather than all of them at the end. Running the lot and reading the values afterwards put every printed line first and the values after, in no order at all — that is issue #11, and the tests written for it are still the ones that say this works.

That is the one thing blocks cannot say with a pair of offsets:

```aurora
if 1 bigger 0 { printb 10; } else { printb 20; };
printb 30;
```

Two expressions. The second is **not at some index after the first** — it is where the two arms of the branch meet:

```
b0()  ... brif -> b2, b3
b2()  printb 10   br b1(...)
b3()  printb 20   br b1(...)
b1(...)  printb 30   ret
```

So a place is a block and how far into it, and an expression carries where it begins.

## Which one is where cannot be counted either

An expression that writes a scope has instructions inside the **scope's own blocks**, and those are reached by being called rather than by the run arriving at them. So where such an expression begins is where its **binding** landed, not where its body did:

```
ident sign = defer { feed(0); };   ->  b0@0   (the binding)
printd sign(7);                    ->  b0@1
printb 1;                          ->  b0@3
```

The blocking writes down where every instruction ended up; the emitter takes the first that landed somewhere the program runs through.

## The session

A REPL session is a file typed slowly and its blocks only grow — the same as before, for a better reason. A scope written on one line is called from a later one, and what its name holds is now **the number of a block** rather than a stretch of a list that must not move.

## Proof

The whole suite, unchanged: the REPL tests, the output-order tests from #11, the examples, the module tests, the docs tests and the differential harness.

`make check` — 0 issues, wasm included (the playground is built for js/wasm and would not have compiled otherwise).

## Next

Nothing outside the emitter reads `Program.Instructions` any more. What remains is the emitter writing blocks directly, so the list — and `OpDefer`, `OpBeginScope`, `OpIf`, `OpJump`, `OpReturn` — leave the IR, and the derivation goes with them. Then the retrospective.

🤖 Generated with [Claude Code](https://claude.com/claude-code)