### PR TITLE
The editor says what a chain would not carry

### DIFF
--- a/cmd/aurorals/main.go
+++ b/cmd/aurorals/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 
+	"github.com/guiferpa/aurora/builder/evm"
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/hosting/lsp/state"
@@ -55,6 +56,7 @@ func main() {
 		Lexer:   lexer.New(),
 		Parser:  parser.New(),
 		Emit:    emitter.New(emitter.NewEmitterOptions{}).EmitProgram,
+		Carries: evm.Warnings,
 		Resolve: resolveModules(documents),
 	})}
 

--- a/cmd/playground/analysis.go
+++ b/cmd/playground/analysis.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"syscall/js"
 
+	"github.com/guiferpa/aurora/builder/evm"
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/hosting/lsp/textdoc"
@@ -75,9 +76,10 @@ func analyses() []js.Func {
 	// One session for the page, the way the language server holds one for an editor: the
 	// phases are built here and the width comes with each document.
 	session := textdoc.NewSession(textdoc.NewSessionOptions{
-		Lexer:  lexer.New(),
-		Parser: parser.New(),
-		Emit:   emitter.New(emitter.NewEmitterOptions{}).EmitProgram,
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
+		Emit:    emitter.New(emitter.NewEmitterOptions{}).EmitProgram,
+		Carries: evm.Warnings,
 	})
 
 	diagnostics := js.FuncOf(func(this js.Value, args []js.Value) any {

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -9,7 +9,7 @@
 | Capability | Method | What you get |
 |---|---|---|
 | **Semantic tokens** | `textDocument/semanticTokens/full` | Coloring for keywords, numbers, text, comments, operators, identifiers, calls, shapes and fields |
-| **Diagnostics** | `textDocument/publishDiagnostics` | Lexer and parser errors underlined where they happen, republished on every change |
+| **Diagnostics** | `textDocument/publishDiagnostics` | Lexer and parser errors underlined where they happen, and warnings: what the compiler has to say short of refusing, and what a chain would not carry — a print, a feature the backend does not write yet. Republished on every change |
 | **Hover** | `textDocument/hover` | The description of the keyword under the cursor, what an identifier was bound to, a shape's fields, or which tape a field reads |
 | **Completion** | `textDocument/completion` | Keywords as snippets, the identifiers and shapes declared in the document, and — right after a `.` — the fields of a shape or what a module offers |
 | **Go to definition** | `textDocument/definition` | Where the name under the cursor was declared, in this file or in the module it came from |

--- a/hosting/lsp/textdoc/session.go
+++ b/hosting/lsp/textdoc/session.go
@@ -4,6 +4,7 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/diag"
 	"github.com/guiferpa/aurora/wire/ir"
 	"github.com/guiferpa/aurora/wire/module"
 )
@@ -20,6 +21,7 @@ type Session struct {
 	parser  parser.Parser
 	resolve Resolve
 	emit    Emit
+	carries Carries
 }
 
 // Emit compiles a tree, which is how the editor hears what the compiler has to say about a
@@ -32,6 +34,17 @@ type Session struct {
 //
 // It is a port for the same reason Resolve is: a host does not put the compiler together.
 type Emit func(ast.AST) (ir.Program, error)
+
+// Carries answers what a backend cannot carry of a compiled program.
+//
+// It is a second port because it is a second question, asked of a different phase. The emitter
+// says what is wrong with a program; a backend says what is missing from the binary it would
+// write — a feature it does not compile yet, and a print, whose log has nowhere to go on a
+// chain.
+//
+// The editor is where that is cheapest to hear. Before this it was only said by "aurora
+// build", which is after the writing is done and often after the deciding is done too.
+type Carries func([]ir.Block) []diag.Warning
 
 // Resolve answers with the modules a document imports, given the use lines it opens with.
 //
@@ -53,8 +66,11 @@ type NewSessionOptions struct {
 	Resolve Resolve
 	// Emit is optional. Without it a document is only checked as far as it parses.
 	Emit Emit
+	// Carries is optional too, and needs Emit: it is asked of what Emit answered. Without it
+	// a document hears nothing about the binary it would compile to.
+	Carries Carries
 }
 
 func NewSession(opts NewSessionOptions) *Session {
-	return &Session{lexer: opts.Lexer, parser: opts.Parser, resolve: opts.Resolve, emit: opts.Emit}
+	return &Session{lexer: opts.Lexer, parser: opts.Parser, resolve: opts.Resolve, emit: opts.Emit, carries: opts.Carries}
 }

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -118,9 +118,16 @@ func (s *Session) Analyze(doc Document) *Analysis {
 	// And what compiling it has to say. The emitter answers with warnings rather than
 	// refusing, so a document that parses can still be worth a word — and the editor is
 	// where that word is cheapest to hear.
+	//
+	// Then what a backend would not carry of it, which is a different question asked of a
+	// different phase: not what is wrong with the program, but what would be missing from the
+	// binary. Both are worth the same underline, and both point at a line.
 	if s.emit != nil {
 		if program, err := s.emit(tree); err == nil {
 			analysis.Warnings = program.Warnings
+			if s.carries != nil {
+				analysis.Warnings = append(analysis.Warnings, s.carries(program.Blocks)...)
+			}
 		}
 	}
 

--- a/hosting/lsp/textdoc/validator_test.go
+++ b/hosting/lsp/textdoc/validator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/guiferpa/aurora/builder/evm"
 	"github.com/guiferpa/aurora/emitter"
 	"github.com/guiferpa/aurora/hosting/lsp"
 	"github.com/guiferpa/aurora/lexer"
@@ -234,4 +235,51 @@ func BenchmarkValidateCodeParseOnly(b *testing.B) {
 
 func BenchmarkValidateCodeWithTheEmitter(b *testing.B) {
 	benchmarkValidate(b, emitter.New(emitter.NewEmitterOptions{}).EmitProgram)
+}
+
+// The editor says what a chain would drop, too.
+//
+// It is a different question from the one the emitter answers — not what is wrong with the
+// program, but what would be missing from the binary — and it was only ever asked by "aurora
+// build", which is after the writing is done and often after the deciding is done too.
+func TestTheEditorSaysWhatABackendWouldNotCarry(t *testing.T) {
+	session := NewSession(NewSessionOptions{
+		Lexer:   lexer.New(),
+		Parser:  parser.New(),
+		Emit:    emitter.New(emitter.NewEmitterOptions{}).EmitProgram,
+		Carries: evm.Warnings,
+	})
+
+	source := "ident double = defer {\n  printd feed(0);\n  feed(0) * 2;\n};\n"
+	diagnostics := session.ValidateCode(Document{Filename: "main.ar", Source: source})
+
+	if len(diagnostics) != 1 {
+		t.Fatalf("expected one diagnostic, got %v", diagnostics)
+	}
+	if got := diagnostics[0].Severity; got != SeverityWarning {
+		t.Errorf("severity is %d, want a warning: the program is right, the binary is smaller", got)
+	}
+	if !strings.Contains(diagnostics[0].Message, "printd is ignored in compiled code") {
+		t.Errorf("message is %q, want it to say the log does not reach the chain", diagnostics[0].Message)
+	}
+	// Line 2 in the source, which the editor counts from zero.
+	if got := diagnostics[0].Range.Start.Line; got != 1 {
+		t.Errorf("it underlines line %d, want the line the print is on", got)
+	}
+}
+
+// Without the port the editor hears nothing about the binary. It is optional for the same
+// reason the emitter's port is: a host that only wants a document checked as far as it parses
+// should not have to carry a backend to get it.
+func TestWithoutTheBackendPortNothingIsSaidAboutTheBinary(t *testing.T) {
+	session := NewSession(NewSessionOptions{
+		Lexer:  lexer.New(),
+		Parser: parser.New(),
+		Emit:   emitter.New(emitter.NewEmitterOptions{}).EmitProgram,
+	})
+
+	source := "ident double = defer {\n  printd feed(0);\n  feed(0) * 2;\n};\n"
+	if diagnostics := session.ValidateCode(Document{Filename: "main.ar", Source: source}); len(diagnostics) != 0 {
+		t.Errorf("said %v without being given a backend to ask", diagnostics)
+	}
 }


### PR DESCRIPTION
```aurora
ident double = defer {
  printd feed(0);
  feed(0) * 2;
};
```

`aurora build` says:

```
main.ar:2:3: warning: printd is ignored in compiled code, by decision: a chain has
nowhere to put a log, and the value it was given carries on
```

The editor said nothing. It does now, on the line the print is on.

## Why it was missing

The language server holds a port to the emitter, and reports what compiling a document has to say. What a **backend** has to say never reached it — so everything about the binary was heard only by whoever ran `aurora build`, which is after the writing is done and often after the deciding is done too.

## Why a second port rather than a wider first one

Because it is a second question, asked of a different phase:

| | |
|---|---|
| the emitter | what is wrong with this program |
| a backend | what would be missing from the binary I would write |

A print is the clearest case: nothing is wrong with the program, and the binary is smaller than it reads. Same for a feature the backend does not compile yet.

It is optional, for the reason the emitter's port is optional — a host that wants a document checked as far as it parses should not have to carry a backend to get it. There is a test for each side of that.

The playground carries both, since it compiles too.

`make check` — 0 issues, wasm included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)