### PR TITLE
A chain is a profile, and a key with a prefix says so

### DIFF
--- a/examples/project/aurora.toml
+++ b/examples/project/aurora.toml
@@ -14,21 +14,35 @@
   # tape_size = 16
 
 [profiles]
-  # "main" is what you get when no profile is named.
+  # "main" is what you get when no profile is named. It says where the source is and where
+  # the binary goes, and nothing else: running and building need nothing else.
   [profiles.main]
     source = "src/main.ar"
     binary = "bin/main"
-    # What deploy and call need, and what this file must not hold. A value written as
-    # ${{ NAME }} is read from .env beside this file, or from the environment the command
-    # runs in when .env does not have it — so a manifest can be tracked and a key cannot.
-    #
-    # A name nothing sets is refused rather than read as empty, so these are left commented
-    # out: this project is built and run by the test suite, and it deploys nowhere.
-    # rpc = "${{ AURORA_RPC }}"
-    # privkey = "${{ AURORA_PRIVKEY }}"
 
   # A project holds as many profiles as it has things to build. This one is a
   # second program with a binary of its own.
   [profiles.label]
     source = "src/label.ar"
     binary = "bin/label"
+
+  # The same program, said again with what it takes to put it on a chain. Deploying and
+  # calling are the two commands that need an address and a key, and a profile is where a
+  # command's settings live — so the chain is a profile rather than a flag repeated by hand:
+  #
+  #   aurora deploy -p sepolia
+  #   aurora call main -p sepolia
+  #
+  # A value written as ${{ NAME }} is read from .env beside this file, or from the
+  # environment the command runs in when .env does not have it. Which is the point: this
+  # file is tracked and a key must not be, so the manifest names the value instead of
+  # holding it.
+  #
+  # A name nothing sets is refused rather than read as empty, so this profile only loads
+  # where somebody has set them. That is why it is a profile of its own: "main" is built and
+  # run by the test suite, on a machine that deploys nowhere and sets nothing.
+  [profiles.sepolia]
+    source = "src/main.ar"
+    binary = "bin/main"
+    rpc = "${{ AURORA_RPC }}"
+    privkey = "${{ AURORA_PRIVKEY }}"

--- a/hosting/cli/deploy.go
+++ b/hosting/cli/deploy.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/ecdsa"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -53,6 +54,24 @@ func decodeBytecode(raw []byte) ([]byte, error) {
 	return decoded, nil
 }
 
+// readPrivkey reads the key that signs the deploy.
+//
+// A key is hex and nothing else here, and a "0x" in front of it is refused by the reader with
+// "invalid hex character 'x'" — which is true and says nothing about what to do. A key copied
+// out of a wallet has that prefix more often than not, so the mistake is named.
+func readPrivkey(written string) (*ecdsa.PrivateKey, error) {
+	key := strings.TrimSpace(written)
+	if strings.HasPrefix(key, "0x") || strings.HasPrefix(key, "0X") {
+		return nil, fmt.Errorf("privkey starts with %q, and a key is written here as hex on its own: drop the prefix", key[:2])
+	}
+
+	privateKey, err := crypto.HexToECDSA(key)
+	if err != nil {
+		return nil, fmt.Errorf("privkey is not a key: %w", err)
+	}
+	return privateKey, nil
+}
+
 // Deploy sends the bytecode to the chain and returns the contract address, the deploy transaction hash, and the deploy timestamp. The caller should persist these via manifest.PersistDeploy.
 func Deploy(ctx context.Context, in DeployInput) (address string, deployTxHash string, deployedAt time.Time, err error) {
 	raw, err := os.ReadFile(in.BinaryPath)
@@ -68,7 +87,7 @@ func Deploy(ctx context.Context, in DeployInput) (address string, deployTxHash s
 		return "", "", time.Time{}, fmt.Errorf("bytecode too short (%d bytes); need at least %d", len(bs), MIN_BYTECODE_LEN)
 	}
 
-	privateKey, err := crypto.HexToECDSA(strings.TrimSpace(in.Privkey))
+	privateKey, err := readPrivkey(in.Privkey)
 	if err != nil {
 		return "", "", time.Time{}, err
 	}

--- a/hosting/cli/deploy_privkey_test.go
+++ b/hosting/cli/deploy_privkey_test.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// A key copied out of a wallet has "0x" in front of it more often than not, and the reader
+// underneath refuses that with "invalid hex character 'x'" — true, and no help at all.
+func TestAKeyWithAPrefixSaysSo(t *testing.T) {
+	_, err := readPrivkey("0x3ef32e39895116e1c37123b85aba020e5f38612f0e168b1c25ed564a97ac8720")
+	if err == nil {
+		t.Fatal("it read a key with a prefix")
+	}
+	for _, want := range []string{"0x", "drop the prefix"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("it says %q, want it to mention %q", err, want)
+		}
+	}
+}
+
+// And what a key is, it reads — with whatever spaces came along from a file.
+func TestAKeyIsReadWithTheSpacesAroundItDropped(t *testing.T) {
+	const key = "3ef32e39895116e1c37123b85aba020e5f38612f0e168b1c25ed564a97ac8720"
+
+	read, err := readPrivkey("  " + key + "\n")
+	if err != nil {
+		t.Fatalf("reading the key: %v", err)
+	}
+	if read == nil {
+		t.Fatal("it read nothing")
+	}
+}
+
+// Anything else is not a key, and says that rather than repeating what a hex reader thinks.
+func TestSomethingThatIsNotAKeySaysSo(t *testing.T) {
+	_, err := readPrivkey("not a key")
+	if err == nil {
+		t.Fatal("it read something that is not a key")
+	}
+	if !strings.Contains(err.Error(), "privkey is not a key") {
+		t.Errorf("it says %q, want it to say what was wrong", err)
+	}
+}


### PR DESCRIPTION
```toml
[profiles.sepolia]
  source = "src/main.ar"
  binary = "bin/main"
  rpc = "${{ AURORA_RPC }}"
  privkey = "${{ AURORA_PRIVKEY }}"
```

```
aurora deploy -p sepolia
aurora call main -p sepolia
```

## Why a profile of its own

Deploying and calling are the two commands that need an address and a key, and a profile is where a command's settings live — so the chain is a profile rather than a flag repeated by hand.

And there is a harder reason: **a name nothing sets is refused**, and `main` is built and run by the test suite on a machine that deploys nowhere and sets nothing. Putting the two settings on `main` made the example refuse to load for everybody who was not deploying it — which is what happened when the maintainer uncommented them.

## A key with `0x` in front of it

```
$ aurora deploy -p sepolia
invalid hex character 'x' in private key
```

True, and no help at all. A key copied out of a wallet has that prefix more often than not, and `docs/manifest.md` says "no `0x` prefix" — the tool did not.

```
privkey starts with "0x", and a key is written here as hex on its own: drop the prefix
```

Anything else that is not a key now says *that*, rather than repeating what a hex reader thinks of it.

Found by writing the profile and using it — which is the argument for examples that are used rather than read.

`make check` — 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)