### PR TITLE
A scope reading a name from around it is refused, and the example shows the shape that works

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,13 @@ graph.svg
 # What 'aurora init' writes at the repository root, which is a scratch project rather
 # than part of the compiler. The examples are tracked; these are not.
 /aurora.toml
-/.aurora.deploys.toml
 /src/
+
+# What a deploy writes, wherever it was run from. It records the address and the transaction
+# of the last deploy per profile, which belongs to whoever deployed and not to the project —
+# and a project is not only at the root: examples/project is one, and so is anywhere somebody
+# points the command at.
+.aurora.deploys.toml
 
 # What aurorals writes where an editor happens to open a project.
 lsp.log

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -89,8 +89,29 @@ func WriteIdent(w io.Writer, names map[string]int, ident []byte) (int, error) {
 }
 
 // WriteLoad reads what a name holds.
+//
+// A name lives in the frame of the scope that bound it, so a scope can only read what it bound
+// itself. A name from around it is refused rather than written, because what would be written
+// is a read of this scope's own frame at the place that name has in another one — and the
+// place a name nobody here bound has is the first one, which is either a value applied to this
+// scope or nothing at all.
+//
+//	ident base = 30;
+//	ident show = defer { base * 2; };
+//
+// answered 0 on a chain where the program answers 60, and said nothing about it.
+//
+// What would let it work is a static link: the frame carrying where the scope was written, and
+// a name from outside read from there. That is a design of its own and it is written down in
+// rfcs/if_and_call.md; until it exists, this is a refusal rather than a silence.
 func WriteLoad(w io.Writer, names map[string]int, ident []byte) (int, error) {
-	if err := WriteFrameAddress(w, names[string(ident)]); err != nil {
+	offset, bound := names[string(ident)]
+	if !bound {
+		return 0, fmt.Errorf(
+			"%q is bound outside the scope that reads it, and a scope can only reach what it bound itself: a name lives in the frame of whoever bound it",
+			ident)
+	}
+	if err := WriteFrameAddress(w, offset); err != nil {
 		return 0, err
 	}
 	return w.Write([]byte{OpMemoryLoad})

--- a/examples/project/src/main.ar
+++ b/examples/project/src/main.ar
@@ -19,6 +19,21 @@
 
 use geometry as g;
 
-ident s = g.new_square(30, 20);
+#- Everything the program does is inside a scope, and the last line applies it. That shape is
+#- what makes the file the same program either way it is reached:
+#-
+#-   aurora run          runs the last line, which applies main and prints what it answered
+#-   aurora call main    a transaction names main, and the contract answers the same value
+#-
+#- Nothing is arranged for one and not the other. A scope is what a transaction can reach by
+#- name, and applying it here is an ordinary call — so what the chain answers is what the last
+#- line printed, and there is one thing to read rather than two.
+#-
+#- What it multiplies is bound inside main, and it has to be: a name lives in the frame of the
+#- scope that bound it, so a scope reaches what it bound itself and nothing from around it.
+ident main = defer {
+  ident s = g.new_square(30, 20);
+  g.area(s.width, s.height);
+};
 
-printd g.area(s.width, s.height);
+printd main();

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -920,3 +920,40 @@ func TestEveryExampleDeploys(t *testing.T) {
 		})
 	}
 }
+
+// A scope can only reach what it bound itself, and reading a name from around it is refused
+// rather than written.
+//
+// A name lives in the frame of the scope that bound it. A scope reading one from outside would
+// be reading its own frame at the place that name has in another — and the place a name nobody
+// here bound has is the first one, which is either a value applied to this scope or nothing at
+// all. So
+//
+//	ident base = 30;
+//	ident show = defer { base * 2; };
+//
+// answered 0 on a chain where the program answers 60, and said nothing about it. What would
+// let it work is a static link, which is a design of its own and written down in
+// rfcs/if_and_call.md; until it exists, this is a refusal.
+func TestAScopeReadingANameFromAroundItIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	path := writeAt(t, dir, "contract.ar", "ident base = 30;\nident show = defer { base * 2; };")
+
+	_, err := newSession(t, sessionOpts{}).Build(t.Context(), path, filepath.Join(dir, "c.bin"))
+	if err == nil {
+		t.Fatal("it wrote a contract that reads a frame nobody filled")
+	}
+	if !strings.Contains(err.Error(), "bound outside the scope that reads it") {
+		t.Errorf("it says %q, and never says the name belongs to another scope", err)
+	}
+}
+
+// And the same program with the binding moved inside the scope compiles and answers, which is
+// what the refusal is telling whoever wrote the other one to do.
+func TestAScopeThatBindsWhatItReadsAnswers(t *testing.T) {
+	const source = "ident show = defer { ident base = 30; base * 2; };"
+
+	if got := decimalOf(onChain(t, source, "show", []string{}, 0)); got != "60" {
+		t.Errorf("the chain answered %s, want 60", got)
+	}
+}


### PR DESCRIPTION
```aurora
ident base = 30;
ident show = defer { base * 2; };
```

answered **0** on a chain where the program answers **60**. It compiled, it deployed, and it said nothing.

Found the way these things should be found and never are: the maintainer deployed a contract, called it, got zeros back, and asked why.

## What was happening

A name lives in **the frame of the scope that bound it**. A scope reading one from outside was reading its own frame at the place that name has in another scope — and the place a name nobody here bound has is the first one, which is either a value applied to this scope or nothing at all.

The lookup answered zero for a name it did not know, and **zero is a valid offset**.

## It was written down, and that is the sharp part

`rfcs/if_and_call.md`, under what the frame convention leaves out:

> **Um `defer` que lê nome do escopo onde foi declarado.** […] Nada aqui impede, e nada aqui resolve.

*Nothing preventing it* was the whole problem. The limit was known and the compiler did not know it — so it deployed.

## What it does now

Refuses, and says which mistake it is: the name is bound outside the scope that reads it, and a scope can only reach what it bound itself.

## And the example shows the shape that works

`examples/project/src/main.ar` puts everything inside a scope and applies it on the last line:

```aurora
ident main = defer {
  ident s = g.new_square(30, 20);
  g.area(s.width, s.height);
};

printd main();
```

Which makes the file **the same program either way it is reached**:

| | |
|---|---|
| `aurora run` | runs the last line, applies `main`, prints what it answered |
| `aurora call main` | a transaction names `main`, and the contract answers the same value |

Nothing is arranged for one and not the other — a scope is what a transaction can reach by name, and applying it here is an ordinary call. Both were checked: 600 from the run, 600 from a call against the deployed binary.

It also carries the rule that broke the contract: what it multiplies is bound **inside** `main`, and has to be.

## One more thing, found while restoring a config

`.aurora.deploys.toml` — what a deploy writes, naming a contract's address and its transaction — was ignored only at the repository root. A project is not only there: `examples/project` is one, and so is anywhere the command is pointed at. It is ignored wherever it is written now.

## Not in this PR

A **static link** — the frame carrying where the scope was written, so a name from outside is read from there — is what would let the first program work as written. It is a design of its own, and the RFC has already ruled out the usual alternative (lambda lifting) with a reason: a `defer` is a first-class value, so the places that apply it are not all known.

🤖 Generated with [Claude Code](https://claude.com/claude-code)