### PR TITLE
returns is the word, in the tree and the parser

### DIFF
--- a/docs/contributing/architecture.md
+++ b/docs/contributing/architecture.md
@@ -190,9 +190,19 @@ then in the same place, and then somebody adds a third because neither of the tw
 word for this — not "answers", not "promises". "Promise" in particular came from another
 tradition and never said anything this language means.
 
-**One exception, and it is a different thing.** A server *answers* a request. That is a
-protocol answering a client, not an expression giving a value, and `hosting/lsp` is full of it
-for a good reason. It stays.
+**The rule is about the language's concept, and the subject is how you tell.** When the thing
+giving a value is an Aurora construct — an expression, a scope, a block, a terminator — it
+**returns**. Two other uses of "answer" are a different word wearing the same spelling, and
+both stay:
+
+- **A Go function described in prose.** "sameKind answers whether b is the kind of node a is"
+  is this project's voice for saying what a helper does. It is not a construct of the language
+  giving a value.
+- **A server answering a request.** That is a protocol answering a client, and `hosting/lsp` is
+  full of it for a good reason.
+
+A rule that does not name its exceptions is a rule somebody breaks by accident, and this one
+was nearly broken twice while it was being written.
 
 **Declared or worked out.** What a scope returns is known two ways: it was declared with
 `returns`, or it was worked out from the body. Both are the same fact and carry the same word;

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -386,7 +386,7 @@ printd r.failed;   #- 0
 printd r.value;    #- 5
 ```
 
-Nothing about the scope says it answers with a `Result`, and nothing has to: the answer is a
+Nothing about the scope says it returns a `Result`, and nothing has to: what comes back is a
 run of two tapes, and `as` names what they are. The claim is the caller's, the same way it is
 on the way in.
 
@@ -433,7 +433,7 @@ innermost else, so its way out is always covered.
 A block that does not keep its promise does not compile:
 
 ```aurora
-#- fails: answers with Person and ends with a number
+#- fails: returns Person and ends with a number
 shape Person { name };
 
 {
@@ -442,7 +442,7 @@ shape Person { name };
 } returns Person;
 ```
 
-An `if` with no else promises nothing, since the path where the test fails answers with the
+An `if` with no else declares nothing, since the path where the test fails returns the
 neutral value:
 
 ```aurora
@@ -456,12 +456,12 @@ shape Person { name };
 
 **What it buys is the other end.** A call to a scope that promised has a shape, so `as`
 disappears from the place it was repeated once per call — and it stops being a claim, since
-the promise was checked. A scope that promises nothing is unchanged: it answers with a run of
+the declaration was checked. A scope that declares nothing is unchanged: it returns a run of
 tapes, and whoever reads its fields writes `as`.
 
 The promise is never required, and never will be. A scope has no signature — it does not
 declare how many values it receives or what they are — so requiring it to declare what it
-answers with would be declaring one end and not the other. `returns` is what you gain by
+returns would be declaring one end and not the other. `returns` is what you gain by
 promising, not a toll for writing a block.
 
 ### What is an error

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -176,7 +176,7 @@ func shapesOf(analysis *Analysis, aliases moduleAliases) shapeTable {
 //
 // It is the parser's own Import with the alias in front instead of the specifier — the same
 // two halves, read for the same reason. The shapes say what a construction is made of; the
-// promises say what a call answers with, which is the only shape a name bound from another
+// returns say what a call gives back, which is the only shape a name bound from another
 // module's scope ever has.
 func importedShapes(analysis *Analysis, aliases moduleAliases) shapeTable {
 	shapes := newShapeTable()
@@ -188,12 +188,12 @@ func importedShapes(analysis *Analysis, aliases moduleAliases) shapeTable {
 		for _, shape := range found.Tree.Shapes {
 			shapes.fields[alias+"."+shape.Name] = shape.Fields
 		}
-		for _, promise := range found.Tree.Promises {
-			// A promise may name a shape of a third module, which this one never declared, so
+		for _, returns := range found.Tree.Returns {
+			// A scope may return a shape of a third module, which this one never declared, so
 			// the fields come with it rather than being looked up.
-			named := alias + "." + promise.Shape
-			shapes.fields[named] = promise.Fields
-			shapes.promises[alias+"."+promise.Scope] = named
+			named := alias + "." + returns.Shape
+			shapes.fields[named] = returns.Fields
+			shapes.returns[alias+"."+returns.Scope] = named
 		}
 	}
 	return shapes

--- a/hosting/lsp/textdoc/shapes.go
+++ b/hosting/lsp/textdoc/shapes.go
@@ -17,17 +17,17 @@ import (
 type shapeTable struct {
 	fields map[string][]string // shape name -> its fields, in order
 	reads  map[string]string   // identifier name -> the shape it is read as
-	// promises is what `returns` said: the name of a scope -> the shape calling it answers
-	// with. A name bound from such a call is read as that shape without anybody claiming it.
-	promises map[string]string
+	// returns is the name of a scope -> the shape calling it gives back. A name bound from
+	// such a call is read as that shape without anybody claiming it.
+	returns map[string]string
 }
 
 // newShapeTable is what nothing has been read into yet.
 func newShapeTable() shapeTable {
 	return shapeTable{
-		fields:   make(map[string][]string),
-		reads:    make(map[string]string),
-		promises: make(map[string]string),
+		fields:  make(map[string][]string),
+		reads:   make(map[string]string),
+		returns: make(map[string]string),
 	}
 }
 
@@ -50,12 +50,12 @@ func (found shapeTable) scan(tokens []token.Token) shapeTable {
 			// `ident p = Point{`, `ident p = <anything> as Point` and a call to a scope that
 			// promised all say what p is; `ident f = defer { ... } returns Point` says what
 			// calling f will.
-			name, shape, promised, called := readBinding(tokens, i)
-			if promised != "" {
-				found.promises[name] = promised
+			name, shape, declared, called := readBinding(tokens, i)
+			if declared != "" {
+				found.returns[name] = declared
 			}
 			if shape == "" && called != "" {
-				shape = found.promises[called]
+				shape = found.returns[called]
 			}
 			if shape != "" {
 				found.reads[name] = shape

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -242,7 +242,7 @@ func (s *Session) load(tree ast.AST) error {
 		s.loaded[each.ID] = each
 		// What it answers with is written down for the lines after this one: a session is a
 		// file typed slowly, and the use line was already read when this module arrived.
-		s.declarations.Import(string(each.ID), ast.Offer{Shapes: each.Tree.Shapes, Promises: each.Tree.Promises})
+		s.declarations.Import(string(each.ID), ast.Offer{Shapes: each.Tree.Shapes, Returns: each.Tree.Returns})
 	}
 	return nil
 }

--- a/parser/header.go
+++ b/parser/header.go
@@ -29,7 +29,7 @@ func ScanUses(tokens []token.Token) []ast.UseDeclaration {
 }
 
 // readUse reads one declaration starting at the use token: the path it names, and the alias
-// it is reached by. A half-written line answers with nothing, which is the common case while
+// it is reached by. A half-written line returns nothing, which is the common case while
 // somebody is typing one.
 func readUse(tokens []token.Token, i int) (string, string, int) {
 	specifier := ""

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -50,7 +50,7 @@ type ParseInput struct {
 	//
 	// It arrives because a shape is resolved while parsing and a shape's name never leaves
 	// the file that declared it — so a scope of another module answering with one has to hand
-	// the fields over. Empty is a file that imports nothing, or one whose imports promised
+	// the fields over. Empty is a file that imports nothing, or one whose imports returned
 	// nothing, and it reads exactly as it did before any of this.
 	Imports map[string]ast.Offer
 	// Declarations carries what `shape` and `as` declared across parses of the same file.
@@ -709,10 +709,10 @@ func (p *pr) ParseBlockExpr() (ast.Node, error) {
 	return p.parseBlock()
 }
 
-// parseBlock reads `{ ... }` and the promise that may follow it.
+// parseBlock reads `{ ... }` and the `returns` that may follow it.
 //
 // A deferred scope is a block with a word in front of it, so it comes through here too — which
-// is what gives it the promise, and what keeps the braces from being read in two places.
+// is what gives it the `returns`, and what keeps the braces from being read in two places.
 func (p *pr) parseBlock() (ast.BlockExpression, error) {
 	if _, err := p.EatToken(token.O_CUR_BRK); err != nil {
 		return ast.BlockExpression{}, err
@@ -1043,7 +1043,7 @@ func (p pr) Parse(in ParseInput) (ast.AST, error) {
 		Filename:   p.filename,
 		Nodes:      nodes,
 		References: p.references,
-		Promises:   p.promises(nodes),
+		Returns:    p.returns(nodes),
 		Shapes:     p.shapes(nodes),
 	}, nil
 }

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -8,17 +8,17 @@ import (
 	"github.com/guiferpa/aurora/wire/token"
 )
 
-// What a block promises, and what happens when it does not keep it.
+// What a block declares it returns, and what happens when it does not keep it.
 //
-// `as` is a claim the compiler believes; this is a promise it checks. The two live in one
-// program, and a block that promises nothing goes on answering with a run of tapes.
+// `as` is a claim the compiler believes; this is a declaration it checks. The two live in one
+// program, and a block that declares nothing goes on returning a run of tapes.
 
 const person = "shape Person { name };\n"
 const result = "shape Result { failed, value };\n"
 
-// The promise is read at the end of a block, and it is the same place for a deferred scope,
+// The `returns` is read at the end of a block, and it is the same place for a deferred scope,
 // which is a block with a word in front of it.
-func TestABlockPromisesAShape(t *testing.T) {
+func TestABlockDeclaresWhatItReturns(t *testing.T) {
 	for _, tc := range []struct {
 		name   string
 		source string
@@ -46,7 +46,7 @@ func TestABlockPromisesAShape(t *testing.T) {
 				"} returns Result;",
 		},
 		{
-			// The promise is kept by a name whose shape was named, the same way a field read
+			// It is kept by a name whose shape was named, the same way a field read
 			// is allowed by one.
 			name:   "a name that was shaped",
 			source: person + "ident make = defer {\nident p = feed(0) as Person;\np;\n} returns Person;",
@@ -60,8 +60,8 @@ func TestABlockPromisesAShape(t *testing.T) {
 	}
 }
 
-// The promise reaches the tree, so whoever reads the block knows what it answers with.
-func TestThePromiseIsOnTheBlock(t *testing.T) {
+// It reaches the tree, so whoever reads the block knows what it returns.
+func TestWhatItReturnsIsOnTheBlock(t *testing.T) {
 	nodes := parse(t, person+"{ Person{\"Joana\"}; } returns Person;")
 
 	block, ok := nodes[1].(ast.BlockExpression)
@@ -91,12 +91,12 @@ var brokenPromises = []struct {
 	{
 		name:   "ends with a number",
 		source: person + "{ ident p = Person{\"Joana\"};\n10; } returns Person;",
-		want:   "answers with Person and ends with a number",
+		want:   "returns Person and ends with a number",
 	},
 	{
 		name:   "ends with another shape",
 		source: person + "shape Place { city };\n{ Place{\"Recife\"}; } returns Person;",
-		want:   "answers with Person and ends with a Place",
+		want:   "returns Person and ends with a Place",
 	},
 	{
 		name:   "an if with no else",
@@ -104,14 +104,14 @@ var brokenPromises = []struct {
 		want:   "its if has no else",
 	},
 	{
-		name:   "an else that answers with something else",
+		name:   "an else that returns something else",
 		source: person + "{ if true { Person{\"Joana\"}; } else { 0; }; } returns Person;",
-		want:   "the else answers with a number",
+		want:   "the else returns a number",
 	},
 	{
-		name:   "an if arm that answers with something else",
+		name:   "an if arm that returns something else",
 		source: person + "{ if true { 0; } else { Person{\"Joana\"}; }; } returns Person;",
-		want:   "the if answers with a number",
+		want:   "the if returns a number",
 	},
 	{
 		name:   "a shape nobody declared",
@@ -125,7 +125,7 @@ var brokenPromises = []struct {
 	},
 }
 
-func TestABlockThatDoesNotKeepItsPromise(t *testing.T) {
+func TestABlockThatDoesNotKeepItsDeclaration(t *testing.T) {
 	for _, tc := range brokenPromises {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := parseSource(t, tc.source, "main.ar")

--- a/parser/shapes.go
+++ b/parser/shapes.go
@@ -36,8 +36,8 @@ type Declarations struct {
 	// Modules is what `use` declared: alias -> specifier. It belongs to the file that wrote
 	// it and to no other, which is the whole point of the alias being mandatory.
 	Modules map[string]string
-	// Returns is what `returns` promised: the name of a scope -> the shape that calling it
-	// answers with. It is not the shape of the name itself — a deferred scope is an index —
+	// Returns is the name of a scope -> the shape calling it returns. It is not the shape of
+	// the name itself — a deferred scope is an index —
 	// but the shape of what comes back from it.
 	Returns map[string]string
 }
@@ -51,21 +51,21 @@ func NewDeclarations() *Declarations {
 	}
 }
 
-// Import writes down what a module answers with, under names nobody can type.
+// Import writes down what a module returns, under names nobody can type.
 //
-// A promise crossing a module is the shape and its fields together, and both are written the
-// way an identifier of that module is: with the module in front. So two modules answering with
+// What a scope returns crosses a module as the shape and its fields together, and both are written the
+// way an identifier of that module is: with the module in front. So two modules returning
 // an Env each are two shapes, and neither can be confused with an Env declared here.
 func (d *Declarations) Import(specifier string, offer ast.Offer) {
 	for _, shape := range offer.Shapes {
 		d.Shapes[module.Qualify(module.ID(specifier), shape.Name)] = shape.Fields
 	}
-	for _, promise := range offer.Promises {
-		// A promise may name a shape of a third module, which this one never declared, so the
+	for _, returns := range offer.Returns {
+		// A scope may return a shape of a third module, which this one never declared, so the
 		// fields come with it rather than being looked up.
-		shape := module.Qualify(module.ID(specifier), promise.Shape)
-		d.Shapes[shape] = promise.Fields
-		d.Returns[module.Qualify(module.ID(specifier), promise.Scope)] = shape
+		shape := module.Qualify(module.ID(specifier), returns.Shape)
+		d.Shapes[shape] = returns.Fields
+		d.Returns[module.Qualify(module.ID(specifier), returns.Scope)] = shape
 	}
 }
 
@@ -273,7 +273,7 @@ func (p *pr) parseShape(expr ast.Node) (ast.Node, error) {
 // parseShapeName reads the name of a shape where one is expected: `Point`, or `m.Point` for
 // one another module declared.
 //
-// The qualified form is read the same way a qualified value is, and answers with the name the
+// The qualified form is read the same way a qualified value is, and gives the name the
 // tables know it by — which nobody can type, so a Point of this file and a Point of another
 // are two shapes and never one.
 func (p *pr) parseShapeName() (string, token.Token, error) {
@@ -307,11 +307,11 @@ func (p *pr) parseShapeName() (string, token.Token, error) {
 	return shape, name, nil
 }
 
-// shapeOf answers which shape a value is read as, or empty when nothing said. A field is
+// shapeOf says which shape an expression returns, or empty when nothing said. A field is
 // one tape wide, so reading a field of a field is never known.
 //
-// What it sees through is what a promise is worth: a block answers with its last expression,
-// and an if answers with whatever the arm that runs answers with — so both arms have to agree,
+// What it sees through is what makes a declaration worth checking: a block returns its last
+// expression, and an if returns whatever the arm that runs returns — so both arms have to agree,
 // and an if with no else agrees with nothing.
 func (p *pr) shapeOf(node ast.Node) string {
 	switch n := node.(type) {
@@ -328,7 +328,7 @@ func (p *pr) shapeOf(node ast.Node) string {
 		return p.shapeOfLast(n.Body)
 	case ast.CalleeLiteral:
 		// Not the shape of the name, which is a deferred scope, but of what calling it
-		// answers with — which is only known because the scope promised.
+		// returns — which is only known because the scope declared it.
 		return p.declarations.Returns[n.Id.Value]
 	case ast.IfExpression:
 		if n.Else == nil {
@@ -342,7 +342,7 @@ func (p *pr) shapeOf(node ast.Node) string {
 	return ""
 }
 
-// shapeOfLast answers for the expression a body ends with, which is what the body answers with.
+// shapeOfLast says which shape the expression a body ends with returns, which is what the body returns.
 func (p *pr) shapeOfLast(body []ast.Node) string {
 	if len(body) == 0 {
 		return ""
@@ -350,35 +350,35 @@ func (p *pr) shapeOfLast(body []ast.Node) string {
 	return p.shapeOf(body[len(body)-1])
 }
 
-// What `returns` promises, and how the promise is kept.
+// What `returns` declares, and how it is kept.
 //
 // `as` is a claim: the compiler believes it and has nothing to check it against, which is why
 // a wrong one reads the wrong tape and the program carries on. `returns` is the other end —
-// the block says what it answers with, and this refuses the block that does not.
+// the block says what it returns, and this refuses the block that does not.
 //
-// The promise is worth what shapeOf can see through, which is why that is the part that grew.
+// The check is worth what shapeOf can see through, which is why that is the part that grew.
 
-// promises is what the top-level scopes of this file said they answer with, with the fields
-// of each — the only thing about a shape that leaves the file that declared it.
+// returns is what the top-level scopes of this file return, with the fields of each — the only
+// thing about a shape that leaves the file that declared it.
 //
-// It is a join of two tables the parse already filled: which scope promised what, and what
-// each shape is made of. Whoever imports this file needs both halves, since a name is worth
-// nothing without the fields it stands for.
-func (p *pr) promises(nodes []ast.Node) []ast.Promise {
-	found := make([]ast.Promise, 0)
+// It is a join of two tables the parse already filled: what each scope returns, and what each
+// shape is made of. Whoever imports this file needs both halves, since a name is worth nothing
+// without the fields it stands for.
+func (p *pr) returns(nodes []ast.Node) []ast.Returns {
+	found := make([]ast.Returns, 0)
 	for _, node := range nodes {
 		binding, ok := node.(ast.IdentLiteral)
 		if !ok {
 			continue
 		}
-		promised, made := p.declarations.Returns[binding.Id]
-		if !made {
+		shape, known := p.declarations.Returns[binding.Id]
+		if !known {
 			continue
 		}
-		found = append(found, ast.Promise{
+		found = append(found, ast.Returns{
 			Scope:  p.bare(binding.Id),
-			Shape:  promised,
-			Fields: p.declarations.Shapes[promised],
+			Shape:  shape,
+			Fields: p.declarations.Shapes[shape],
 		})
 	}
 	return found
@@ -386,8 +386,8 @@ func (p *pr) promises(nodes []ast.Node) []ast.Promise {
 
 // shapes is every shape this file declared, with what each is made of.
 //
-// All of them cross, and not only the ones a promise names: a file that imports this one may
-// want to build one, or to name one with `as`, and neither goes through a promise.
+// All of them cross, and not only the ones a scope returns: a file that imports this one may
+// want to build one, or to name one with `as`, and neither goes through what a scope returns.
 func (p *pr) shapes(nodes []ast.Node) []ast.Shape {
 	found := make([]ast.Shape, 0)
 	for _, node := range nodes {
@@ -414,60 +414,60 @@ func (p *pr) parseReturns(body []ast.Node, closing token.Token) (string, error) 
 	if _, err := p.EatToken(token.RETURNS); err != nil {
 		return "", err
 	}
-	promised, _, err := p.parseShapeName()
+	declared, _, err := p.parseShapeName()
 	if err != nil {
 		return "", err
 	}
-	if err := p.answersWith(body, promised, "", closing); err != nil {
+	if err := p.returnsWhatItDeclared(body, declared, "", closing); err != nil {
 		return "", err
 	}
-	return promised, nil
+	return declared, nil
 }
 
-// answersWith refuses a body that ends with something other than what was promised.
+// returnsWhatItDeclared refuses a body that ends with something other than what was declared.
 //
-// A `where` names the arm being read, so a promise broken inside a branch says which one; the
+// A `where` names the arm being read, so a declaration broken inside a branch says which one; the
 // block itself has no name and simply ends.
-func (p *pr) answersWith(body []ast.Node, promised, where string, at token.Token) error {
+func (p *pr) returnsWhatItDeclared(body []ast.Node, declared, where string, at token.Token) error {
 	if len(body) == 0 {
-		return brokenPromise(at, promised, where, "nothing")
+		return brokenDeclaration(at, declared, where, "nothing")
 	}
 
 	last := body[len(body)-1]
-	// An if is looked through rather than at: it answers with whatever the arm that runs
-	// answers with, so every arm has to keep the promise. A branch is nested ifs by the time
+	// An if is looked through rather than at: it returns whatever the arm that runs
+	// returns, so every arm has to keep the declaration. A branch is nested ifs by the time
 	// anything reads the tree, so this covers it too.
 	if answer, ok := last.(ast.IfExpression); ok {
 		if answer.Else == nil {
-			return token.NewError(at, "this block answers with %s and its if has no else at line %d and column %d: one path answers with nothing",
-				promised, at.GetLine(), at.GetColumn())
+			return token.NewError(at, "this block returns %s and its if has no else at line %d and column %d: one path returns nothing",
+				declared, at.GetLine(), at.GetColumn())
 		}
-		if err := p.answersWith(answer.Body, promised, "the if", at); err != nil {
+		if err := p.returnsWhatItDeclared(answer.Body, declared, "the if", at); err != nil {
 			return err
 		}
-		return p.answersWith(answer.Else.Body, promised, "the else", at)
+		return p.returnsWhatItDeclared(answer.Else.Body, declared, "the else", at)
 	}
 
-	if p.shapeOf(last) == promised {
+	if p.shapeOf(last) == declared {
 		return nil
 	}
-	return brokenPromise(at, promised, where, describeAnswer(last))
+	return brokenDeclaration(at, declared, where, describeReturn(last))
 }
 
-// brokenPromise says what was promised and what is there instead.
-func brokenPromise(at token.Token, promised, where, answer string) error {
+// brokenDeclaration says what was declared and what is there instead.
+func brokenDeclaration(at token.Token, declared, where, returned string) error {
 	if where == "" {
-		return token.NewError(at, "this block answers with %s and ends with %s at line %d and column %d",
-			promised, answer, at.GetLine(), at.GetColumn())
+		return token.NewError(at, "this block returns %s and ends with %s at line %d and column %d",
+			declared, returned, at.GetLine(), at.GetColumn())
 	}
-	return token.NewError(at, "this block answers with %s and %s answers with %s at line %d and column %d",
-		promised, where, answer, at.GetLine(), at.GetColumn())
+	return token.NewError(at, "this block returns %s and %s returns %s at line %d and column %d",
+		declared, where, returned, at.GetLine(), at.GetColumn())
 }
 
-// describeAnswer names what a node answers with, for the message of a promise that was not
+// describeReturn names what a node returns, for the message of a declaration that was not
 // kept. It is the reader's words rather than the tree's: somebody reading the error is looking
 // at what they wrote, not at a node type.
-func describeAnswer(node ast.Node) string {
+func describeReturn(node ast.Node) string {
 	switch n := node.(type) {
 	case ast.NumberLiteral:
 		return "a number"

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -112,10 +112,10 @@ func (r *Resolver) Resolve(entry string) ([]module.Module, error) {
 func OffersOf(modules []module.Module) map[string]ast.Offer {
 	offers := make(map[string]ast.Offer, len(modules))
 	for _, each := range modules {
-		if len(each.Tree.Promises) == 0 && len(each.Tree.Shapes) == 0 {
+		if len(each.Tree.Returns) == 0 && len(each.Tree.Shapes) == 0 {
 			continue
 		}
-		offers[string(each.ID)] = ast.Offer{Shapes: each.Tree.Shapes, Promises: each.Tree.Promises}
+		offers[string(each.ID)] = ast.Offer{Shapes: each.Tree.Shapes, Returns: each.Tree.Returns}
 	}
 	return offers
 }

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -155,7 +155,7 @@ type BooleanExpression struct {
 
 type BlockExpression struct {
 	mark
-	// Returns is the shape this block promised to answer with, and empty when it promised
+	// Returns is the shape this block declared it returns, and empty when it declared
 	// nothing. It is checked where it is written and never reaches an instruction: like the
 	// declaration it names, it is read while compiling and dropped.
 	Returns string `json:"returns,omitempty"`
@@ -241,17 +241,17 @@ type AST struct {
 	// somewhere else. Only whoever holds the other modules can answer that, which is why the
 	// parse hands it over instead of deciding.
 	References []Reference `json:"references,omitempty"`
-	// Promises is what this file's top-level scopes said they answer with, and Shapes is every
-	// shape it declared. Both leave with the tree for whoever imports this file.
-	Promises []Promise `json:"promises,omitempty"`
-	Shapes   []Shape   `json:"shapes,omitempty"`
+	// Returns is what this file's top-level scopes return, and Shapes is every shape it
+	// declared. Both leave with the tree for whoever imports this file.
+	Returns []Returns `json:"returns,omitempty"`
+	Shapes  []Shape   `json:"shapes,omitempty"`
 }
 
 // An Offer is what a module hands whoever imports it, as far as shapes are concerned: the
-// shapes it declares, and what its scopes said they answer with.
+// shapes it declares, and what its scopes return.
 type Offer struct {
-	Shapes   []Shape   `json:"shapes,omitempty"`
-	Promises []Promise `json:"promises,omitempty"`
+	Shapes  []Shape   `json:"shapes,omitempty"`
+	Returns []Returns `json:"returns,omitempty"`
 }
 
 // A Shape is a shape a module declared, and what it is made of.
@@ -264,14 +264,17 @@ type Shape struct {
 	Fields []string `json:"fields"`
 }
 
-// A Promise is what one exported scope said it answers with, and what that shape is made
-// of.
+// Returns is what one exported scope returns, and what that shape is made of.
 //
-// It is the only thing about a shape that leaves the file that declared it. A shape's name
-// is read while a file is parsed and dropped, so a module that answers with one has to hand
-// over the fields as well — otherwise whoever imports it has a run of tapes and no way to
-// turn a name into an index.
-type Promise struct {
+// It is the only thing about a shape that leaves the file that declared it. A shape's name is
+// read while a file is parsed and dropped, so a module that returns one has to hand over the
+// fields as well — otherwise whoever imports it has a run of tapes and no way to turn a name
+// into an index.
+//
+// The name is plural because that is the word: a scope returns, and this is what it returns.
+// It used to be called a promise, which came from another tradition and said nothing this
+// language means — see "The words" in docs/contributing/architecture.md.
+type Returns struct {
 	// Scope is the name the scope is bound to, as the module's own file typed it.
 	Scope  string   `json:"scope"`
 	Shape  string   `json:"shape"`


### PR DESCRIPTION
First layer of the rename the words rule asks for (merged in #142). Pure rename — nothing a program does changes.

| before | after |
|---|---|
| `ast.Promise` | `ast.Returns` |
| `Tree.Promises`, `Offer.Promises` | `Tree.Returns`, `Offer.Returns` |
| `answersWith` | `returnsWhatItDeclared` |
| `brokenPromise` / `describeAnswer` | `brokenDeclaration` / `describeReturn` |

The type had to move as one piece: it is public and crosses a module, so the resolver, the REPL and the language server come along. Thirteen sites outside tests.

## What a person reads

```
this block answers with Person and ends with a number
this block returns Person and ends with a number
```

`docs/language-design.md` declares that message in a snippet the documentation check runs — so the doc and the compiler were made to agree again rather than one being left behind. **The docs test caught it**, which is the second time this week that check has earned its place.

## An exception the rule did not name

I nearly renamed straight through this:

```go
// sameKind answers whether b is the kind of node a is
```

That is this project's voice for saying what a **Go helper** does — not a construct of the language giving a value — and there are hundreds of them. Renaming those would have been 400 comments of churn with nothing to do with the collision the rule exists to fix.

So the rule now says how to tell: **when the thing giving a value is an Aurora construct, it returns.** Prose about a helper, and a server answering a request, are a different word wearing the same spelling. Both stay, both named.

A rule that does not name its exceptions is a rule somebody breaks by accident — and this one was nearly broken twice while it was being written.

`make check` — 0 issues.

## Next

Two layers left: the pipeline (`wire/ir`, `emitter`, `builder/evm`, `evaluator`), where "answers" is the verb of terminators and **is** the language's concept; then `hosting` and `cmd`, preserving the protocol sense in the language server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)