### PR TITLE
returns is the word, in the pipeline

### DIFF
--- a/builder/evm/blocks.go
+++ b/builder/evm/blocks.go
@@ -123,9 +123,9 @@ func writeTerminator(bs io.Writer, term ir.Terminator, order []ir.BlockID, at ma
 				return err
 			}
 		}
-		write := WriteReturn
+		write := WriteReturnToCaller
 		if scope.Answers {
-			write = WriteAnswer
+			write = WriteReturnToChain
 		}
 		_, err := write(bs)
 		return err

--- a/builder/evm/build_test.go
+++ b/builder/evm/build_test.go
@@ -130,7 +130,7 @@ func TestBuildWithoutCallables(t *testing.T) {
 	if runtime[0] == OpPush1 && len(runtime) > 2 && runtime[2] == OpCallDataLoad {
 		t.Error("no dispatcher should be emitted when there is no callable")
 	}
-	// The top of a program is a block, and a block answers with what it computed. It used to
+	// The top of a program is a block, and a block returns what it computed. It used to
 	// stop instead, throwing the value away and leaving a dead byte at the end of every scope.
 	if runtime[len(runtime)-1] != OpReturn {
 		t.Errorf("runtime should answer, got %#x", runtime[len(runtime)-1])
@@ -331,8 +331,8 @@ func TestBuildIsDeterministic(t *testing.T) {
 	}
 }
 
-// A block with nothing in it answers with the neutral value. The top of a program is a block
-// like any other, so a contract whose top does nothing still answers rather than falling off
+// A block with nothing in it returns the neutral value. The top of a program is a block
+// like any other, so a contract whose top does nothing still returns rather than falling off
 // the end of its own code.
 func TestAnEmptyBlockAnswersWithNothing(t *testing.T) {
 	buf := bytes.NewBuffer(nil)

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -54,8 +54,8 @@ const (
 	// FRAME_START_SIZE is what writing where the first frame begins measures: a push of the
 	// address, a push of the slot, and the store.
 	FRAME_START_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
-	// ANSWER_SIZE is what handing a value to the chain measures.
-	ANSWER_SIZE = PUSH_ONE_SIZE + 1 + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1
+	// RETURN_TO_CHAIN_SIZE is what handing a value to the chain measures.
+	RETURN_TO_CHAIN_SIZE = PUSH_ONE_SIZE + 1 + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1
 )
 
 type Dispatcher struct {

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -101,7 +101,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteAnswer(want)
+				WriteReturnToChain(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}
@@ -121,7 +121,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteAnswer(want)
+				WriteReturnToChain(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}
@@ -144,7 +144,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 2 * MEMORY_SLOT_SIZE}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteAnswer(want)
+				WriteReturnToChain(want)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -232,11 +232,11 @@ func ResolveOperandsOrder(insts []ir.Instruction, tapeSize int) []ir.Instruction
 		case produces(op) && taken[label] > 0:
 			hold(label, sequence)
 		case produces(op):
-			// Nobody takes it, so there is nowhere to move it to: it is the answer of the
+			// Nobody takes it, so there is nowhere to move it to: it is what is returned by the
 			// scope it was written in, and it stays where it was written.
 			out = append(out, sequence...)
 		case op == ir.OpIdent && taken[label] > 0:
-			// A scope whose last expression is a binding answers with the neutral value,
+			// A scope whose last expression is a binding returns the neutral value,
 			// which is what the evaluator answers. On the stack that has to be pushed: the
 			// binding itself left nothing there.
 			sequence = append(sequence, ir.NewInstruction(inst.GetLabel(), ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -99,7 +99,7 @@ func WriteIdent(w io.Writer, names map[string]int, ident []byte) (int, error) {
 //	ident base = 30;
 //	ident show = defer { base * 2; };
 //
-// answered 0 on a chain where the program answers 60, and said nothing about it.
+// answered 0 on a chain where the program returns 60, and said nothing about it.
 //
 // What would let it work is a static link: the frame carrying where the scope was written, and
 // a name from outside read from there. That is a design of its own and it is written down in
@@ -117,12 +117,12 @@ func WriteLoad(w io.Writer, names map[string]int, ident []byte) (int, error) {
 	return w.Write([]byte{OpMemoryLoad})
 }
 
-// WriteAnswer hands the value on the stack to the chain.
+// WriteReturnToChain hands the value on the stack to the chain.
 //
 // It goes through a slot of its own rather than through the first one, which holds where the
 // running scope's frame starts: writing the answer there would lose the frame in the act of
 // answering.
-func WriteAnswer(w io.Writer) (int, error) {
+func WriteReturnToChain(w io.Writer) (int, error) {
 	if _, err := w.Write([]byte{OpPush1, RETURN_SCRATCH}); err != nil {
 		return 0, err
 	}
@@ -132,14 +132,14 @@ func WriteAnswer(w io.Writer) (int, error) {
 	return w.Write([]byte{OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn})
 }
 
-// WriteReturn ends a scope: the value it answers with is on the stack, and the address to go
+// WriteReturn ends a scope: the value it returns is on the stack, and the address to go
 // back to is under it.
 //
 // It goes back to whoever called and never to the chain, even when the caller is the way in
 // from a transaction. That is what lets one body serve both: a scope called by another has to
 // hand its value over and let that one carry on, and only the way in from a transaction ends
 // the call — which it does in the epilogue, where it belongs.
-func WriteReturn(w io.Writer) (int, error) {
+func WriteReturnToCaller(w io.Writer) (int, error) {
 	return w.Write([]byte{OpSwap1, OpJump})
 }
 
@@ -171,7 +171,7 @@ func WriteFrameAddress(w io.Writer, offset int) error {
 //	           PUSH2 <internal>
 //	           JUMP
 //	epilogue:  JUMPDEST          <- the body comes back here, value on the stack
-//	           <answer the chain>
+//	           <return to the chain>
 //	internal:  JUMPDEST          <- another scope jumps here, having written the frame
 //	           <body>            feed(n) reads the frame, whoever filled it
 //	           SWAP1; JUMP       back to whoever called
@@ -191,7 +191,7 @@ func WriteFrameAddress(w io.Writer, offset int) error {
 // hand a contract a value its own language cannot hold.
 //
 // The body answers to whoever called it and never to the chain, even when the caller is the
-// prologue: answering the chain is what the epilogue does, and keeping it there is what lets
+// prologue: returning to the chain is what the epilogue does, and keeping it there is what lets
 // the same body serve a transaction and a scope.
 func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal int) error {
 	for at := 0; at < reads; at++ {
@@ -223,13 +223,13 @@ func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal
 }
 
 // WriteScopeEpilogue emits what a transaction's way in comes back to: the value the scope
-// answered with is on the stack, and it goes to the chain.
+// returned is on the stack, and it goes to the chain.
 //
 // It is here and not at the end of the body because the body does not know who called it. A
 // scope called by another has to hand its value back and let that one carry on; only the way
 // in from a transaction ends the call.
 func WriteScopeEpilogue(w io.Writer) error {
-	_, err := WriteAnswer(w)
+	_, err := WriteReturnToChain(w)
 	return err
 }
 
@@ -500,7 +500,7 @@ func writeRemainingLength(w io.Writer, inst ir.Instruction, tapeSize int) error 
 // the language says a shape is. So on a chain it is a word like every other value, with the
 // first tape at the far end and the last one at the bottom, which is where a tape sits inside
 // a word anyway. Point{10, 20} at a tape of eight bytes is 10 << 64 | 20, the same number the
-// evaluator answers, so a scope answering a run answers the same thing on both sides.
+// evaluator answers, so a scope returning a run answers the same thing on both sides.
 //
 // That is also the ceiling: a word is thirty-two bytes and a run is as many tapes as it has,
 // so a shape of five fields at the default tape does not fit, and the builder refuses it
@@ -661,7 +661,7 @@ func writeCallOut(w io.Writer, inst ir.Instruction, scope Scope, back int, calle
 		}
 	}
 
-	// A position the callee reads and this call did not fill has to answer with zeros, which
+	// A position the callee reads and this call did not fill has to return zeros, which
 	// is what the language answers for reading past what was applied. On the way in from a
 	// transaction that is free — the calldata gives zeros past its end — but a frame is
 	// memory an earlier activation already used, so what is left there is the last call's
@@ -725,7 +725,7 @@ func ScopeInternalAt(base, params, tapeSize int) (int, error) {
 	}
 	// The way in opens with a JUMPDEST the dispatcher lands on; the prologue follows; what it
 	// comes back to opens with one of its own, and the way in from another scope with a third.
-	return base + 1 + int(measured) + 1 + ANSWER_SIZE, nil
+	return base + 1 + int(measured) + 1 + RETURN_TO_CHAIN_SIZE, nil
 }
 
 // WriteScope emits a scope whole: the way in from a transaction, what that way comes back to,
@@ -742,7 +742,7 @@ func WriteScope(bs io.Writer, blocks []ir.Block, entry ir.BlockID, tapeSize, bas
 	if err != nil {
 		return err
 	}
-	epilogue := internal - 1 - ANSWER_SIZE
+	epilogue := internal - 1 - RETURN_TO_CHAIN_SIZE
 
 	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
 		return err
@@ -1212,7 +1212,7 @@ func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, s
 		}
 	}
 
-	// A comparison answers with a tape like any other value, and the EVM already answers
+	// A comparison returns a tape like any other value, and the EVM already answers
 	// these with one or zero, which is what a tape holding true or false is.
 	if compare, ok := comparisons[op]; ok {
 		if _, err := bs.Write(compare); err != nil {

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -194,11 +194,11 @@ func TestWriteGetArg(t *testing.T) {
 }
 
 // Ending a scope goes back to whoever called it: the value is on the stack and the address to
-// go back to is under it. It never answers the chain — that is the epilogue's, and keeping it
+// go back to is under it. It never returns to the chain — that is the epilogue's, and keeping it
 // there is what lets one body serve a transaction and a scope alike.
-func TestWriteReturn(t *testing.T) {
+func TestWriteReturnToCaller(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteReturn(bs); err != nil {
+	if _, err := WriteReturnToCaller(bs); err != nil {
 		t.Fatalf("writing the return: %v", err)
 	}
 	if got, want := bs.Bytes(), []byte{OpSwap1, OpJump}; !bytes.Equal(got, want) {
@@ -209,17 +209,17 @@ func TestWriteReturn(t *testing.T) {
 // Answering the chain goes through a slot of its own, not the first one: that holds where the
 // running scope's frame begins, and writing the answer there would lose the frame in the act
 // of answering.
-func TestWriteAnswer(t *testing.T) {
+func TestWriteReturnToChain(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteAnswer(bs); err != nil {
+	if _, err := WriteReturnToChain(bs); err != nil {
 		t.Fatalf("writing the answer: %v", err)
 	}
 	expected := []byte{OpPush1, RETURN_SCRATCH, OpMemoryStore, OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn}
 	if got := bs.Bytes(); !bytes.Equal(got, expected) {
 		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 	}
-	if bs.Len() != ANSWER_SIZE {
-		t.Errorf("it measures %d and says it measures %d", bs.Len(), ANSWER_SIZE)
+	if bs.Len() != RETURN_TO_CHAIN_SIZE {
+		t.Errorf("it measures %d and says it measures %d", bs.Len(), RETURN_TO_CHAIN_SIZE)
 	}
 }
 

--- a/emitter/blocks.go
+++ b/emitter/blocks.go
@@ -208,7 +208,7 @@ func (b *blocking) branch(id ir.BlockID, params []ir.Label, held []ir.Instructio
 // arm turns one side of a branch into a block that hands its value to the block the two meet
 // at.
 //
-// What it answers with is its own closing return — the one naming the "if" rather than a
+// What it returns is its own closing return — the one naming the "if" rather than a
 // scope, which used to mean "the value of this arm". It is taken off the end rather than
 // searched for, because a branch written inside this one has returns of its own and they
 // belong to it.

--- a/emitter/blocks_test.go
+++ b/emitter/blocks_test.go
@@ -156,9 +156,9 @@ func TestBothArmsHandTheirValueToTheSameBlock(t *testing.T) {
 		t.Errorf("the block they meet at takes %d values, want the one each arm hands it", len(meet.Params))
 	}
 	// It names the one it takes, and that name is what the value is known as after the branch:
-	// here the scope answers with it, without knowing which arm computed it.
+	// here the scope returns it, without knowing which arm computed it.
 	if len(meet.Params) == 1 && string(meet.Term.Value.Bytes()) != string(meet.Params[0]) {
-		t.Errorf("it answers with %q and takes %q, want them to be the same value",
+		t.Errorf("it returns %q and takes %q, want them to be the same value",
 			meet.Term.Value.Bytes(), meet.Params[0])
 	}
 }

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -25,7 +25,7 @@ func GenerateLabel(tc *int) []byte {
 }
 
 // originOf answers where a token was written, so an instruction can point at it. A nil token
-// answers with nothing, which is what a phase after this one reads as "no place to point at".
+// returns nothing, which is what a phase after this one reads as "no place to point at".
 func originOf(t token.Token) ir.Origin {
 	if t == nil {
 		return ir.Origin{}
@@ -117,7 +117,7 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 		return emitIdentifierLiteral(tc, insts, n, tapeSize)
 	}
 
-	// A node this does not know emits nothing, and answers with the neutral value.
+	// A node this does not know emits nothing, and returns the neutral value.
 	return byteutil.FalseTape(tapeSize)
 }
 
@@ -243,7 +243,7 @@ func emitTapeBracketExpression(tc *int, insts *[]ir.Instruction, n ast.TapeBrack
 
 // emitShapeDeclaration answers the neutral value: a declaration does no work.
 func emitShapeDeclaration(tc *int, insts *[]ir.Instruction, _ ast.ShapeDeclaration, tapeSize int) ir.Label {
-	// A declaration emits no work. It still answers with a value, because everything in
+	// A declaration emits no work. It still returns a value, because everything in
 	// Aurora is an expression, and the neutral one is what a declaration is worth.
 	l := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
@@ -363,7 +363,7 @@ func emitIfExpression(tc *int, insts *[]ir.Instruction, n ast.IfExpression, tape
 			eul = EmitInstruction(tc, &euze, inst, tapeSize)
 		}
 	} else {
-		// An if with no else answers with the neutral value on the path where the test
+		// An if with no else returns the neutral value on the path where the test
 		// fails, and the arm says so rather than leaving whoever reads the IR to know it.
 		// A consumer that has to put a value somewhere — a stack — has nothing to put
 		// there otherwise, and one that does not would be reading an operand naming

--- a/emitter/golden_test.go
+++ b/emitter/golden_test.go
@@ -61,7 +61,7 @@ func TestEmittedProgramMatchesTheGolden(t *testing.T) {
 	}
 }
 
-// The golden has to be able to fail, or it pins nothing: an emitter that answered with an
+// The golden has to be able to fail, or it pins nothing: an emitter that returned an
 // empty program would pass a test that only checked it did not error.
 func TestGoldenIsNotEmpty(t *testing.T) {
 	want, err := os.ReadFile(filepath.Join("testdata", "wide.ir"))

--- a/emitter/warning.go
+++ b/emitter/warning.go
@@ -79,7 +79,7 @@ func checkAsserts(nodes []ast.Node) []diag.Warning {
 // of it. But a body says how many positions it can address — the highest index it feeds, plus
 // one — and that number is known where the body is written.
 //
-// Applying fewer is not an error and will not become one. A position nobody wrote answers with
+// Applying fewer is not an error and will not become one. A position nobody wrote returns
 // a tape of zeros, which is a defined answer and a reasonable thing to want. It is also almost
 // always a mistake, and since that answer is silent, this is the only place it can be said out
 // loud.
@@ -108,13 +108,13 @@ func checkAppliedValues(nodes []ast.Node) []diag.Warning {
 	return warnings
 }
 
-// appliedValuesWarning names the first position that will answer with zeros, which is the one
+// appliedValuesWarning names the first position that will return zeros, which is the one
 // whoever wrote the call is least expecting. It points at the call rather than at the scope:
 // the scope is fine, and the call is what has to change.
 func appliedValuesWarning(call ast.CalleeLiteral, positions int) diag.Warning {
 	applied := len(call.Params)
 	warning := diag.Warning{Message: fmt.Sprintf(
-		"%s reads %d positions and %d were applied: feed(%d) answers with a tape of zeros",
+		"%s reads %d positions and %d were applied: feed(%d) returns a tape of zeros",
 		call.Id.Value, positions, applied, applied)}
 	if call.Id.Token != nil {
 		warning.Line = call.Id.Token.GetLine()

--- a/emitter/warning_test.go
+++ b/emitter/warning_test.go
@@ -163,7 +163,7 @@ func TestTheWalkReachesEveryExpression(t *testing.T) {
 }
 
 // A scope has no arity, but a body says how many positions it can address: the highest index
-// it feeds, plus one. Applying fewer is not an error — what was not applied answers with a
+// it feeds, plus one. Applying fewer is not an error — what was not applied returns a
 // tape of zeros, which is a defined answer — but that answer is silent, so it is said here.
 func TestApplyingFewerValuesThanTheScopeReads(t *testing.T) {
 	source := "ident sum = defer { feed(0) + feed(1); };\nprintb sum(5);\n"

--- a/evaluator/defer_value_test.go
+++ b/evaluator/defer_value_test.go
@@ -94,7 +94,7 @@ func TestCallingSomethingThatIsNotADeferFails(t *testing.T) {
 	}{
 		{name: "a number with no scope behind it", source: "ident a = 777;\na();"},
 		// The value of a block is a number like any other, so what makes it callable or not
-		// is whether it names a block — the same bargain as below. A block answering 1 is
+		// is whether it names a block — the same bargain as below. A block returning 1 is
 		// answering the number of a block, and calling it is calling that scope.
 		{name: "the value of a block that names none", source: "ident a = { 777; };\na();"},
 	}

--- a/evaluator/dispatch_test.go
+++ b/evaluator/dispatch_test.go
@@ -227,7 +227,7 @@ func TestExecuteInstructionDispatchesToTheRightOperation(t *testing.T) {
 	}
 }
 
-// recorder is a printer that keeps what it was asked to print and answers with what it was
+// recorder is a printer that keeps what it was asked to print and returns what it was
 // told to answer. The evaluator no longer knows how a tape is shown — a host says that — so
 // what a test here can check is which port an opcode reaches for, and what comes back.
 type recorder struct {
@@ -291,7 +291,7 @@ func TestExecuteInstructionDispatchesThePrints(t *testing.T) {
 	}
 }
 
-// A print is an expression, so it answers with a value like everything else in Aurora — the
+// A print is an expression, so it returns a value like everything else in Aurora — the
 // one the printer gives back. Answering with nothing would make "printd x + 1" mean nothing.
 func TestAPrintAnswersWithWhatThePrinterGaveBack(t *testing.T) {
 	printer := &recorder{says: byteutil.FromUint64(7)}
@@ -355,7 +355,7 @@ func TestExecuteInstructionDispatchesAnAssert(t *testing.T) {
 
 // An error raised by an operation comes back out of the dispatch rather than being swallowed
 // on the way. Both of these also prove the opcode reached the operation it names: nothing
-// else answers with these words.
+// else returns these words.
 func TestExecuteInstructionCarriesAnErrorBack(t *testing.T) {
 	cases := []struct {
 		name string

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -18,7 +18,7 @@ import (
 //
 // The evaluator does not know what printing is — whether it reaches a terminal, a page or
 // nothing at all — and it does not choose. It hands over the tape and keeps what comes back,
-// which is the value the expression answers with.
+// which is the value the expression returns.
 type Printer interface {
 	Print(value []byte) ([]byte, error)
 }
@@ -285,7 +285,7 @@ func (e *Evaluator) tapeSlice(left, right ir.Operand) ([]byte, int) {
 // The three print builtins read the same tape three ways, and the evaluator knows none of the
 // three: it hands the value to whoever was given for that reading and keeps what came back.
 //
-// What comes back is the value of the expression. Everything in Aurora answers with
+// What comes back is the value of the expression. Everything in Aurora returns
 // something, and a print used to be the exception — it left nothing under its label, which is
 // why a line of "printd 42" in the REPL showed no value at all.
 func (e *Evaluator) EvaluatePrintBytes(label []byte, left ir.Operand) error {
@@ -395,7 +395,7 @@ func (e *Evaluator) EvaluateCallOver(label []byte, operands []ir.Operand) error 
 
 	// A name bound to a scope holds the number of a block, and running the scope is running
 	// from there. A value that names no block is a value with no scope behind it — a number,
-	// or what a block answered with — and block zero is the top of the program, which nothing
+	// or what a block returned — and block zero is the top of the program, which nothing
 	// is bound to.
 	if int(index) >= len(e.blocks) || index == 0 {
 		return fmt.Errorf("call: value is not a deferred scope")
@@ -586,7 +586,7 @@ func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.Point, until func(ir.Po
 
 		term := block.Term
 		if term.Kind == ir.Ret {
-			return e.answered(term.Value), nil
+			return e.returned(term.Value), nil
 		}
 
 		target := term.Targets[0]
@@ -600,7 +600,7 @@ func (e *Evaluator) RunBlocks(blocks []ir.Block, from ir.Point, until func(ir.Po
 // answered reads what a terminator carries, and answers the neutral tape where there is
 // nothing to read. An empty block still has a value, and so does a scope whose last expression
 // bound a name rather than computing one.
-func (e *Evaluator) answered(operand ir.Operand) []byte {
+func (e *Evaluator) returned(operand ir.Operand) []byte {
 	if value := e.value(operand); value != nil {
 		return value
 	}
@@ -632,7 +632,7 @@ func (e *Evaluator) arrive(block ir.Block, target ir.Target) ir.BlockID {
 
 	values := make([][]byte, 0, len(target.Args))
 	for _, arg := range target.Args {
-		values = append(values, e.answered(arg))
+		values = append(values, e.returned(arg))
 	}
 
 	e.environ = e.environ.GetPrevious()
@@ -688,7 +688,7 @@ func (e *Evaluator) ExecuteInstruction(inst ir.Instruction) error {
 
 type NewEvaluatorOptions struct {
 	// A Printer per reading of a tape. What each one does with the value, and what it
-	// answers with, is the host's business: the evaluator only asks and keeps the answer.
+	// returns, is the host's business: the evaluator only asks and keeps the answer.
 	PrintBytes   Printer
 	PrintChars   Printer
 	PrintDecimal Printer

--- a/evaluator/evaluator_test.go
+++ b/evaluator/evaluator_test.go
@@ -366,7 +366,7 @@ func runEvaluateCase(t *testing.T, cases []EvaluateCase, options RunEvaluateCase
 				return
 			}
 
-			// What the program answers with is the value of its last expression, and the
+			// What the program returns is the value of its last expression, and the
 			// emitter says which label that landed under. A test asking for a label it
 			// guessed is pinning how the emitter numbers them, which is not what it means
 			// to check.
@@ -1170,7 +1170,7 @@ ident answer = outer(7, 99);`,
 					t.Fatalf("evaluating: %v", err)
 				}
 				// inner reads position 1 and one value was applied to it, so it reads past
-				// the end and answers with zeros: one, after the addition. It used to read
+				// the end and returns zeros: one, after the addition. It used to read
 				// 99 — the second value applied to outer, which inner never saw applied to
 				// itself — and answer 100.
 				for _, value := range returns {

--- a/wire/ir/block.go
+++ b/wire/ir/block.go
@@ -49,7 +49,7 @@ type Block struct {
 type TermKind byte
 
 const (
-	// Ret ends the block and answers with Value. For a scope's last block that is the scope's
+	// Ret ends the block and returns Value. For a scope's last block that is the scope's
 	// answer.
 	Ret TermKind = iota
 	// Br goes to the one block in Targets.
@@ -71,7 +71,7 @@ type Terminator struct {
 	Kind TermKind
 	// Cond is what BrIf chooses on.
 	Cond Operand
-	// Value is what Ret answers with.
+	// Value is what Ret returns.
 	Value Operand
 	// Targets is where control goes: one block for Br, two for BrIf, none for Ret.
 	Targets []Target

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -76,12 +76,12 @@ func Reaches(blocks []Block, from BlockID) []BlockID {
 // on to another.
 //
 // It is how one file follows another. Each is compiled as a program of its own and ends by
-// answering, and a program made of several runs them in the order their dependencies were
+// returning, and a program made of several runs them in the order their dependencies were
 // found — so every ending in the first is turned into going to the second, and only the last
-// file still answers.
+// file still returns.
 //
 // A scope is untouched by this: its blocks are not reached from the top of a file, because a
-// binding names a block and naming is not going. So a scope still ends by answering, which is
+// binding names a block and naming is not going. So a scope still ends by returning, which is
 // what a call needs it to do.
 func GoesOnTo(blocks []Block, from, next BlockID) []Block {
 	for _, id := range Reaches(blocks, from) {

--- a/wire/ir/blocks_test.go
+++ b/wire/ir/blocks_test.go
@@ -95,7 +95,7 @@ func TestShiftedMovesEverythingThatNamesABlock(t *testing.T) {
 }
 
 // One file carries on into the next, and a scope is untouched by that — it is named rather than
-// gone to, so it still ends by answering, which is what a call needs it to do.
+// gone to, so it still ends by returning, which is what a call needs it to do.
 func TestGoesOnToTurnsEndingsIntoGoings(t *testing.T) {
 	blocks := []Block{
 		{ID: 0, Insts: []Instruction{NewInstruction([]byte("a"), 1, BlockOf(2), Nothing())}, Term: Goes(1)},

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -25,7 +25,7 @@ const (
 	OpSave  // Imm -> the bytes themselves, which is how a literal reaches the program
 	OpLoad  // Name -> what the name is bound to, looked up where the program is running
 
-	// Comparison. The answer is a tape like any other: false is all zeros.
+	// Comparison. What it returns is a tape like any other: false is all zeros.
 	OpDiff    // Ref, Ref -> whether the two differ
 	OpEquals  // Ref, Ref -> whether the two are the same
 	OpBigger  // Ref, Ref -> whether the first is greater
@@ -40,7 +40,7 @@ const (
 	OpGetFeed // Imm -> the value at that position of the vector applied to this scope, or a
 	//            tape of zeros where nothing was applied
 
-	OpCall // Name -> runs the scope that name reaches, and leaves what it answered
+	OpCall // Name -> runs the scope that name reaches, and leaves what it returned
 
 	// Printing. Three readings of one tape, and the whole difference between them is which
 	// opcode it is. They are logs, and they produce no bytecode, by decision.

--- a/wire/ir/operand.go
+++ b/wire/ir/operand.go
@@ -82,7 +82,7 @@ func (o Operand) Kind() Kind { return o.kind }
 
 // Bytes answers the operand as the bytes it carries.
 //
-// An operand that is not there answers with an empty slice rather than nil, because that is
+// An operand that is not there returns an empty slice rather than nil, because that is
 // what every reader of the IR has always been handed and none of them checks.
 func (o Operand) Bytes() []byte {
 	if o.bytes == nil {

--- a/wire/ir/operand_test.go
+++ b/wire/ir/operand_test.go
@@ -36,12 +36,12 @@ func TestAnOperandSaysWhatItIs(t *testing.T) {
 	}
 }
 
-// An operand that is not there answers with an empty slice, never nil: that is what every
+// An operand that is not there returns an empty slice, never nil: that is what every
 // reader of the IR has always been handed, and none of them checks.
 func TestAnOperandThatIsNotThereStillAnswersWithBytes(t *testing.T) {
 	for _, operand := range []Operand{Nothing(), RefTo(nil), ImmOf(nil, 8)} {
 		if got := operand.Bytes(); got == nil {
-			t.Errorf("%v answered with nil", operand)
+			t.Errorf("%v returned nil", operand)
 		}
 	}
 }

--- a/wire/ir/origin.go
+++ b/wire/ir/origin.go
@@ -11,7 +11,7 @@ package ir
 // it was parsed from, and until now the emitter held that and let it go.
 //
 // Zero means the emitter had nothing to point at — a value it invented rather than one
-// somebody wrote, like the neutral tape a declaration answers with. Line and Column are
+// somebody wrote, like the neutral tape a declaration returns. Line and Column are
 // 1-based, matching diag.Warning and the token positions it comes from.
 type Origin struct {
 	Line   int

--- a/wire/ir/program.go
+++ b/wire/ir/program.go
@@ -3,7 +3,7 @@ package ir
 import "github.com/guiferpa/aurora/wire/diag"
 
 // Expression is one top-level expression of a program: where it begins among the blocks, and
-// the label the value it answers with ends up under.
+// the label the value it returns ends up under.
 //
 // A caller that wants to report values in source order needs it. Reading what a program left
 // behind after the whole of it has run cannot give that order: what print wrote along the way


### PR DESCRIPTION
Second layer. What a block, a scope, an arm or a terminator gives back is **returns** everywhere now — `wire/ir`, the emitter, the builder, the evaluator.

## Two names that carried the confusion

A scope ends two ways: it goes back to whoever called it, or it ends the call and hands the value to the chain. They were `WriteReturn` and `WriteAnswer` — which reads as two different things.

They are the same thing with two destinations:

| before | after |
|---|---|
| `WriteReturn` | `WriteReturnToCaller` |
| `WriteAnswer` | `WriteReturnToChain` |
| `ANSWER_SIZE` | `RETURN_TO_CHAIN_SIZE` |
| `e.answered(...)` | `e.returned(...)` |

Naming them properly says what they are, which the old pair actively hid.

## The prose, decided by the rule rather than by a regex

**"answers with" is always a construct giving a value** — 33 of them, all `returns` now. Plus the phrases where the subject is an Aurora construct: *a block either answers, goes somewhere, or chooses* → *returns*; *a scope still ends by answering* → *by returning*; *the position will answer with zeros* → *will return zeros*.

**And these stay**, because the exception in the rule exists for exactly them:

```go
// Shifted answers the same blocks, numbered from an offset.
// GetOperands answers every operand, in the order they were written.
```

That is this project's voice for saying what a **Go helper** does. Renaming those would have been churn with nothing to do with the collision the rule fixes.

## Proof

`make check` — 0 issues, and the differential harness passes, which is what says nothing a program does changed.

## Next

One layer left: `hosting` and `cmd`, with the messages a person reads — preserving the protocol sense in the language server, where a server answers a request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)