### PR TITLE
A profile is read when it is asked for

### DIFF
--- a/shared/manifest/environment_test.go
+++ b/shared/manifest/environment_test.go
@@ -36,7 +36,11 @@ func TestAManifestReadsWhatItNames(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loading: %v", err)
 	}
-	if got := m.Profiles["main"].Privkey; got != "abc123" {
+	main, err := m.Profile("main")
+	if err != nil {
+		t.Fatalf("reading the profile: %v", err)
+	}
+	if got := main.Privkey; got != "abc123" {
 		t.Errorf("the key is %q, want what .env set", got)
 	}
 }
@@ -64,10 +68,14 @@ func TestTheProjectComesFirstAndTheMachineSecond(t *testing.T) {
 	if err != nil {
 		t.Fatalf("loading: %v", err)
 	}
-	if got := m.Profiles["main"].Privkey; got != "from-the-project" {
+	main, err := m.Profile("main")
+	if err != nil {
+		t.Fatalf("reading the profile: %v", err)
+	}
+	if got := main.Privkey; got != "from-the-project" {
 		t.Errorf("the key is %q, want the project's own", got)
 	}
-	if got := m.Profiles["main"].RPC; got != "from-the-machine" {
+	if got := main.RPC; got != "from-the-machine" {
 		t.Errorf("the address is %q, want the machine's, since the project does not say", got)
 	}
 }
@@ -85,9 +93,13 @@ func TestANameNothingSetsIsRefused(t *testing.T) {
 `,
 	})
 
-	_, err := Load(dir)
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	_, err = m.Profile("main")
 	if err == nil {
-		t.Fatal("it loaded a manifest naming something nothing sets")
+		t.Fatal("it read a profile naming something nothing sets")
 	}
 	for _, want := range []string{"NOBODY_SETS_THIS", EnvFilename} {
 		if !strings.Contains(err.Error(), want) {
@@ -107,8 +119,12 @@ func TestAManifestThatNamesNothingNeedsNothing(t *testing.T) {
 `,
 	})
 
-	if _, err := Load(dir); err != nil {
+	m, err := Load(dir)
+	if err != nil {
 		t.Fatalf("loading: %v", err)
+	}
+	if _, err := m.Profile("main"); err != nil {
+		t.Fatalf("reading the profile: %v", err)
 	}
 }
 
@@ -185,8 +201,12 @@ func TestACommentIsNotAValue(t *testing.T) {
 `,
 	})
 
-	if _, err := Load(dir); err != nil {
+	m, err := Load(dir)
+	if err != nil {
 		t.Fatalf("loading: %v", err)
+	}
+	if _, err := m.Profile("main"); err != nil {
+		t.Fatalf("reading the profile: %v", err)
 	}
 }
 
@@ -211,7 +231,47 @@ func TestOnlyWhatADeployNeedsIsRead(t *testing.T) {
 	if got := m.Project.Name; got != "${{ SOMETHING }}" {
 		t.Errorf("the project is named %q, want the reference left as it was written", got)
 	}
-	if got := m.Profiles["main"].Source; got != "${{ SOMETHING }}" {
+	main, err := m.Profile("main")
+	if err != nil {
+		t.Fatalf("reading the profile: %v", err)
+	}
+	if got := main.Source; got != "${{ SOMETHING }}" {
 		t.Errorf("the source is %q, want the reference left as it was written", got)
+	}
+}
+
+// A project holding a profile for a chain builds and runs on a machine that sets nothing.
+//
+// This is the whole reason a profile's values are read when the profile is asked for, and not
+// when the manifest is loaded. Reading every profile at load made a project with one deploy
+// profile refuse to do anything at all — build, run, test — anywhere the key was not set. It
+// went unnoticed locally because the machine that wrote it had a .env, and the machine that
+// runs the tests does not.
+func TestAProfileNobodyAsksForIsNotRead(t *testing.T) {
+	dir := projectWith(t, map[string]string{
+		Filename: `[project]
+  name = "p"
+[profiles]
+  [profiles.main]
+    source = "src/main.ar"
+    binary = "bin/main"
+  [profiles.sepolia]
+    source = "src/main.ar"
+    rpc = "${{ NOBODY_SETS_THIS }}"
+    privkey = "${{ NOR_THIS }}"
+`,
+	})
+
+	m, err := Load(dir)
+	if err != nil {
+		t.Fatalf("loading: %v", err)
+	}
+	if _, err := m.Profile("main"); err != nil {
+		t.Fatalf("reading the profile nobody has to set anything for: %v", err)
+	}
+
+	// And the one that does name them still says so, to whoever asks for it.
+	if _, err := m.Profile("sepolia"); err == nil {
+		t.Error("the profile that names what nothing sets was read without a word")
 	}
 }

--- a/shared/manifest/manifest.go
+++ b/shared/manifest/manifest.go
@@ -27,6 +27,11 @@ type Manifest struct {
 	Project  Project                `toml:"project"`
 	Profiles map[string]Profile     `toml:"profiles"`
 	Deploys  map[string]DeployState `toml:"deploys"`
+
+	// environment is what the values a profile names are read from, and path is what an error
+	// about one of them points at. Neither is written in the file.
+	environment Environment
+	path        string
 }
 
 // DeployState holds the last deploy result for a profile. Written by the CLI on each deploy; do not edit by hand.
@@ -124,39 +129,15 @@ func Load(projectRoot string) (*Manifest, error) {
 	if m.Profiles == nil {
 		m.Profiles = make(map[string]Profile)
 	}
-	if err := m.readEnvironment(projectRoot, path); err != nil {
+	if m.environment, err = LoadEnvironment(projectRoot); err != nil {
 		return nil, err
 	}
+	m.path = path
 	m.Deploys = loadDeploysFile(projectRoot)
 	if m.Deploys == nil {
 		m.Deploys = make(map[string]DeployState)
 	}
 	return &m, nil
-}
-
-// readEnvironment replaces every value that names the environment with what it names.
-//
-// The fields are written out rather than walked, because a value that may come from outside is
-// a decision about that value: a path is a path and a name is a name, and neither is a thing a
-// project would keep somewhere else. What is left is what a deploy needs and a manifest should
-// not hold.
-func (m *Manifest) readEnvironment(projectRoot, path string) error {
-	environment, err := LoadEnvironment(projectRoot)
-	if err != nil {
-		return err
-	}
-
-	for name, profile := range m.Profiles {
-		where := fmt.Sprintf("%s: profile %s", path, name)
-		if profile.RPC, err = environment.Expand(where, profile.RPC); err != nil {
-			return err
-		}
-		if profile.Privkey, err = environment.Expand(where, profile.Privkey); err != nil {
-			return err
-		}
-		m.Profiles[name] = profile
-	}
-	return nil
 }
 
 // loadDeploysFile reads .aurora.deploys.toml and returns the deploys map, or nil if the file is missing.
@@ -211,6 +192,20 @@ func (m *Manifest) Profile(name string) (Profile, error) {
 	p, ok := m.Profiles[name]
 	if !ok {
 		return Profile{}, fmt.Errorf("profile %q not found in manifest", name)
+	}
+
+	// What the profile names is read here rather than when the manifest was loaded, so a
+	// profile is only ever asked for what somebody is using it for. A project holding a
+	// profile for a chain — an address and a key, named rather than written down — is a
+	// project that has to build and run on a machine that sets neither, and reading every
+	// profile at load made it refuse to do anything at all.
+	where := fmt.Sprintf("%s: profile %s", m.path, name)
+	var err error
+	if p.RPC, err = m.environment.Expand(where, p.RPC); err != nil {
+		return Profile{}, err
+	}
+	if p.Privkey, err = m.environment.Expand(where, p.Privkey); err != nil {
+		return Profile{}, err
 	}
 	return p, nil
 }


### PR DESCRIPTION
`main` is red. This fixes it.

## What broke

A project holding a profile for a chain refused to do **anything** — build, run, test — on any machine that did not set the key:

```
examples/project/aurora.toml: profile sepolia names "AURORA_RPC", and nothing sets it
```

The manifest read every profile's values when it was loaded, so one profile naming something unset stopped the whole file from loading, whatever profile you were using.

It is read when the profile is asked for now. **What a project needs to put itself on a chain is needed by whoever is putting it on a chain, and by nobody else.**

## How it got in, which is the part worth reading

The pull request before this one (#140) split the chain settings onto a profile of their own, and said **in its own body** that this was the reason for the split:

> a name nothing sets is refused, and `main` is built and run by the test suite on a machine that deploys nowhere and sets nothing

That was false. The split changed nothing, because loading read both profiles anyway.

And `make check` passed locally. **This machine has a `.env` and the machine that runs the tests does not** — so the check meant to prove the manifest works without the secret was answered by the secret.

I also merged #140 while the Go 1.23 job was already red: my command chained the merge after a watch that reports failure without failing.

## Proof

`TestAProfileNobodyAsksForIsNotRead` — a manifest with a deploy profile loads and `main` reads fine, while asking for the deploy profile still says what is missing.

And `make check` was run with `.env` moved aside, which is the condition CI runs in and the one I had not tested. 0 issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)