### PR TITLE
What the IR is, and why it is blocks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -123,6 +123,9 @@ source of truth — this table is a pointer, not a copy.
   them. Read it before writing code here.
 - **`.claude/agents/aurora-internals.md`** — how the compiler actually works, verified
   against the code rather than the docs.
+- **[docs/contributing/ir.md](docs/contributing/ir.md)** — what the IR is and what a consumer
+  of it has to do. Read it before touching the emitter, the evaluator or a backend;
+  **[why-blocks.md](docs/contributing/why-blocks.md)** beside it says why it has this shape.
 - **`docs/`** for the end user, **`docs/contributing/`** for contributors (English),
   **`rfcs/`** for proposals and debt (Portuguese).
 - **`docs/roadmap.md`** is the direction: anything the user can perceive gets an entry there.

--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ is, and overrides `tape_size` from the manifest.
 
 Build, tests, coverage, lint and CI: **[docs/development.md](docs/development.md)**. How the
 compiler is put together: **[docs/contributing/architecture.md](docs/contributing/architecture.md)**.
+What the IR is and how to run it, for anyone writing a second backend:
+**[docs/contributing/ir.md](docs/contributing/ir.md)** — and why it is blocks rather than a list:
+**[docs/contributing/why-blocks.md](docs/contributing/why-blocks.md)**.
 
 ```sh
 go run ./cmd/aurora repl   # fast loop, no build needed

--- a/docs/contributing/ir.md
+++ b/docs/contributing/ir.md
@@ -1,0 +1,260 @@
+# The IR, and how a consumer runs it
+
+What the emitter hands over, what each piece of it means, and what a program that reads it has
+to do. If you are writing a second backend — another chain, another machine, an interpreter of
+your own — this is the whole contract. You should not have to read the evaluator to write one.
+
+The types are in `wire/ir`. The evaluator (`evaluator/`) and the EVM backend (`builder/evm/`)
+are two readers of the same thing, and everything below is true of both.
+
+## A program is blocks
+
+```go
+type Program struct {
+    Blocks      []Block
+    Expressions []Expression
+    Warnings    []diag.Warning
+}
+```
+
+`Blocks[0]` is where the program begins. Everything else is reached from there — by control
+arriving at it, or by a name holding it.
+
+```go
+type Block struct {
+    ID     BlockID
+    Params []Label
+    Insts  []Instruction
+    Term   Terminator
+    Origin Origin
+}
+```
+
+**A block has one way in and one way out.** Control arrives at its first instruction and leaves
+at its terminator, and nowhere else. That is not a convention — there is no instruction that
+can send control anywhere, so it cannot be broken.
+
+Two things follow, and both are what a consumer is buying:
+
+- **Every instruction in a block is movable.** A consumer may hold one back and emit it next to
+  whoever takes its value, or drop it when nobody does. The EVM backend does exactly that,
+  because a stack machine wants a value produced immediately before it is consumed.
+- **Nothing has to be counted.** A jump names a block. A scope is a block. There is no length
+  to read and no offset to add.
+
+## An instruction computes one value
+
+```go
+type Instruction interface {
+    GetLabel() []byte      // the name the value it computes is known by
+    GetOpCode() byte
+    GetOperands() []Operand
+    GetOrigin() Origin     // where in the source it came from; may be unknown
+}
+```
+
+Three-address code, with the operand count free: a construction of n values — the fields of a
+shape, the items of a tape — is **one instruction with n operands**, not a chain of n. A
+consumer never has to recognise that a run of instructions was one thing.
+
+Every opcode `wire/ir` declares computes a value. There is no opcode for control.
+
+### Operands say what they are
+
+This is the part that most repays reading. The same bytes mean different things, and the kind
+says which:
+
+| kind | what it is |
+|---|---|
+| `KindRef` | the label of a value another instruction in this block left |
+| `KindImm` | the value itself, a tape — the program wrote it down |
+| `KindConst` | a number the operation takes about itself: an index, a width, a count |
+| `KindName` | a name that outlives a block — a binding, a scope being called |
+| `KindBlock` | a block of this program: what a scope is worth |
+| `KindText` | bytes written for a person, never a value — an assertion's message |
+
+The difference between `Imm` and `Const` is the one to get right. Both are numbers written into
+the instruction. An `Imm` is a **value of the program** and obeys the tape width; a `Const` is
+something the operation says about itself and does not. `OpField ref, Const(1), Const(2)` reads
+field 1 of a run of 2 — neither number is a value, and neither is narrowed to a tape.
+
+The difference between `Ref` and `Imm` is what tells a stack machine who puts a value on the
+stack: a `Ref` was put there by whoever produced it, an `Imm` reaches the stack at the
+instruction that takes it.
+
+## A terminator says where control goes
+
+```go
+type Terminator struct {
+    Kind    TermKind   // Ret, Br, BrIf
+    Cond    Operand    // BrIf
+    Value   Operand    // Ret
+    Targets []Target   // Br: one. BrIf: two.
+}
+
+type Target struct {
+    Block BlockID
+    Args  []Operand
+}
+```
+
+There are three kinds and there is no fourth. A block either **answers**, **goes** somewhere,
+or **chooses** between two somewheres.
+
+`BrIf` goes to `Targets[0]` when `Cond` is not the neutral tape, and to `Targets[1]` when it
+is.
+
+### Values are handed over, not left somewhere
+
+A `Target` carries `Args`, and the block it names takes them under the names in its `Params`.
+That is how the arms of a branch meet:
+
+```
+b0:              v0 = bigger feed(0), 0
+                 brif v0 -> b1, b2
+b1:              v1 = 10
+                 br b3(v1)
+b2:              v2 = 20
+                 br b3(v2)
+b3(v0):          ret v0
+```
+
+Both arms hand their value to `b3`, which takes it under the name `v0` — the name the whole
+branch answers by. **This is what makes an `if` an expression**, and it is written down rather
+than agreed: whoever reads the value afterwards reads it under that name, without knowing which
+arm ran.
+
+It used to be an agreement kept in two places and stated in neither — off a chain a name in a
+map, on one a place on the stack — and an agreement nothing can check is one a consumer can
+break quietly.
+
+A block written inside an expression is the same shape: the run up to it, the block itself, and
+where the run carries on, with the value handed to the third.
+
+## What a scope is
+
+A scope is a block, and **what a scope is worth is the number of that block**:
+
+```
+b0()
+    0x30 OpSave  block 1              <- the scope is worth block 1
+    0x31 OpIdent name area  ref 0x30  <- the binding is an ordinary binding
+    0x32 OpCall  name area  imm 7
+b1(_, _)                              <- takes two values, unnamed
+    OpGetFeed const 0
+    OpGetFeed const 1
+    OpMultiply ref ref
+    ret ref
+```
+
+Three things to read off that:
+
+**A scope's parameters are unnamed.** They arrive as the vector applied to it, and `OpGetFeed`
+reads a position of that vector rather than a name. `len(block.Params)` is how many positions
+the body addresses — the highest it feeds, plus one — and a call applying fewer is legal: a
+position nobody filled answers the neutral tape.
+
+**A scope is reached by being named, never by control arriving at it.** No terminator points at
+`b1`. That is what makes reachability from `Blocks[0]` the right way to ask "which blocks does
+this run pass through", and `ir.Reaches` does exactly that.
+
+**The binding is an ordinary instruction.** A scope nobody binds still has a value, which is why
+`defer {};` written on its own is worth something.
+
+## Running one
+
+The whole of it:
+
+```
+arrive at a block
+  hand it the values the target carried, under the names in Params
+  run its instructions in order
+  read its terminator
+    Ret   -> the run answers with that value
+    Br    -> arrive at the one target
+    BrIf  -> arrive at one of the two, on the condition
+```
+
+`evaluator/evaluator.go`'s `RunBlocks` is that loop and little else.
+
+### Where names live
+
+A consumer that keeps values under names — an interpreter — needs one more rule, and it can be
+read off the arrival rather than carried:
+
+- **arriving with values closes a place for names.** A branch handing the value of the arm that
+  ran, a block handing its value on: in both, whatever was bound inside is done with. Read the
+  values first, then close, then write the names down in the place that will read them.
+- **arriving with none opens one.** Going into an arm, or into a block written inside an
+  expression. What it binds is its own, so the `x` of an inner block is not the `x` of the one
+  around it.
+
+The values applied to the running scope come in with an opened place: a block is not applied
+anything of its own — nothing calls it, control walks into it — so `feed` still means the
+enclosing vector.
+
+A consumer that keeps values somewhere else — a stack machine — ignores all of this. The EVM
+backend has no places for names in this sense; it lays out one run of memory per activation.
+
+### A call
+
+`OpCall name, args...` — the first operand names the scope, the rest are the values applied.
+
+Resolve the name to a value; that value is the number of a block. Build somewhere for the
+applied values, run from that block, and what its `Ret` answers with is what the call answers
+with.
+
+A value that names no block is a value with no scope behind it. Block zero is the top of the
+program, which nothing is bound to, so it is not a scope either.
+
+A number equal to a block number **is** that scope, and that is deliberate: an untyped language
+cannot distinguish values that are the same bytes, and does not pretend to. It is the same
+bargain the language already makes for `true` and `1`.
+
+## Where each top-level expression begins
+
+```go
+type Expression struct {
+    At    Point   // Block, and how far into it
+    Label []byte
+}
+```
+
+A runner that wants to answer where each expression happens — rather than all of them at the
+end — runs from one `At` to the next. The REPL and the playground do this, so that a line
+holding several expressions interleaves what it printed with what each one was worth.
+
+It is two numbers rather than one because **an expression is not a stretch of anything**: one
+containing a branch spans four blocks, and the expression after it begins in the block where
+that branch's arms meet.
+
+## What a program of several files is
+
+The loader compiles each file on its own — each numbers its blocks from zero — and joins them:
+every block after the first file moves (`ir.Shifted`), and each file's endings become goings
+into the next (`ir.GoesOnTo`). `Range.Top` is where each file begins.
+
+A scope is untouched by that joining, and the reason is the whole point of a block: **a binding
+names a block, and naming is not going.** So a scope is never reached from the top of a file,
+and still ends by answering, which is what a call needs it to do.
+
+## Writing a consumer
+
+The shortest honest list:
+
+1. Walk `ir.Reaches(blocks, 0)` for the code the program runs through. Anything not in it is a
+   scope, reached by being named.
+2. For each block: hand over the params, run the instructions, read the terminator.
+3. Read operands by `Kind()`. Never guess from the opcode which operand is which — that is how
+   this backend produced a contract that answered 4 where the program answered 7.
+4. For a call, resolve the name to a block number and run it.
+5. If you keep values under names, follow the open/close rule above. If you keep them on a
+   stack, you do not need it.
+
+And one warning worth its own line: **anything you derive rather than read is a second
+description of the same program, and two descriptions drift.** Every silent bug this compiler
+has had came from one consumer counting something a different way from another.
+
+## Why it is not a list
+
+It was, until it was not. That is [why-blocks.md](why-blocks.md).

--- a/docs/contributing/why-blocks.md
+++ b/docs/contributing/why-blocks.md
@@ -1,0 +1,143 @@
+# Why the IR is blocks and not a list
+
+Aurora's IR was a flat list of instructions for most of its life, and is now blocks with
+terminators. This is what each form costs, what the change bought, and what it did not.
+
+It is written down because the choice looks arbitrary from the outside — both forms hold the
+same instructions, and one of them is obviously simpler to build. The reason for the other is
+made of specific bugs, and they are named here.
+
+## What the list was
+
+Structure was written as instructions, and the instructions counted:
+
+```
+ 0  OpDefer         ref 0x3038      target 10        <- my body is the next 10
+ 1  OpBeginScope
+ 2  OpGetFeed       const 0
+ 3  OpBigger        ref 0x3032      imm 0
+ 4  OpIf            ref 0x3033      target 3         <- skip 3 when false
+ 5  OpSave          imm 1
+ 6  OpReturn        ref 0x3034      ref 0x3031       <- the value of this arm
+ 7  OpJump          target 2                         <- skip 2
+ 8  OpSave          imm 0
+ 9  OpReturn        ref 0x3034      ref 0x3030
+10  OpReturn        ref 0x3038      ref 0x3034       <- the value of this scope
+11  OpIdent         name sign       ref 0x303130
+```
+
+Read that and the shape of the program is there — but it is in the **order of the list** and in
+**arithmetic over indices**, and nowhere else. `target 10`, `target 3`, `target 2` are counts.
+The two `OpReturn` at 6 and 9 mean "the value of this arm"; the one at 10 means "the value of
+this scope"; they are the same opcode, told apart by looking at what their first operand names.
+
+## What it cost
+
+Not in the abstract. Each of these happened.
+
+**Every consumer worked the structure out again, in its own way.** The evaluator walked a
+cursor and let each instruction move it. The builder sliced the list to find scopes, added
+counts to find where a jump landed, and measured bytes to turn those into addresses. Two ways
+of counting one thing is two chances to count it differently.
+
+**A scope written inside another was written as straight-line code.** The builder found scopes
+by scanning the top of the list, so a nested one escaped it and its body ran on the way past —
+its return firing in the middle of code that had not asked for it.
+
+```aurora
+ident outer = defer { ident inner = defer { 1; }; 2; };
+```
+
+answered 1 on chain where the program answers 2. It compiled, it deployed, and it said nothing.
+The evaluator never had that bug, because it counted differently.
+
+**Nothing could be reordered.** The order *was* the structure, so any pass that moved or
+inserted an instruction made every count a lie. The EVM backend needs to move instructions —
+a stack machine wants a value produced immediately before it is consumed — so it kept a list of
+opcodes it refused to move across, and the correctness of that list was an assumption.
+
+**Two things that should have been checkable were agreements.** That both arms of a branch
+leave exactly one value, and that whoever reads a branch's value finds it: off a chain that was
+a name in a map, on a chain a place on the stack. Neither was in the IR, so neither could be
+checked, and a consumer that got it wrong got it wrong quietly.
+
+**A block written inside an expression could not be told from a scope's body.** Both open with
+the same instruction and close with the same return. The derivation read the inner return as
+the outer scope's and ended the scope there, dropping everything written after it — again,
+compiling and deploying.
+
+## What blocks cost
+
+They are not free, and the costs are real:
+
+**More types.** `Block`, `Terminator`, `Target`, `Point`, `BlockID`, plus operations over them.
+A list needed none of that.
+
+**Building one is more work than appending to a slice.** Blocks have to be reserved before they
+are filled, because a branch names blocks that have not been walked yet.
+
+**A place is two numbers.** Anything that used to point into the program with one integer now
+needs a block and an offset. That touched the REPL, the playground, and how a module's range is
+recorded.
+
+**Reading one is less immediate.** A list is the program in order, top to bottom. Blocks are a
+graph, and following it means following terminators.
+
+That last one is the honest complaint, and the answer to it is that the list only *looked* like
+the program in order. It stopped being the program in order the moment it held a jump.
+
+## What blocks bought
+
+**The counting is gone, and with it the code that did it.** From `builder/evm` alone:
+`PickDeferAtCursor`, `withoutNestedScopes`, `landingsOf`, `armsOf`, `targetOf`, `PositionsOf`,
+`WriteCode`, `IdentManager` — 800 lines out, 200 in. From the evaluator: the cursor, the
+offsets, the four entry points that took a pair of them, and the machinery a call needed to
+find a scope by index and fetch its answer from an agreed key — 516 lines out, 37 in.
+
+**Every instruction is movable, by construction.** A block has one way in and one way out, so
+nothing inside it moves control. The list of opcodes the lowering refused to cross is down to
+one entry, and that one is there for a different reason: what a call takes has to be put in
+front of it.
+
+**The two agreements are written down.** A target carries the values it hands over, and the
+block it names says what it takes them as. `if` being an expression is structure now.
+
+**A name for a place instead of a distance.** `brif v0 -> b1, b2` cannot be off by one. A count
+can.
+
+**Structure left the IR.** `OpDefer`, `OpBeginScope`, `OpIf`, `OpJump` and `OpReturn` are the
+emitter's own, used on its way to the blocks. Every opcode `wire/ir` declares computes a value,
+which means a consumer has one kind of thing to handle.
+
+## What it did not buy
+
+**It did not make the compiler correct.** Six bugs were found while crossing over, and two of
+them were introduced by the crossing itself — a nested scope losing its structure, and an
+inline block ending its enclosing scope. Both were caught by the differential harness, which is
+the thing actually keeping this honest.
+
+**It did not remove the derivation, only moved it.** The emitter still builds a list and turns
+it into blocks. That derivation is one place, tested against the list it came from, and private
+to the emitter — which is different from every consumer deriving its own, and it is not the
+same as being gone.
+
+**It did not change what a program answers.** Not once, deliberately: every step was proved by
+the same tests passing, and the differential harness compares the chain against the evaluator
+on every feature the language has.
+
+## Would you choose this for a new language?
+
+For Aurora, yes, and the reason is specific rather than general.
+
+Aurora has two consumers of its IR that must agree — an evaluator and a backend that compiles
+to EVM bytecode — and the whole promise is that *the same program answers the same thing on a
+chain and off it*. A form that lets each consumer derive the structure its own way is a form
+that lets that promise break silently, and it did, more than once.
+
+A language with one consumer would feel the cost and not the benefit. A list is fine when
+nobody else has to agree with you about what it means.
+
+## Where to read next
+
+[ir.md](ir.md) is what the IR is now and how to run it, written for whoever wants to build a
+consumer of their own.

--- a/hosting/cli/docs_test.go
+++ b/hosting/cli/docs_test.go
@@ -77,7 +77,14 @@ func documentationFiles(t *testing.T) []string {
 	t.Helper()
 
 	var docs []string
-	for _, root := range []string{repoRoot(t), filepath.Join(repoRoot(t), "docs")} {
+	// The contributing documents too: Aurora written for a contributor is Aurora, and a
+	// snippet that stopped compiling is as wrong there as anywhere else.
+	roots := []string{
+		repoRoot(t),
+		filepath.Join(repoRoot(t), "docs"),
+		filepath.Join(repoRoot(t), "docs", "contributing"),
+	}
+	for _, root := range roots {
 		entries, err := os.ReadDir(root)
 		if err != nil {
 			t.Fatalf("reading %s: %v", root, err)


### PR DESCRIPTION
The two documents that close the migration.

## `docs/contributing/ir.md` — for whoever builds a consumer

Another chain, another machine, an interpreter of their own. **Nobody should have to read the evaluator end to end to write a second backend**, and this is the whole contract:

- what a program is, and what `Blocks[0]` means
- what a block guarantees — one way in, one way out — and the two things that buys: every instruction is movable, and nothing has to be counted
- what each kind of operand means, with the two distinctions that repay reading: `Imm` vs `Const` (a value of the program vs a number the operation says about itself), and `Ref` vs `Imm` (who puts the value on the stack)
- what a terminator decides, and how values are **handed over** between blocks rather than left in a place both sides agree on
- what a scope is worth, why its parameters are unnamed, and why no terminator points at it
- the loop for running one, in nine lines
- the rule for opening and closing a place for names, which can be read off the arrival
- what a call does, and what a number that names no block is
- a five-step list for writing a consumer, ending with the warning this repository earned: *anything you derive rather than read is a second description of the same program, and two descriptions drift*

## `docs/contributing/why-blocks.md` — for whoever asks why

Made of **specific bugs**, not principles. Both of these compiled, deployed, and said nothing:

```aurora
ident outer = defer { ident inner = defer { 1; }; 2; };
```

answered 1 where the program answers 2 — the builder found scopes by scanning the top of the list, so a nested one escaped it and ran on the way past. The evaluator never had that bug, *because it counted differently*.

And a block written inside an expression could not be told from a scope's body — both open with the same instruction and close with the same return — so everything written after it was dropped.

It also says **what blocks cost**, because they are not free: more types, a place that is two numbers instead of one, and a form that is a graph where the old one read top to bottom. That last is the honest complaint, and the answer is that the list only *looked* like the program in order — it stopped being that the moment it held a jump.

And **what it did not buy**: six bugs found while crossing, two of them made by the crossing, all six caught by the differential harness — which is the thing actually keeping any of this honest. The derivation was moved, not removed.

It ends by asking whether you would choose this for a new language, and answering: for Aurora yes, for a language with one consumer no. A list is fine when nobody else has to agree with you about what it means.

## One change that is not documentation

The documentation check now reaches `docs/contributing`. It scanned the repo root and `docs/` only, so a contributor document holding Aurora escaped it — which is how this PR found out. Aurora written for a contributor is Aurora.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)