### PR TITLE
One thing, one word — and an RFC for knowing which shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,6 +94,9 @@ be known by all. **A vital package is pure**: no I/O, nothing done that is not r
 **Errors are resolved in hosting**, which is also the only layer that touches the world, and
 **wiring happens only in `main`**. A sub-package has the kind of its parent.
 
+The words this project uses — one thing, one word — are in the same file, under **The words**.
+`returns` is the verb for what an expression gives, and there is no second word for it.
+
 Why each of those, what belongs where, and what the tree does not obey yet:
 **[docs/contributing/architecture.md](docs/contributing/architecture.md)**, which is the
 source of truth — this table is a pointer, not a copy.

--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -171,6 +171,34 @@ that its parent never uses.
 The second signal: `build`, `run` and `test` are **functions inside `hosting/cli`**, not
 packages. The same argument that makes `cli/repl` would make `cli/build`.
 
+## The words
+
+One thing, one word. A concept with two names drifts: the two get used in different places,
+then in the same place, and then somebody adds a third because neither of the two seemed to fit.
+
+| word | what it names |
+|---|---|
+| **shape** | the declaration and the kind: `shape Point { x, y }` |
+| **run** | the value a shape builds: tapes laid end to end |
+| **field** | one tape of a run, by the name the shape gave it |
+| **returns** | what an expression gives. A scope returns a shape; the keyword declares it |
+| **tape** | a value: a fixed run of bytes, `tape_size` wide |
+| **scope** | a block of code that is applied to a vector of values |
+
+**`returns` is the verb, everywhere.** An expression returns a value; a scope returns a shape;
+`returns Point` declares what a scope returns and the compiler checks it. There is no second
+word for this — not "answers", not "promises". "Promise" in particular came from another
+tradition and never said anything this language means.
+
+**One exception, and it is a different thing.** A server *answers* a request. That is a
+protocol answering a client, not an expression giving a value, and `hosting/lsp` is full of it
+for a good reason. It stays.
+
+**Declared or worked out.** What a scope returns is known two ways: it was declared with
+`returns`, or it was worked out from the body. Both are the same fact and carry the same word;
+which of the two it is travels beside it, because an editor may want to show the difference and
+a warning may want to name it.
+
 ## Where a test goes
 
 **With the thing it tests**, which for an artefact means the artefact's own package. Before

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -121,6 +121,13 @@ as deep as it nests, shapes, and the tape operations.
 Nothing a program can write is missing from it any more. What a contract does not get is what
 was decided not to reach a chain, and two limits that are written down:
 
+- **A scope only reaches what it bound itself**, so everything a scope works on arrives as a
+  value applied to it. What would let a scope read a name from around it is a static link —
+  the frame carrying where the scope was written — and it is not built.
+- **A contract holds no state, says nothing, and does not know who called it.** There is no
+  storage, no event, no caller, and no way to refuse a transaction. Each of them is its own
+  decision, and each has the same question under it: what does it mean off a chain, where
+  there is no storage, no log, and nobody calling. `rfcs/` is where those are argued.
 - **A shape reaches the chain while its run fits a word.** A run is its tapes and nothing else,
   so a shape of five fields at the default tape of eight is forty bytes and is refused rather
   than written short. Four fields fill a word exactly.

--- a/rfcs/shape_inference.md
+++ b/rfcs/shape_inference.md
@@ -2,8 +2,13 @@
 
 **Estado:** proposta · **Data:** 2026-08-25
 
-Hoje o `returns` é a única fonte para saber o que um escopo responde. Esta RFC diz por que isso
-está errado, o que passa a ser inferido, e o que o `returns` vira.
+Hoje o `returns` é a única fonte para saber qual shape um escopo retorna. Esta RFC diz por que
+isso está errado, o que passa a ser descoberto, e o que o `returns` vira.
+
+O vocabulário está em [docs/contributing/architecture.md](../docs/contributing/architecture.md),
+seção **The words**: `returns` é o verbo — uma expressão *returns* um valor, um escopo *returns*
+um shape —, `shape` é o que é retornado, e `field` é um tape de uma run. Não há segunda palavra
+para nada disso.
 
 > Os blocos aqui **não** estão marcados como `aurora`: `hosting/cli/docs_test.go` executa todo
 > bloco assim marcado no repositório, e o primeiro exemplo abaixo não compila hoje — que é
@@ -28,8 +33,9 @@ name it with 'as'
 Acrescente `returns Square` ao `defer` e o mesmo programa responde 30.
 
 O caminho é este: `shapeOf` para uma chamada lê `declarations.Returns[nome]`
-(`parser/shapes.go`), e `Returns` só é preenchido quando o `returns` foi escrito
-(`parser/parser.go`). Sem promessa, a chamada não tem shape, e ler um campo dela é recusado.
+(`parser/shapes.go`), e esse mapa só é preenchido quando o `returns` foi escrito
+(`parser/parser.go`). Sem a declaração, a chamada não retorna shape nenhum, e ler um field dela
+é recusado.
 
 O compilador **poderia** saber. O corpo do escopo termina em `Square{...}`, ali, no mesmo
 arquivo. Ele simplesmente não olha.
@@ -56,24 +62,49 @@ descrição fraca é justamente a que a pessoa vê enquanto escreve.
 
 ## A decisão
 
-**Inferir qual shape é trabalho da linguagem.** O `returns` deixa de ser fonte e vira
-**restrição que o compilador confere**.
-
-Três consequências, e a terceira é a que custa:
+**Descobrir qual shape um escopo retorna é trabalho da linguagem.** O `returns` deixa de ser
+fonte e vira **restrição que o compilador confere**.
 
 **O que já existe faz quase tudo.** `answersWith` (`parser/shapes.go`) já percorre um corpo e
-calcula o shape da última expressão, olhando através dos braços de um `if`. Ele só usa isso
-para conferir uma promessa. Separar esse passeio da checagem é o começo.
+calcula qual shape ele retorna, olhando através dos braços de um `if`. Ele só usa isso para
+conferir a declaração. Separar esse passeio da checagem é o começo — e o nome dele muda junto,
+porque "answers" sai do vocabulário.
 
-**Um shape inferido atravessa módulo.** `promises()` exporta o que estiver em `Returns`, e o
-editor já lê `Tree.Promises` do módulo importado — então inferir no parser faz o editor
-conhecer shapes atravessando arquivo sem que o servidor de linguagem mude uma linha.
+**Um shape descoberto atravessa módulo.** `promises()` exporta o que estiver no mapa, e o editor
+já lê o que o módulo importado oferece — então descobrir no parser faz o editor conhecer shapes
+atravessando arquivo sem que o servidor de linguagem mude uma linha.
 
 **E o preço, dito com todas as letras:** a superfície pública de um módulo passa a ser
-inferida. Mudar a última expressão de um escopo muda, calado, o que quem importa aquele arquivo
-enxerga. É o mesmo preço que qualquer linguagem paga por inferência através de fronteira, e foi
-escolhido de propósito: a alternativa — exigir `returns` para atravessar — devolve a obrigação
-exatamente no caso que motivou esta RFC.
+descoberta. Mudar a última expressão de um escopo muda, calado, o que quem importa aquele
+arquivo enxerga. É o mesmo preço que qualquer linguagem paga por inferência através de
+fronteira, e foi escolhido de propósito: a alternativa — exigir `returns` para atravessar —
+devolve a obrigação exatamente no caso que motivou esta RFC.
+
+## Declarado ou descoberto viaja junto
+
+O que um escopo retorna é sabido de dois jeitos: foi **declarado** com `returns`, ou foi
+**descoberto** do corpo. É o mesmo fato e carrega a mesma palavra — mas qual dos dois viaja ao
+lado, num campo.
+
+```go
+// Returns is what a scope gives back, and how that is known.
+type Returns struct {
+    Scope  string
+    Shape  string
+    Fields []string
+    // Declared says the returns was written. Worked out from the body otherwise.
+    Declared bool
+}
+```
+
+Isso não é enfeite. Ele paga em três lugares:
+
+- **O editor pode mostrar a diferença** — um shape que o arquivo garante e um que ele apenas
+  acabou retornando não são a mesma promessa a quem lê.
+- **O aviso de superfície implícita fica possível sem maquinaria nova**: um escopo do topo que
+  retorna um shape sem declarar pode render um aviso, se um dia isso incomodar.
+- **A regra do vocabulário sobrevive.** Sem esse campo, alguém acabaria inventando uma segunda
+  palavra para "o que foi declarado" — que é exatamente como "promise" nasceu.
 
 ## O que o `returns` passa a ser
 
@@ -84,38 +115,37 @@ ident new_square = defer { Square{feed(0), feed(1)}; } returns Square;
 ```
 
 Continua conferido: um corpo que termina em outra coisa continua sendo recusado, com as mesmas
-mensagens (`brokenPromise`, `describeAnswer`). Inferir **não** pode virar aceitar promessa
-errada.
+mensagens. Descobrir **não** pode virar aceitar declaração errada.
 
 O que ele deixa de ser é obrigação para o compilador saber. E ele ganha um lugar onde volta a
-ser a única fonte: **quando o destino não estiver no programa**. Chamar outro contrato — a
-ideia de `use "<endereço>@<hash>" as c;` — resolve para bytecode, e bytecode não tem nomes. Ali
-a promessa é tudo o que existe, o que é consistente com a regra: *o `returns` serve ao que não
+ser a única fonte: **quando o destino não estiver no programa**. Chamar outro contrato — a ideia
+de `use "<endereço>@<hash>" as c;` — resolve para bytecode, e bytecode não tem nomes. Ali a
+declaração é tudo o que existe, o que é consistente com a regra: *o `returns` serve ao que não
 dá para resolver em tempo de compilação*.
 
 ## Os limites, nomeados
 
 Uma checagem que se cala onde não tem certeza é a regra deste compilador, e não uma falta. Onde
-a inferência se cala:
+a descoberta se cala:
 
-**Referência para frente.** `ident a = defer { b(); };` escrito antes de `b` não infere, porque
-o parser é de uma passada. É o comportamento de hoje, então não é regressão — mas é limite, e
-está escrito aqui para ninguém descobrir sozinho.
+**Referência para frente.** `ident a = defer { b(); };` escrito antes de `b` não descobre nada,
+porque o parser é de uma passada. É o comportamento de hoje, então não é regressão — mas é
+limite, e está escrito aqui para ninguém descobrir sozinho.
 
-**Recursão.** Inferir `down` consulta o que `down` responde, que ainda não existe, e responde
-vazio. Não trava: é leitura de mapa, não recursão.
+**Recursão.** Descobrir o que `down` retorna consulta o que `down` retorna, que ainda não
+existe, e responde vazio. Não trava: é leitura de mapa, não recursão.
 
-**Um `if` sem `else`.** Já é vazio no `shapeOf`, e é a diferença de contrato entre inferir e
-conferir: para a promessa, um caminho que responde nada é **erro**; para a inferência, é
+**Um `if` sem `else`.** Já é vazio no `shapeOf`, e é a diferença de contrato entre descobrir e
+conferir: para uma declaração, um caminho que retorna nada é **erro**; para a descoberta, é
 **desconhecido**.
 
 ## O que esta RFC não faz
 
 **O tamanho de uma run para guardá-la contígua na memória.** É pergunta diferente e de outra
-fase. "Qual índice é `.width`" é do parser e precisa da identidade do shape; "quantos tapes tem
-a run" precisa só da contagem de campos, e o builder já resolve o destino de toda chamada
+fase. "Qual índice é `.width`" é do parser e precisa do nome do shape; "quantos tapes tem a run"
+precisa só da contagem de fields, e o builder já resolve o destino de toda chamada
 estaticamente — o `Entry` de cada escopo já carrega quantas posições ele lê, e ganharia quantos
-tapes ele responde. Isso vai na RFC do `Effect`, com shape na memória como caso motivador.
+tapes ele retorna. Isso vai na RFC do `Effect`, com shape na memória como caso motivador.
 
 **Fazer o editor parar de varrer tokens.** Ele passa a ler o que o parser sabe, e o passeio de
 tokens fica como reserva — porque autocompletar tem que funcionar **enquanto se digita**, e
@@ -123,17 +153,19 @@ documento meio escrito quase nunca parseia. O que muda é o papel: deixa de ser 
 
 ## As etapas
 
-1. **Um passeio só.** Separar de `answersWith` a função que responde qual shape um corpo
-   responde. Nada muda para quem escreve Aurora; os testes que existem são a prova.
-2. **Inferir o que um escopo responde**, quando ele não prometeu. Puramente aditivo: nada que
-   compila deixa de compilar, e passa a compilar o que hoje é recusado.
-3. **O editor lê o que a linguagem sabe**, com o passeio de tokens como reserva.
+1. **O vocabulário.** `returns` em tudo, "answers" e "promise" fora, `ast.Returns` no lugar de
+   `ast.Promise`. Renomeação pura, por camada, cada uma com `make check`.
+2. **Um passeio só.** Separar da checagem a função que descobre qual shape um corpo retorna.
+   Nada muda para quem escreve Aurora; os testes que existem são a prova.
+3. **Descobrir o que um escopo retorna**, quando ele não declarou, e carregar `Declared` junto.
+   Puramente aditivo: nada que compila deixa de compilar, e passa a compilar o que hoje é
+   recusado.
+4. **O editor lê o que a linguagem sabe**, com o passeio de tokens como reserva.
 
 ## Em aberto
 
-1. **Um aviso para superfície implícita.** Um escopo do topo que responde um shape sem declarar
-   `returns` podia render um aviso — empurrando para superfície explícita sem obrigar. Fica de
-   fora agora porque acrescenta ruído antes de a gente saber se incomoda.
-2. **Ligar duas vezes.** Um nome ligado a dois `defer` diferentes: o segundo sobrescreve. Hoje
-   é assim para o `returns` também, então nada muda — mas é um lugar onde inferir amplia o
+1. **Um aviso para superfície implícita.** Fica de fora agora porque acrescenta ruído antes de a
+   gente saber se incomoda — e com `Declared` no lugar, é uma linha quando incomodar.
+2. **Ligar duas vezes.** Um nome ligado a dois `defer` diferentes: o segundo sobrescreve. Hoje é
+   assim para o `returns` também, então nada muda — mas é um lugar onde descobrir amplia o
    alcance de um comportamento que ninguém decidiu.

--- a/rfcs/shape_inference.md
+++ b/rfcs/shape_inference.md
@@ -1,0 +1,139 @@
+# A linguagem sabe qual shape, sem precisar do `returns`
+
+**Estado:** proposta · **Data:** 2026-08-25
+
+Hoje o `returns` é a única fonte para saber o que um escopo responde. Esta RFC diz por que isso
+está errado, o que passa a ser inferido, e o que o `returns` vira.
+
+> Os blocos aqui **não** estão marcados como `aurora`: `hosting/cli/docs_test.go` executa todo
+> bloco assim marcado no repositório, e o primeiro exemplo abaixo não compila hoje — que é
+> justamente o ponto.
+
+---
+
+## O que acontece hoje
+
+```
+shape Square { width, height };
+ident new_square = defer { Square{feed(0), feed(1)}; };
+ident s = new_square(30, 20);
+printd s.width;
+```
+
+```
+cannot read field width at line 4 and column 10: nothing says which shape this value is,
+name it with 'as'
+```
+
+Acrescente `returns Square` ao `defer` e o mesmo programa responde 30.
+
+O caminho é este: `shapeOf` para uma chamada lê `declarations.Returns[nome]`
+(`parser/shapes.go`), e `Returns` só é preenchido quando o `returns` foi escrito
+(`parser/parser.go`). Sem promessa, a chamada não tem shape, e ler um campo dela é recusado.
+
+O compilador **poderia** saber. O corpo do escopo termina em `Square{...}`, ali, no mesmo
+arquivo. Ele simplesmente não olha.
+
+## E tem um segundo problema, mais fundo
+
+O editor não usa o que a linguagem sabe. O servidor de linguagem monta a **própria** tabela de
+shapes varrendo o fluxo de tokens (`hosting/lsp/textdoc/shapes.go`, `scan`), casando padrões:
+
+```
+shape N { ... }
+ident p = N{
+ident p = ... as N
+ident f = defer { ... } returns N
+```
+
+É uma reimplementação do `shapeOf`, e mais fraca: o `shapeOf` resolve um bloco pela última
+expressão, um `if` cujos braços concordam, e uma cadeia de ligações. O `scan` não resolve
+nenhum dos três.
+
+São **duas descrições da mesma coisa**, e duas descrições divergem — que é o modo de falhar que
+este repositório vem encontrando de outras formas o ano todo. A diferença é que aqui a
+descrição fraca é justamente a que a pessoa vê enquanto escreve.
+
+## A decisão
+
+**Inferir qual shape é trabalho da linguagem.** O `returns` deixa de ser fonte e vira
+**restrição que o compilador confere**.
+
+Três consequências, e a terceira é a que custa:
+
+**O que já existe faz quase tudo.** `answersWith` (`parser/shapes.go`) já percorre um corpo e
+calcula o shape da última expressão, olhando através dos braços de um `if`. Ele só usa isso
+para conferir uma promessa. Separar esse passeio da checagem é o começo.
+
+**Um shape inferido atravessa módulo.** `promises()` exporta o que estiver em `Returns`, e o
+editor já lê `Tree.Promises` do módulo importado — então inferir no parser faz o editor
+conhecer shapes atravessando arquivo sem que o servidor de linguagem mude uma linha.
+
+**E o preço, dito com todas as letras:** a superfície pública de um módulo passa a ser
+inferida. Mudar a última expressão de um escopo muda, calado, o que quem importa aquele arquivo
+enxerga. É o mesmo preço que qualquer linguagem paga por inferência através de fronteira, e foi
+escolhido de propósito: a alternativa — exigir `returns` para atravessar — devolve a obrigação
+exatamente no caso que motivou esta RFC.
+
+## O que o `returns` passa a ser
+
+Uma declaração dirigida a quem lê, que o compilador confere.
+
+```
+ident new_square = defer { Square{feed(0), feed(1)}; } returns Square;
+```
+
+Continua conferido: um corpo que termina em outra coisa continua sendo recusado, com as mesmas
+mensagens (`brokenPromise`, `describeAnswer`). Inferir **não** pode virar aceitar promessa
+errada.
+
+O que ele deixa de ser é obrigação para o compilador saber. E ele ganha um lugar onde volta a
+ser a única fonte: **quando o destino não estiver no programa**. Chamar outro contrato — a
+ideia de `use "<endereço>@<hash>" as c;` — resolve para bytecode, e bytecode não tem nomes. Ali
+a promessa é tudo o que existe, o que é consistente com a regra: *o `returns` serve ao que não
+dá para resolver em tempo de compilação*.
+
+## Os limites, nomeados
+
+Uma checagem que se cala onde não tem certeza é a regra deste compilador, e não uma falta. Onde
+a inferência se cala:
+
+**Referência para frente.** `ident a = defer { b(); };` escrito antes de `b` não infere, porque
+o parser é de uma passada. É o comportamento de hoje, então não é regressão — mas é limite, e
+está escrito aqui para ninguém descobrir sozinho.
+
+**Recursão.** Inferir `down` consulta o que `down` responde, que ainda não existe, e responde
+vazio. Não trava: é leitura de mapa, não recursão.
+
+**Um `if` sem `else`.** Já é vazio no `shapeOf`, e é a diferença de contrato entre inferir e
+conferir: para a promessa, um caminho que responde nada é **erro**; para a inferência, é
+**desconhecido**.
+
+## O que esta RFC não faz
+
+**O tamanho de uma run para guardá-la contígua na memória.** É pergunta diferente e de outra
+fase. "Qual índice é `.width`" é do parser e precisa da identidade do shape; "quantos tapes tem
+a run" precisa só da contagem de campos, e o builder já resolve o destino de toda chamada
+estaticamente — o `Entry` de cada escopo já carrega quantas posições ele lê, e ganharia quantos
+tapes ele responde. Isso vai na RFC do `Effect`, com shape na memória como caso motivador.
+
+**Fazer o editor parar de varrer tokens.** Ele passa a ler o que o parser sabe, e o passeio de
+tokens fica como reserva — porque autocompletar tem que funcionar **enquanto se digita**, e
+documento meio escrito quase nunca parseia. O que muda é o papel: deixa de ser a única fonte.
+
+## As etapas
+
+1. **Um passeio só.** Separar de `answersWith` a função que responde qual shape um corpo
+   responde. Nada muda para quem escreve Aurora; os testes que existem são a prova.
+2. **Inferir o que um escopo responde**, quando ele não prometeu. Puramente aditivo: nada que
+   compila deixa de compilar, e passa a compilar o que hoje é recusado.
+3. **O editor lê o que a linguagem sabe**, com o passeio de tokens como reserva.
+
+## Em aberto
+
+1. **Um aviso para superfície implícita.** Um escopo do topo que responde um shape sem declarar
+   `returns` podia render um aviso — empurrando para superfície explícita sem obrigar. Fica de
+   fora agora porque acrescenta ruído antes de a gente saber se incomoda.
+2. **Ligar duas vezes.** Um nome ligado a dois `defer` diferentes: o segundo sobrescreve. Hoje
+   é assim para o `returns` também, então nada muda — mas é um lugar onde inferir amplia o
+   alcance de um comportamento que ninguém decidiu.


### PR DESCRIPTION
Two commits: the words this project uses, and the RFC written in them.

## The words

Three names were in use for one relation. What an expression gives back was **"answers"** in the code (111 uses), **"returns"** in the keyword and the maps, and **"promise"** in the tree and the parser.

A concept with two names drifts — the two get used in different places, then in the same place, and then somebody adds a third because neither seemed to fit. That is exactly how this one got to three.

So: **`returns` is the verb, everywhere.** An expression returns a value, a scope returns a shape, `returns Point` declares what a scope returns. `shape` is what is returned, `field` is one tape of a run. No second word for any of it.

**"Promise" goes.** It came from another tradition and never said anything this language means.

**One exception, named in the rule:** a server *answers* a request. That is a protocol answering a client, not an expression giving a value, and `hosting/lsp` is full of it for a good reason. A rule that does not name its exception is a rule somebody breaks by accident — I nearly did, before checking what those 129 occurrences actually meant.

The rule lives in `docs/contributing/architecture.md`, which already declares itself the source of truth everything points at.

## The RFC

```
shape Square { width, height };
ident new_square = defer { Square{feed(0), feed(1)}; };
ident s = new_square(30, 20);
printd s.width;
```

```
cannot read field width at line 4 and column 10: nothing says which shape this value is
```

Add `returns Square` and the same program answers 30. **The compiler could have known** — the body ends in `Square{...}`, four lines up, in the same file. It simply does not look.

Under that sits the worse half: **the editor does not use what the language knows.** The language server builds its own shape table by pattern-matching tokens — a weaker copy of `shapeOf`, which already resolves a block by its last expression, an `if` whose arms agree, and a chain of bindings. Two descriptions of one thing, and the weak one is what somebody sees while typing.

**The decision:** working out which shape is the language's job; `returns` becomes a constraint the compiler checks. A worked-out shape crosses a module, and the price is written down rather than glossed — a module's public surface becomes implicit.

## Declared or worked out travels with it

```go
type Returns struct {
    Scope    string
    Shape    string
    Fields   []string
    Declared bool // written with returns, or worked out from the body
}
```

Not decoration. It pays three times: an editor can show the difference; the warning about an implicit public surface becomes a line rather than machinery; and **the vocabulary survives** — without it, somebody would have invented a second word for "the declared one", which is how "promise" was born.

## What is not here

The **rename itself** — ~600 sites across ten packages. It goes by layer, each a pure rename with `make check` as the proof, and it is step 1 of the RFC's own list. A single mechanical diff across ten packages is what `CLAUDE.md` says not to write, and I have twice today shown why blanket regex deserves that caution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)