### PR TITLE
A manifest can name a value instead of holding it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,11 @@ graph.svg
 /aurora.toml
 /src/
 
+# What a project keeps out of its manifest, wherever the project is. A manifest is tracked and
+# a key is not, which is the whole reason a manifest may name the environment instead of
+# holding it.
+.env
+
 # What a deploy writes, wherever it was run from. It records the address and the transaction
 # of the last deploy per profile, which belongs to whoever deployed and not to the project —
 # and a project is not only at the root: examples/project is one, and so is anywhere somebody

--- a/docs/manifest.md
+++ b/docs/manifest.md
@@ -104,9 +104,44 @@ To **deploy**, you need a **wallet** (to sign the deploy transaction) and an **R
 **Why:**  
 - **`rpc`** and **`privkey`** (wallet key) keep deploy configuration in one place per profile (e.g. main, sepolia) instead of long CLI arguments.
 
-**Security:**  
-- If `aurora.toml` contains `privkey`, do not commit it. Add `aurora.toml` to `.gitignore` for sensitive profiles, or use env vars / a secrets manager for the key value.  
-- Prefer environment-specific values or env vars for `rpc` if the URL contains secrets.
+**Security: name the value instead of holding it.**
+
+A manifest is tracked and a key is not, so a value may be written as a reference to the
+environment and read at load time:
+
+```toml
+[profiles.main]
+  source = "src/main.ar"
+  binary = "bin/main"
+  rpc = "${{ AURORA_RPC }}"
+  privkey = "${{ AURORA_PRIVKEY }}"
+```
+
+Where it is read from, in order:
+
+1. **`.env` beside the manifest**, which is what a project keeps out of what it tracks. It
+   holds `NAME=value` a line at a time; `#` opens a comment, `export` in front is allowed, and
+   a value may be quoted when it means the spaces at its ends. Nothing else is interpreted — a
+   value here is a secret or an address, and both mean their own bytes.
+2. **The environment the command runs in**, when `.env` does not have the name.
+
+That order is what lets a project be cloned and run: the project says what it needs beside
+itself, and a machine that knows better — a build server holding the real key, someone running
+against another chain — still gets to say so for whatever the project did not write down.
+
+**A name nothing sets is refused**, not read as empty. An empty value reaches a deploy as a key
+that is not a key, and the failure that follows says nothing about the manifest that caused it.
+
+The braces are doubled on purpose: `${NAME}` and `$NAME` are left alone, so a manifest that
+passes through a shell is not quietly rewritten by it.
+
+**Only `rpc` and `privkey` are read this way.** A path is a path and a name is a name — neither
+is a thing a project would keep somewhere else — and a reference written anywhere else stays as
+it was written. A comment is not a value either, so a manifest may show the form beside the
+setting it explains without being asked to resolve the example.
+
+`.env` is in the repository's `.gitignore`. If you write a key straight into `aurora.toml`
+instead, do not commit that file.
 
 ---
 

--- a/examples/project/aurora.toml
+++ b/examples/project/aurora.toml
@@ -18,6 +18,14 @@
   [profiles.main]
     source = "src/main.ar"
     binary = "bin/main"
+    # What deploy and call need, and what this file must not hold. A value written as
+    # ${{ NAME }} is read from .env beside this file, or from the environment the command
+    # runs in when .env does not have it — so a manifest can be tracked and a key cannot.
+    #
+    # A name nothing sets is refused rather than read as empty, so these are left commented
+    # out: this project is built and run by the test suite, and it deploys nowhere.
+    # rpc = "${{ AURORA_RPC }}"
+    # privkey = "${{ AURORA_PRIVKEY }}"
 
   # A project holds as many profiles as it has things to build. This one is a
   # second program with a binary of its own.

--- a/shared/manifest/environment.go
+++ b/shared/manifest/environment.go
@@ -1,0 +1,142 @@
+package manifest
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// EnvFilename is where a project keeps what it does not want written down in its manifest.
+const EnvFilename = ".env"
+
+// reference is what a manifest writes where a value comes from the environment.
+//
+// The braces are doubled so that it cannot be mistaken for anything a shell would expand: a
+// manifest is read by Aurora and never by a shell, and a form a shell would touch is a form
+// somebody will one day pipe through one.
+var reference = regexp.MustCompile(`\$\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}`)
+
+// Environment is what a project's values are read from, when the manifest says to read them.
+type Environment struct {
+	// file is what .env held, and it is looked at first.
+	file map[string]string
+}
+
+// LoadEnvironment reads the .env of a project, if it has one. A project without one is not an
+// error: the system's environment is still there, and a manifest that names nothing needs
+// neither.
+func LoadEnvironment(projectRoot string) (Environment, error) {
+	path := filepath.Join(projectRoot, EnvFilename)
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return Environment{}, nil
+	}
+	if err != nil {
+		return Environment{}, fmt.Errorf("open %s: %w", path, err)
+	}
+	defer func() { _ = f.Close() }()
+
+	values := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for line := 1; scanner.Scan(); line++ {
+		name, value, ok := readSetting(scanner.Text())
+		if !ok {
+			continue
+		}
+		if name == "" {
+			return Environment{}, fmt.Errorf("%s:%d: a setting with no name", path, line)
+		}
+		values[name] = value
+	}
+	if err := scanner.Err(); err != nil {
+		return Environment{}, fmt.Errorf("read %s: %w", path, err)
+	}
+	return Environment{file: values}, nil
+}
+
+// readSetting reads one line of a .env: a name, an equals, and the rest. A blank line and a
+// comment are neither a setting nor a mistake, and say so by answering false.
+//
+// The value may be quoted, which is how a value with spaces at either end says it means them.
+// Nothing else is interpreted — no escapes and no expansion — because a value here is a secret
+// or an address, and both are meant to arrive exactly as they were written.
+func readSetting(line string) (name, value string, ok bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", "", false
+	}
+	line = strings.TrimPrefix(line, "export ")
+
+	name, value, found := strings.Cut(line, "=")
+	if !found {
+		return "", "", false
+	}
+	name = strings.TrimSpace(name)
+	value = strings.TrimSpace(value)
+
+	for _, quote := range []string{`"`, `'`} {
+		if len(value) >= 2 && strings.HasPrefix(value, quote) && strings.HasSuffix(value, quote) {
+			value = value[1 : len(value)-1]
+			break
+		}
+	}
+	return name, value, true
+}
+
+// Lookup answers what a name is set to, and where it was found.
+//
+// The project's own .env comes first and the system's environment second. A project says what
+// it needs in a file beside itself, and a machine may say otherwise — a build server holding
+// the real key, a person running against a different chain — so the outer one is the fallback
+// and not the override. It is the order that lets a project be cloned and run.
+func (e Environment) Lookup(name string) (string, bool) {
+	if value, found := e.file[name]; found {
+		return value, true
+	}
+	return os.LookupEnv(name)
+}
+
+// Expand answers the text with every reference to the environment replaced by what it names.
+//
+// A name nothing sets is refused rather than replaced with nothing. An empty value reaches a
+// deploy as a key that is not a key and an address that is not an address, and the failure
+// that follows says nothing about the manifest that caused it — which is the whole reason a
+// manifest may name the environment at all.
+func (e Environment) Expand(where, text string) (string, error) {
+	var missing []string
+
+	expanded := reference.ReplaceAllStringFunc(text, func(match string) string {
+		name := reference.FindStringSubmatch(match)[1]
+		value, found := e.Lookup(name)
+		if !found {
+			missing = append(missing, name)
+			return match
+		}
+		return value
+	})
+
+	if len(missing) > 0 {
+		return "", fmt.Errorf(
+			"%s names %s, and nothing sets %s: put it in %s beside the manifest, or in the environment the command runs in",
+			where, strings.Join(quoted(missing), ", "), plural(len(missing)), EnvFilename)
+	}
+	return expanded, nil
+}
+
+func quoted(names []string) []string {
+	out := make([]string, 0, len(names))
+	for _, name := range names {
+		out = append(out, fmt.Sprintf("%q", name))
+	}
+	return out
+}
+
+func plural(n int) string {
+	if n == 1 {
+		return "it"
+	}
+	return "them"
+}

--- a/shared/manifest/environment_test.go
+++ b/shared/manifest/environment_test.go
@@ -1,0 +1,217 @@
+package manifest
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func projectWith(t *testing.T, files map[string]string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	for name, content := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+			t.Fatalf("writing %s: %v", name, err)
+		}
+	}
+	return dir
+}
+
+// A value the manifest should not hold is named instead, and read from beside it.
+func TestAManifestReadsWhatItNames(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		EnvFilename: "PRIVKEY=abc123\n",
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+    privkey = "${{ PRIVKEY }}"
+`,
+	})
+
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if got := m.Profiles["main"].Privkey; got != "abc123" {
+		t.Errorf("the key is %q, want what .env set", got)
+	}
+}
+
+// The project's own file comes first and the machine's environment second, so a project can be
+// cloned and run — and a machine that knows better still gets to say so, for what the project
+// did not write down.
+func TestTheProjectComesFirstAndTheMachineSecond(t *testing.T) {
+	t.Setenv("RPC", "from-the-machine")
+	t.Setenv("PRIVKEY", "from-the-machine")
+
+	dir := projectWith(t, map[string]string{
+		EnvFilename: "PRIVKEY=from-the-project\n",
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+    rpc = "${{ RPC }}"
+    privkey = "${{ PRIVKEY }}"
+`,
+	})
+
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if got := m.Profiles["main"].Privkey; got != "from-the-project" {
+		t.Errorf("the key is %q, want the project's own", got)
+	}
+	if got := m.Profiles["main"].RPC; got != "from-the-machine" {
+		t.Errorf("the address is %q, want the machine's, since the project does not say", got)
+	}
+}
+
+// A name nothing sets is refused. An empty value reaches a deploy as a key that is not a key,
+// and the failure that follows says nothing about the manifest that caused it.
+func TestANameNothingSetsIsRefused(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+    privkey = "${{ NOBODY_SETS_THIS }}"
+`,
+	})
+
+	_, err := Load(dir)
+	if err == nil {
+		t.Fatal("it loaded a manifest naming something nothing sets")
+	}
+	for _, want := range []string{"NOBODY_SETS_THIS", EnvFilename} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("it says %q, want it to mention %q", err, want)
+		}
+	}
+}
+
+// A project with nothing to hide needs neither file nor environment.
+func TestAManifestThatNamesNothingNeedsNothing(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+`,
+	})
+
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+}
+
+// What a .env holds and what it does not. A value arrives as it was written, because it is a
+// secret or an address and both mean their own bytes.
+func TestWhatAnEnvFileHolds(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		EnvFilename: strings.Join([]string{
+			"# a comment",
+			"",
+			"PLAIN=value",
+			"  SPACED  =  around  ",
+			`QUOTED="  kept  "`,
+			"SINGLE='kept too'",
+			"export EXPORTED=works",
+			"WITH_EQUALS=a=b",
+			"no equals here",
+		}, "\n"),
+	})
+
+	env, err := LoadEnvironment(dir)
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+
+	for name, want := range map[string]string{
+		"PLAIN":       "value",
+		"SPACED":      "around",
+		"QUOTED":      "  kept  ",
+		"SINGLE":      "kept too",
+		"EXPORTED":    "works",
+		"WITH_EQUALS": "a=b",
+	} {
+		if got, found := env.Lookup(name); !found || got != want {
+			t.Errorf("%s is %q (found=%v), want %q", name, got, found, want)
+		}
+	}
+	if _, found := env.Lookup("a comment"); found {
+		t.Error("a comment was read as a setting")
+	}
+}
+
+// A reference is written with doubled braces so that nothing a shell touches looks like one.
+func TestOnlyDoubledBracesAreAReference(t *testing.T) {
+	t.Setenv("NAME", "read")
+	env, err := LoadEnvironment(t.TempDir())
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+
+	got, err := env.Expand("test", `a = "${{ NAME }}" b = "${NAME}" c = "$NAME"`)
+	if err != nil {
+		t.Fatalf("expanding: %v", err)
+	}
+	if want := `a = "read" b = "${NAME}" c = "$NAME"`; got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+// A manifest may show the form in a comment beside the setting it explains, and a comment is
+// not a value: nothing tries to resolve it.
+//
+// It is the reason the reading happens on the values and not on the text. Doing it on the text
+// was shorter, and it asked a manifest to resolve its own example.
+func TestACommentIsNotAValue(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+    # A value written as ${{ AURORA_PRIVKEY }} is read from .env beside this file.
+    # privkey = "${{ AURORA_PRIVKEY }}"
+`,
+	})
+
+	if _, err := Load(dir); err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+}
+
+// And a value that is not one of the two a deploy needs is left alone. A path is a path: it is
+// not a thing a project keeps somewhere else, so it is not read from anywhere else.
+func TestOnlyWhatADeployNeedsIsRead(t *testing.T) {
+	t.Setenv("SOMETHING", "read")
+
+	dir := projectWith(t, map[string]string{
+		Filename: `[project]
+  name = "${{ SOMETHING }}"
+[profiles]
+  [profiles.main]
+    source = "${{ SOMETHING }}"
+`,
+	})
+
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if got := m.Project.Name; got != "${{ SOMETHING }}" {
+		t.Errorf("the project is named %q, want the reference left as it was written", got)
+	}
+	if got := m.Profiles["main"].Source; got != "${{ SOMETHING }}" {
+		t.Errorf("the source is %q, want the reference left as it was written", got)
+	}
+}

--- a/shared/manifest/manifest.go
+++ b/shared/manifest/manifest.go
@@ -98,9 +98,21 @@ type deploysFile struct {
 }
 
 // Load reads and parses the manifest from the given project root directory.
-// Deploy state is read from .aurora.deploys.toml when present; aurora.toml is not modified for deploys.
+//
+// What the manifest says may come from the environment: a value written as ${{ NAME }} is
+// read from the project's .env, or from the environment the command runs in when the file
+// does not have it. That is what lets a key stay out of a manifest a repository tracks.
+//
+// It happens after the manifest is parsed, on the values themselves. Doing it on the text
+// before would have been shorter and would have read a reference written inside a comment,
+// which is not a value — a manifest showing the form in a comment beside a setting would have
+// been asked to resolve the example.
+//
+// Deploy state is read from .aurora.deploys.toml when present; aurora.toml is not modified for
+// deploys.
 func Load(projectRoot string) (*Manifest, error) {
 	path := filepath.Join(projectRoot, Filename)
+
 	var m Manifest
 	md, err := toml.DecodeFile(path, &m)
 	if err != nil {
@@ -112,11 +124,39 @@ func Load(projectRoot string) (*Manifest, error) {
 	if m.Profiles == nil {
 		m.Profiles = make(map[string]Profile)
 	}
+	if err := m.readEnvironment(projectRoot, path); err != nil {
+		return nil, err
+	}
 	m.Deploys = loadDeploysFile(projectRoot)
 	if m.Deploys == nil {
 		m.Deploys = make(map[string]DeployState)
 	}
 	return &m, nil
+}
+
+// readEnvironment replaces every value that names the environment with what it names.
+//
+// The fields are written out rather than walked, because a value that may come from outside is
+// a decision about that value: a path is a path and a name is a name, and neither is a thing a
+// project would keep somewhere else. What is left is what a deploy needs and a manifest should
+// not hold.
+func (m *Manifest) readEnvironment(projectRoot, path string) error {
+	environment, err := LoadEnvironment(projectRoot)
+	if err != nil {
+		return err
+	}
+
+	for name, profile := range m.Profiles {
+		where := fmt.Sprintf("%s: profile %s", path, name)
+		if profile.RPC, err = environment.Expand(where, profile.RPC); err != nil {
+			return err
+		}
+		if profile.Privkey, err = environment.Expand(where, profile.Privkey); err != nil {
+			return err
+		}
+		m.Profiles[name] = profile
+	}
+	return nil
 }
 
 // loadDeploysFile reads .aurora.deploys.toml and returns the deploys map, or nil if the file is missing.


### PR DESCRIPTION
```toml
[profiles.main]
  source = "src/main.ar"
  binary = "bin/main"
  rpc = "${{ AURORA_RPC }}"
  privkey = "${{ AURORA_PRIVKEY }}"
```

Which is what lets a manifest be tracked while a key is not — the thing `docs/manifest.md` has been asking for in prose (*"use env vars / a secrets manager for the key value"*), and the thing that put a private key in a working tree this afternoon.

## Where it reads from, in order

1. **`.env` beside the manifest** — `NAME=value` a line at a time, `#` opens a comment, `export` in front is allowed, and a value may be quoted when it means the spaces at its ends. Nothing else is interpreted: a value here is a secret or an address, and both mean their own bytes.
2. **The environment the command runs in**, when `.env` does not have the name.

**That order is the point.** A project says what it needs beside itself, so it can be cloned and run; and a machine that knows better — a build server holding the real key, somebody running against another chain — still gets to say so for whatever the project did not write down.

## A name nothing sets is refused

Not read as empty. An empty value reaches a deploy as a key that is not a key and an address that is not an address, and the failure that follows says nothing about the manifest that caused it.

## Two decisions worth your eyes

**The braces are doubled** so a shell cannot mistake one for its own: `${NAME}` and `$NAME` are left exactly as written. A manifest is read by Aurora and never by a shell, and a form a shell would touch is a form somebody will one day pipe through one.

**Only `rpc` and `privkey` are read this way**, and the fields are written out rather than walked. A value that may come from outside is a decision about that value: a path is a path and a name is a name, and neither is a thing a project keeps somewhere else.

## A design I got wrong first, and the test that says so

I expanded the **text** before parsing it. Shorter, and it read a reference written inside a **comment** — so the example `aurora.toml`, which shows the form in a comment beside the setting it explains, was asked to resolve its own example and refused to load. The example suite caught it.

It reads the values now, after parsing. `TestACommentIsNotAValue` pins it.

`.env` is ignored wherever a project is. `make check` — 0 issues, and `shared/manifest` coverage is up from 87.9% to 89.6%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)