### PR TITLE
returns is the word, in hosting and the docs

### DIFF
--- a/cmd/aurorals/modules.go
+++ b/cmd/aurorals/modules.go
@@ -23,7 +23,7 @@ import (
 // moved past — a name they just wrote would be underlined as missing, and one they just
 // deleted would go on resolving.
 
-// resolveModules answers with the modules a document imports, for a tree the server already
+// resolveModules returns the modules a document imports, for a tree the server already
 // parsed. It is the port textdoc is handed: everything about the world is on this side of it.
 func resolveModules(s *state.State) textdoc.Resolve {
 	lx := lexer.New()
@@ -57,7 +57,7 @@ func resolveModules(s *state.State) textdoc.Resolve {
 	}
 }
 
-// readThroughBuffers answers with what the editor is showing, and falls back to the disk.
+// readThroughBuffers returns what the editor is showing, and falls back to the disk.
 func readThroughBuffers(s *state.State) resolver.Read {
 	return func(path string) ([]byte, error) {
 		if text, open := openDocument(s, path); open {

--- a/cmd/aurorals/project_test.go
+++ b/cmd/aurorals/project_test.go
@@ -11,7 +11,7 @@ import (
 // business: it walks up from the file, the way the CLI does. What it finds is handed to the
 // analysis, which knows nothing about manifests.
 
-// project writes a manifest and answers with the path of a source file beside it.
+// project writes a manifest and returns the path of a source file beside it.
 func project(t *testing.T, manifest string) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -87,7 +87,7 @@ func TestTapeSizeForFollowsTheManifestBeingEdited(t *testing.T) {
 	}
 }
 
-// timeAfter answers with a modification time later than the file's, so a rewrite is visible
+// timeAfter returns a modification time later than the file's, so a rewrite is visible
 // however coarse the filesystem's clock is.
 func timeAfter(t *testing.T, path string) time.Time {
 	t.Helper()

--- a/cmd/aurorals/session_test.go
+++ b/cmd/aurorals/session_test.go
@@ -276,7 +276,7 @@ func TestSessionDefinitionAnswersWithALocation(t *testing.T) {
 	}
 }
 
-// A position with no name under it is answered with null rather than with nothing. A request
+// A position with no name under it is returned null rather than with nothing. A request
 // carries an id and the client waits on it: silence is a client that waits forever.
 func TestSessionDefinitionOfNothingIsNull(t *testing.T) {
 	uri := "file:///tmp/main.ar"

--- a/cmd/playground/analysis.go
+++ b/cmd/playground/analysis.go
@@ -14,7 +14,7 @@ import (
 	"github.com/guiferpa/aurora/parser"
 )
 
-// The page is a third client of the analyses the language server answers with, next to the
+// The page is a third client of the analyses the language server returns, next to the
 // editor plugin and the CLI's own use of the phases: the colours come from the lexer and the
 // marks from the parser.
 //
@@ -56,7 +56,7 @@ func positionFrom(args []js.Value) lsp.Position {
 	return pos
 }
 
-// marshal answers with JSON, which is what crosses to the page. A value that cannot be
+// marshal returns JSON, which is what crosses to the page. A value that cannot be
 // encoded answers as nothing rather than as a broken string: an editor that colours nothing
 // is a worse day than one that colours late, and neither is worth stopping the page for.
 func marshal(v any) any {

--- a/docs/lsp.md
+++ b/docs/lsp.md
@@ -23,13 +23,13 @@ Three things come back, depending on where the cursor is.
 
 **Right after a dot on a value**, the fields of that shape and nothing else. The shape comes
 from what was declared — `ident p = Point{...}`, `... as Point`, or a call to a scope that
-promised with `returns` — read straight from the tokens rather than from the tree, because a
+declared with `returns` — read straight from the tokens rather than from the tree, because a
 document being edited hardly ever parses: the moment someone types `p.` there is no field name
 yet, and that is exactly when completion is wanted. The dot is declared as a trigger character,
 so the client asks on its own.
 
 The shape does not have to be declared here. What the imported modules offer is written down
-first — their shapes, and what their scopes promised — under the alias this file gave them, so
+first — their shapes, and what their scopes return — under the alias this file gave them, so
 `ident s = g.new_square(4, 5);` is enough for `s.` to answer with `width` and `height`. That is
 the same table the parser fills, read the same way.
 
@@ -68,7 +68,7 @@ they are, so that client gets the bare keyword.
 
 ### Go to definition
 
-Four things are names, and each one answers with where it was written:
+Four things are names, and each one answers the place it was written:
 
 | Under the cursor | Lands on |
 |---|---|
@@ -83,7 +83,7 @@ module: `s.width` lands inside `shape Square { width, height };`, in the file th
 The module's own source is lexed and asked exactly what the open document is asked, which is
 why a value, a shape and a field all cross without a rule of their own.
 
-Asking about a name where it is declared answers with itself. That is what "declared here"
+Asking about a name where it is declared answers itself. That is what "declared here"
 looks like, and it reads differently from "not declared at all", which answers with nothing.
 
 The binding that answers is **the one above the cursor**, so a name bound twice lands on the

--- a/docs/module_system_design.md
+++ b/docs/module_system_design.md
@@ -153,7 +153,7 @@ expressions, `ident` is *the* way to bind a name, and `ident area = defer { ... 
 precedent.
 
 It loses to the premise. **A name bound by `ident` holds a tape**, and a module has no bytes and
-no width. Worse, the form promises what it cannot give: bound that way, `m` should print, pass
+no width. Worse, the form claims what it cannot give: bound that way, `m` should print, pass
 to a `defer` and sit in a shape field, and each of those becomes a surprise rather than an
 ordinary error. The language already separates the two — `ident x = 10;` binds, `shape Point
 { x, y };` declares, and `Point` is a name you use and cannot print. **An import is the sibling

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -55,7 +55,7 @@ Three things follow, and each of them is what a module already meant:
 - **Two files are two scopes.** A test may bind a name the module it checks also binds; they
   are different names, and the module's is reached through the alias.
 
-A shape crosses the way it crosses anywhere: named through the alias, or carried by a promise.
+A shape crosses the way it crosses anywhere: named through the alias, or carried by what a scope returns.
 
 ```aurora
 #- src/point.ar

--- a/emitter/program_test.go
+++ b/emitter/program_test.go
@@ -118,7 +118,7 @@ func TestEmitProgramLabelsScopes(t *testing.T) {
 			expr := program.Expressions[0]
 
 			// The value of a scope reaches whoever reads it by being handed over: the block
-			// the run carries on into takes it, under the name the expression answers by.
+			// the run carries on into takes it, under the name the expression returns under.
 			taken := false
 			for _, block := range program.Blocks {
 				for _, param := range block.Params {
@@ -128,7 +128,7 @@ func TestEmitProgramLabelsScopes(t *testing.T) {
 				}
 			}
 			if !taken {
-				t.Errorf("no block takes %q, and that is the name the expression answers by", expr.Label)
+				t.Errorf("no block takes %q, and that is the name the expression returns under", expr.Label)
 			}
 		})
 	}

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -135,7 +135,7 @@ ident multiply = defer { feed(0) * feed(1); };`
 	}
 }
 
-// A name the contract does not have reaches the no-match STOP, which answers with nothing —
+// A name the contract does not have reaches the no-match STOP, which returns nothing —
 // it does not run the first scope it finds.
 func TestAnUnknownNameAnswersWithNothing(t *testing.T) {
 	const source = `ident add = defer { feed(0) + feed(1); };`
@@ -191,7 +191,7 @@ func TestArithmeticWrapsAtTheTapeWidthOnBothSides(t *testing.T) {
 			// This is why every result is cut and not only the one that leaves: a sum, a
 			// difference and a product agree either way, because wrapping and adding can be
 			// done in either order. A division cannot. At one byte 255 + 1 is 0, and 0 / 2 is
-			// 0 — but 256 / 2 is 128, and cutting that afterwards still answers 128.
+			// 0 — but 256 / 2 is 128, and cutting that afterwards still returns 128.
 			name:     "a division after a sum that left the width",
 			source:   `ident half = defer { (feed(0) + feed(1)) / feed(2); };`,
 			function: "half", args: []string{"255", "1", "2"}, tapeSize: 1,
@@ -205,8 +205,8 @@ func TestArithmeticWrapsAtTheTapeWidthOnBothSides(t *testing.T) {
 	}
 }
 
-// Reading past the values applied to a scope is not an error — the read always answers with a
-// tape. What it answers with is the question, and today the two backends answer differently:
+// Reading past the values applied to a scope is not an error — the read always returns a
+// tape. What it returns is the question, and today the two backends answer differently:
 // the evaluator takes the index modulo the length of the vector, so a missing argument comes
 // back as the first one; the chain reads past the end of the calldata, which the EVM gives as
 // zeros.
@@ -347,7 +347,7 @@ func TestABranchAnswersTheSameOnChainAndOff(t *testing.T) {
 	}
 }
 
-// A comparison answers with a tape like any other value, and the EVM answers these with one or
+// A comparison returns a tape like any other value, and the EVM answers these with one or
 // zero, which is what a tape holding true or false is.
 //
 // The two that are not symmetric are the ones that say anything: the EVM reads its first
@@ -452,7 +452,7 @@ ident outer = defer { middle(feed(0)) + middle(1); };`
 
 // A shape reaches the chain. It is not a new kind of value: Point{10, 20} is two tapes laid
 // end to end, and on a chain that is one word with the first tape at the far end — the same
-// number the evaluator answers, which is what lets a scope hand a run back either way.
+// number the evaluator returns, which is what lets a scope hand a run back either way.
 //
 // Reading a field is counting back from the last tape, which is why the instruction says how
 // many the run has: nothing in the value marks where it ends.
@@ -502,7 +502,7 @@ ident build = defer { ident p = Point{twice(feed(0)), twice(feed(1))}; p.x + p.y
 	agree(t, source, "build", []string{"3", "4"}, 0)
 }
 
-// A scope answering a whole run answers the tapes laid end to end, with the first at the far
+// A scope returning a whole run answers the tapes laid end to end, with the first at the far
 // end — which is what makes the run a number the evaluator agrees with.
 //
 // This one cannot go through the harness's usual comparison: it compares what printd wrote,
@@ -622,7 +622,7 @@ func TestTapeOperationsAnswerTheSameOnChainAndOff(t *testing.T) {
 // A body is code that runs when the scope is called, and that is as true of a scope written
 // inside another as of one written at the top. Its body used to be written straight into the
 // outer one and run on the way past — its return firing in the middle of code that had not
-// asked for it — so the first of these answered 1 on chain where the program answers 2. It
+// asked for it — so the first of these answered 1 on chain where the program returns 2. It
 // compiled, it deployed, and it said nothing.
 func TestAScopeWrittenInsideAnotherDoesNotRunOnTheWayPast(t *testing.T) {
 	cases := []struct {
@@ -656,7 +656,7 @@ func TestAScopeWrittenInsideAnotherDoesNotRunOnTheWayPast(t *testing.T) {
 	}
 }
 
-// A position a scope reads and the call did not fill answers with zeros, which is what the
+// A position a scope reads and the call did not fill returns zeros, which is what the
 // language answers for reading past what was applied.
 //
 // On the way in from a transaction that is free: the calldata gives zeros past its end. A
@@ -799,7 +799,7 @@ func TestABlockInsideAnExpressionAnswersTheSameOnChainAndOff(t *testing.T) {
 			source: "ident f = defer { ident a = { feed(0) + 1; }; a * 10; };",
 		},
 		{
-			name:   "and the scope answers with something else entirely",
+			name:   "and the scope returns something else entirely",
 			source: "ident f = defer { ident a = { feed(0) + 1; }; feed(0) * 2; };",
 		},
 		{
@@ -835,7 +835,7 @@ func TestABlockInsideAnExpressionAnswersTheSameOnChainAndOff(t *testing.T) {
 // first time anything read what the print was worth.
 //
 // The evaluator prints as it goes and the chain does not, so what is compared here is only what
-// the scope answers with — the harness runs both and reads the last thing said.
+// the scope returns — the harness runs both and reads the last thing said.
 func TestAPrintIsTheValueItWasGivenOnChain(t *testing.T) {
 	cases := []struct {
 		name   string
@@ -858,7 +858,7 @@ func TestAPrintIsTheValueItWasGivenOnChain(t *testing.T) {
 			want:   "26730",
 		},
 		{
-			name:   "and one whose value nobody reads still answers for the scope",
+			name:   "and one whose value nobody reads still returns for the scope",
 			source: "ident f = defer { printd feed(0); };",
 			want:   "3",
 		},
@@ -932,7 +932,7 @@ func TestEveryExampleDeploys(t *testing.T) {
 //	ident base = 30;
 //	ident show = defer { base * 2; };
 //
-// answered 0 on a chain where the program answers 60, and said nothing about it. What would
+// answered 0 on a chain where the program returns 60, and said nothing about it. What would
 // let it work is a static link, which is a design of its own and written down in
 // rfcs/if_and_call.md; until it exists, this is a refusal.
 func TestAScopeReadingANameFromAroundItIsRefused(t *testing.T) {

--- a/hosting/cli/examples_test.go
+++ b/hosting/cli/examples_test.go
@@ -34,7 +34,7 @@ func exampleSources(t *testing.T) ([]string, error) {
 	return sources, err
 }
 
-// runFrom makes the directory an example is run from the current one, and answers with the
+// runFrom makes the directory an example is run from the current one, and returns the
 // path to name it by from there.
 func runFrom(t *testing.T, source string) string {
 	t.Helper()

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -20,7 +20,7 @@ func projectOf(t *testing.T, files map[string]string) string {
 	return dir
 }
 
-// run compiles and evaluates the entry of a project, and answers with what it printed. The
+// run compiles and evaluates the entry of a project, and returns what it printed. The
 // entry is named the way somebody standing in the project would name it.
 func run(t *testing.T, entry string) (string, error) {
 	t.Helper()
@@ -205,7 +205,7 @@ func TestATestWhoseModuleIsNotThere(t *testing.T) {
 // What crosses a module and what does not, which is a sharper line than it looks.
 //
 // The value crosses whole: a shape is a run of tapes and nothing in it says a shape built
-// it, so a scope in another file answers with one and the bytes arrive intact. What does not
+// it, so a scope in another file returns one and the bytes arrive intact. What does not
 // cross is the declaration — the table that turns a field name into an index — because it is
 // read while a file is parsed and belongs to that file.
 func TestAShapeValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
@@ -243,7 +243,7 @@ func TestAShapeValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
 //
 // The shape is declared in one file and read in another, and nothing in the reading file
 // names it: what crossed is the promise the scope made, with the fields of the shape it
-// answers with — which is what turns a field name into the index of a tape.
+// returns — which is what turns a field name into the index of a tape.
 func TestAPromisedShapeCrossesAModule(t *testing.T) {
 	projectOf(t, map[string]string{
 		"src/os.ar": "shape Env { found, value };\n" +

--- a/hosting/cli/root_test.go
+++ b/hosting/cli/root_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 )
 
-// repoRoot answers with the directory holding go.mod, found by walking up from wherever the
+// repoRoot returns the directory holding go.mod, found by walking up from wherever the
 // test happens to run.
 //
 // The tests that read docs/ and examples/ used to count directories — "..", ".." — which is

--- a/hosting/cli/session.go
+++ b/hosting/cli/session.go
@@ -22,7 +22,7 @@ type Session struct {
 	lexer   *lexer.Lexer
 	parser  parser.Parser
 	emitter emitter.Emitter
-	// newEvaluator answers with a fresh one. An evaluator is per program, not per session: it
+	// newEvaluator returns a fresh one. An evaluator is per program, not per session: it
 	// holds the names a program bound, the scopes it deferred and the assertions that ran, and
 	// "aurora test" checks one file after another, each of which is its own program.
 	newEvaluator func() *evaluator.Evaluator
@@ -49,7 +49,7 @@ type NewSessionOptions struct {
 	Warnings io.Writer
 }
 
-// evaluator answers with a fresh evaluator, or says that the session was built without a way
+// evaluator returns a fresh evaluator, or says that the session was built without a way
 // of making one. A build needs none; a run and a test do, and printing nowhere by default
 // would hide the wiring mistake in the one place it shows.
 func (s *Session) evaluator() (*evaluator.Evaluator, error) {

--- a/hosting/cli/target_test.go
+++ b/hosting/cli/target_test.go
@@ -133,7 +133,7 @@ func TestALooseFileOutsideAProjectHasNoWidthOfItsOwn(t *testing.T) {
 	}
 }
 
-// A manifest that cannot be read is said out loud rather than answered with the default: a
+// A manifest that cannot be read is said out loud rather than returned the default: a
 // project pinned to one byte compiling at eight in silence is what this guards against.
 func TestALooseFileReportsABrokenManifest(t *testing.T) {
 	dir := t.TempDir()

--- a/hosting/lsp/listener_test.go
+++ b/hosting/lsp/listener_test.go
@@ -86,7 +86,7 @@ func TestListenAnswersShutdownAndStopsOnExit(t *testing.T) {
 	})
 
 	if !strings.Contains(out.String(), `"result":null`) {
-		t.Errorf("shutdown must be answered with a null result, got %q", out.String())
+		t.Errorf("shutdown must be returned a null result, got %q", out.String())
 	}
 	if called != 0 {
 		t.Error("nothing may be handled after exit")

--- a/hosting/lsp/textdoc/definition.go
+++ b/hosting/lsp/textdoc/definition.go
@@ -25,7 +25,7 @@ type DefinitionRequest struct {
 	Params DefinitionParams `json:"params"`
 }
 
-// DefinitionResponse answers with one location, which is one of the three forms the protocol
+// DefinitionResponse returns one location, which is one of the three forms the protocol
 // allows. A name is declared in one place in Aurora, so the list form would always hold one.
 type DefinitionResponse struct {
 	lsp.Response
@@ -49,7 +49,7 @@ func NewDefinitionResponse(id int, location lsp.Location) DefinitionResponse {
 
 // A Definition is where a name was declared: which file, and the range of the name inside it.
 //
-// The file is a path rather than a URI because this package answers with values and never
+// The file is a path rather than a URI because this package returns values and never
 // touches the world — which URI a path is depends on the host, and only the host knows.
 type Definition struct {
 	Filename string
@@ -61,7 +61,7 @@ type Definition struct {
 //
 // Four things are names here, and each is declared somewhere a token can be found: a value
 // bound with `ident`, a shape declared with `shape`, a field inside a shape's declaration,
-// and the declaration itself — asking about a name where it was written answers with itself,
+// and the declaration itself — asking about a name where it was written returns itself,
 // which is what tells "declared here" from "not declared at all".
 //
 // The file it lands in is this one or a module's, and the question does not change between
@@ -230,7 +230,7 @@ func ownerOf(tokens []token.Token, subject token.Token) token.Token {
 //
 // Nearest before, because that is the one the language would find: a name is bound before it
 // is used, and a second binding of the same name shadows the first from where it is written.
-// A binding that only appears later is answered with anyway — a deferred scope runs when it
+// A binding that only appears later is returned anyway — a deferred scope runs when it
 // is called, so a body can name something written under it, and a jump to the wrong end of a
 // file is a better answer than none.
 func bindingOf(tokens []token.Token, name string, at int) token.Token {

--- a/hosting/lsp/textdoc/definition_test.go
+++ b/hosting/lsp/textdoc/definition_test.go
@@ -35,7 +35,7 @@ func TestDefinitionInTheSameFile(t *testing.T) {
 			want: lsp.LineRange(1, 17, 18),
 		},
 		{
-			name: "a name asked about where it is declared answers with itself",
+			name: "a name asked about where it is declared returns itself",
 			at:   lsp.Position{Line: 0, Character: 6},
 			want: lsp.LineRange(0, 6, 11),
 		},

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -165,7 +165,7 @@ func exportedValue(found module.Module, name string) ast.Node {
 //
 // The order is the point. A name bound here can be read as a shape declared over there —
 // `ident s = g.new_square(1, 2);` — and the reader of the tokens only knows what that call
-// answers with if the promise is already written down when it walks past the call.
+// returns if the promise is already written down when it walks past the call.
 func shapesOf(analysis *Analysis, aliases moduleAliases) shapeTable {
 	return importedShapes(analysis, aliases).scan(analysis.Tokens)
 }

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -98,7 +98,7 @@ func TestCompletionAfterAModuleDot(t *testing.T) {
 	}
 }
 
-// A shape still answers with its fields after a dot, which is the other reader of the same
+// A shape still returns its fields after a dot, which is the other reader of the same
 // question.
 func TestCompletionAfterAShapeDotStillWorks(t *testing.T) {
 	source := "shape Point { x, y };\nident p = Point{1, 2};\nprintd p.\n"
@@ -137,7 +137,7 @@ func TestCompletionOffersTheModules(t *testing.T) {
 
 // From here on the editor reads the other files too, through the port it is handed. These
 // hand it a project in memory: what is on a disk is the server's business, and this package
-// answers with values whatever the world it is put in.
+// returns values whatever the world it is put in.
 func withModuleFiles(files map[string]string) *Session {
 	lx := lexer.New()
 	ps := parser.New()
@@ -324,7 +324,7 @@ func TestTheEditorOffersAModuleShapes(t *testing.T) {
 	}
 }
 
-// And a name whose shape came from another file answers with its fields after the dot, which
+// And a name whose shape came from another file returns its fields after the dot, which
 // is the whole point of the shape crossing: however the name got it — built here, claimed
 // with as, or promised by the scope that answered.
 func TestCompletionOnAShapeFromAnotherModule(t *testing.T) {

--- a/hosting/lsp/textdoc/session.go
+++ b/hosting/lsp/textdoc/session.go
@@ -46,7 +46,7 @@ type Emit func(ast.AST) (ir.Program, error)
 // build", which is after the writing is done and often after the deciding is done too.
 type Carries func([]ir.Block) []diag.Warning
 
-// Resolve answers with the modules a document imports, given the use lines it opens with.
+// Resolve returns the modules a document imports, given the use lines it opens with.
 //
 // It takes the declarations rather than a tree because a document being edited does not
 // parse, and what is inside a module is wanted exactly then — the moment a dot is typed.

--- a/hosting/lsp/textdoc/shapes.go
+++ b/hosting/lsp/textdoc/shapes.go
@@ -89,11 +89,11 @@ func readDeclaration(tokens []token.Token, i int) (string, []string, int) {
 }
 
 // readBinding reads what `ident name = ...` binds, up to the end of the statement: the shape
-// it is read as, the shape calling it will answer with, and the scope it was bound from.
+// it is read as, the shape calling it will return, and the scope it was bound from.
 //
 // Only what sits at the top of the value is read. A body between braces is another scope's
 // business — the semicolons in it do not end this statement, and a construction inside it says
-// what that scope answers with rather than what this name is.
+// what that scope returns rather than what this name is.
 func readBinding(tokens []token.Token, i int) (name, shape, promised, called string) {
 	if i+2 >= len(tokens) || tokens[i+1].GetTag().Id != token.ID || tokens[i+2].GetTag().Id != token.ASSIGN {
 		return "", "", "", ""
@@ -129,7 +129,7 @@ func readBinding(tokens []token.Token, i int) (name, shape, promised, called str
 				// A construction: the name of a shape in front of a brace.
 				shape = nameAt(tokens, j)
 			case token.O_PAREN:
-				// A call: what it answers with is known when that scope promised.
+				// A call: what it returns is known when that scope promised.
 				called = nameAt(tokens, j)
 			}
 		}

--- a/hosting/lsp/textdoc/shapes_test.go
+++ b/hosting/lsp/textdoc/shapes_test.go
@@ -181,7 +181,7 @@ func TestTheEditorReadsNoPromiseWhereThereIsNone(t *testing.T) {
 }
 
 // The body of a scope is another scope's business: a construction inside it says what that
-// scope answers with, not what the name being bound is.
+// scope returns, not what the name being bound is.
 func TestABodyDoesNotShapeTheNameItIsBoundTo(t *testing.T) {
 	const source = "shape Result { failed, value };\n" +
 		"ident divide = defer { Result{1, 0}; };\n" +

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -66,7 +66,7 @@ func (a *Analysis) module(specifier string) (module.Module, bool) {
 // The width is given rather than discovered because finding it is the host's business and
 // each host finds it differently: the language server walks up from the file to the project
 // manifest, and the playground reads the control on the page. This package takes values and
-// answers with values, which is also what lets it run where there is no filesystem at all.
+// returns values, which is also what lets it run where there is no filesystem at all.
 //
 // A zero width means the language's default.
 type Document struct {
@@ -115,7 +115,7 @@ func (s *Session) Analyze(doc Document) *Analysis {
 		analysis.ModuleErr = loader.Check(append(analysis.Modules, module.Module{ID: "", Tree: tree}))
 	}
 
-	// And what compiling it has to say. The emitter answers with warnings rather than
+	// And what compiling it has to say. The emitter returns warnings rather than
 	// refusing, so a document that parses can still be worth a word — and the editor is
 	// where that word is cheapest to hear.
 	//
@@ -175,7 +175,7 @@ func (a *Analysis) Diagnostics() Diagnostics {
 // warnings answers what compiling the document had to say, as things an editor underlines.
 //
 // They are warnings and not errors because none of them stops a program: a call applying
-// fewer values than a scope reads is legal, and what was not applied answers with zeros. That
+// fewer values than a scope reads is legal, and what was not applied returns zeros. That
 // answer is silent, which is the whole reason the compiler says anything at all — and an
 // editor is where it is heard soonest.
 //
@@ -272,7 +272,7 @@ func (s *Session) HoverInfo(doc Document, pos lsp.Position) string {
 			return info + describeExport(analysis, tk)
 		}
 		// A shape name or a field read out of one: the declaration is what says these are
-		// anything other than a name, so it is what hover has to answer with. The declaration
+		// anything other than a name, so it is what hover has to return. The declaration
 		// may be in another file, which is why the imports are read here too.
 		if shape, fields, index := shapesOf(analysis, aliases).shapeAt(analysis.Tokens, tk); shape != "" {
 			if index < 0 {

--- a/hosting/repl/editor.go
+++ b/hosting/repl/editor.go
@@ -240,7 +240,7 @@ func apply(edit func(l *line), l *line) {
 	}
 }
 
-// end closes the line off on the terminal and answers with what it was.
+// end closes the line off on the terminal and returns what it was.
 func (e *editor) end(text string, err error) (string, error) {
 	_, _ = fmt.Fprint(e.out, "\r\n")
 	return text, err

--- a/hosting/repl/repl.go
+++ b/hosting/repl/repl.go
@@ -240,7 +240,7 @@ func (s *Session) load(tree ast.AST) error {
 			return err
 		}
 		s.loaded[each.ID] = each
-		// What it answers with is written down for the lines after this one: a session is a
+		// What it returns is written down for the lines after this one: a session is a
 		// file typed slowly, and the use line was already read when this module arrived.
 		s.declarations.Import(string(each.ID), ast.Offer{Shapes: each.Tree.Shapes, Returns: each.Tree.Returns})
 	}

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -21,7 +21,7 @@ import (
 // took its writer. These go in the way a shell pipe does — lines in, everything the session
 // said out — so what is pinned here is the REPL as someone uses it, not its parts.
 
-// typed types the lines given and answers with everything the session wrote back. It puts the
+// typed types the lines given and returns everything the session wrote back. It puts the
 // session together the way cmd/aurora does, since that is now where a session is made.
 func typed(t *testing.T, lines string, tapeSize int) string {
 	t.Helper()

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -69,7 +69,7 @@ func TestWhatItReturnsIsOnTheBlock(t *testing.T) {
 		t.Fatalf("the second node is %T, want a block", nodes[1])
 	}
 	if block.Returns != "Person" {
-		t.Errorf("the block promises %q, want Person", block.Returns)
+		t.Errorf("the block returns %q, want Person", block.Returns)
 	}
 }
 
@@ -78,7 +78,7 @@ func TestABlockWithoutAPromiseIsUnchanged(t *testing.T) {
 	nodes := parse(t, person+"{ Person{\"Joana\"}; };")
 
 	if block := nodes[1].(ast.BlockExpression); block.Returns != "" {
-		t.Errorf("the block promises %q, want nothing", block.Returns)
+		t.Errorf("the block returns %q, want nothing", block.Returns)
 	}
 }
 

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -97,7 +97,7 @@ var (
 	TagOr         = Tag{OR, "or", ""}
 	TagPull       = Tag{PULL, "pull", "Pull item in right to left"}
 	TagPush       = Tag{PUSH, "push", "Push item in left to right"}
-	TagReturns    = Tag{RETURNS, "returns", "Name the shape a block answers with"}
+	TagReturns    = Tag{RETURNS, "returns", "Name the shape a block returns"}
 	TagSemicolon  = Tag{SEMICOLON, ";", ""}
 	TagShape      = Tag{SHAPE, "shape", "Name the fields of a run of tapes"}
 	TagSmaller    = Tag{SMALLER, "smaller", ""}


### PR DESCRIPTION
The last layer, and the one where the exception in the rule had to hold.

## It held

Every `answer` left inside the language server is one of two things, and neither is a construct of the language giving a value:

```go
// A request must always be answered or the client waits forever
// exit ends the session; shutdown only answers, per the spec
// Documents answers every open document, keyed by the URI it arrived under
```

Protocol, and Go-helper prose. Exactly what the rule carved out, and it took no judgement call at the end — the shape of the sentence decided it every time.

## What changed is what a person reads

| where | before | after |
|---|---|---|
| an editor completion | *Name the shape a block answers with* | *Name the shape a block returns* |
| a compiler error | *this block answers with Person…* | *this block returns Person…* (#143) |
| `docs/lsp.md` | *what their scopes promised* | *what their scopes return* |
| a test | *the block promises %q* | *the block returns %q* |

**That is the whole point.** Somebody meets this idea in a tooltip, in an error message, and in a document — and until now met three different words for it.

## Where the vocabulary stands

One word everywhere it means one thing, across three layers: the tree and the parser (#143), the pipeline (#144), and this.

`make check` — 0 issues.

## Next

Step 1 of `rfcs/shape_inference.md` is done. What follows is where a person actually gains something: split the walk from the check, work out what a scope returns when it did not declare it — with `Declared` travelling beside it — and have the editor read what the parser knows instead of scanning tokens.

The case that starts compiling: `s.width` after a call, with no `returns` anywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)