### PR TITLE
The compiler works out what a scope returns

### DIFF
--- a/builder/evm/stream_test.go
+++ b/builder/evm/stream_test.go
@@ -65,7 +65,7 @@ func TestBytecodeIsAWellFormedStream(t *testing.T) {
 	}
 }
 
-// The walk has to be able to fail, or it proves nothing: a push that promises more bytes
+// The walk has to be able to fail, or it proves nothing: a push that claims more bytes
 // than the stream has is exactly the desynchronisation being guarded against.
 func TestTheWalkNoticesATruncatedPush(t *testing.T) {
 	truncated := []byte{OpPush4, 0x01, 0x02}

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -400,13 +400,18 @@ printd make() as Result.value;   #- 42
 ```
 
 A shape's **name** belongs to the file that declared it: another file writes it as the
-module's, `g.Point`, and a promise carries the shape where nothing names it at all. See
+module's, `g.Point`, and what a scope returns carries the shape where nothing names it at all. See
 [modules.md](modules.md).
 
-### Promising a shape with `returns`
+### Declaring a shape with `returns`
 
-`as` is what whoever reads a value claims about it, and the compiler believes it. `returns` is
-the other end: what a block promises about itself, checked where it is written.
+The compiler already knows what a block returns: it reads what the block ends with. `as` is
+for the other case — a value whose shape nothing in the program says, which the reader
+claims and the compiler believes.
+
+`returns` is neither. It is a block saying what it returns, at the place it is written, and
+the compiler keeping it — so a mistake is caught where it was made rather than where it
+arrives.
 
 ```aurora
 shape Result { failed, value };
@@ -426,11 +431,11 @@ printd r.value;    #- 5
 
 The word comes after the brace that closes the block, and that is the only place it goes — a
 block, or a deferred scope, which is a block with a word in front of it. An `if` never takes
-one; it is looked *through*, which is why the example above compiles: both arms answer with a
+one; it is looked *through*, which is why the example above compiles: both arms return a
 `Result`. A `branch` is nested ifs by the time anything reads it, and its last item is the
 innermost else, so its way out is always covered.
 
-A block that does not keep its promise does not compile:
+A block that does not keep its declaration does not compile:
 
 ```aurora
 #- fails: returns Person and ends with a number
@@ -454,15 +459,27 @@ shape Person { name };
 } returns Person;
 ```
 
-**What it buys is the other end.** A call to a scope that promised has a shape, so `as`
-disappears from the place it was repeated once per call — and it stops being a claim, since
-the declaration was checked. A scope that declares nothing is unchanged: it returns a run of
-tapes, and whoever reads its fields writes `as`.
+**A call has a shape whether or not the scope declared one.** The compiler reads what the
+body ends with, so `as` does not appear at the call either way:
 
-The promise is never required, and never will be. A scope has no signature — it does not
+```aurora
+shape Square { width, height };
+
+ident new_square = defer { Square{feed(0), feed(1)}; };
+
+ident s = new_square(30, 20);
+printd s.width;    #- 30
+```
+
+What is left unknown is a body the walk cannot resolve — one that ends with arithmetic, which
+is a tape and not a run, or with a call to a scope written further down the file. There, and
+only there, whoever reads a field writes `as`, and `returns` is what removes the need to.
+
+So `returns` is never required, and never will be. A scope has no signature — it does not
 declare how many values it receives or what they are — so requiring it to declare what it
-returns would be declaring one end and not the other. `returns` is what you gain by
-promising, not a toll for writing a block.
+returns would be declaring one end and not the other. What it is for is being held to it:
+a block that changes what it ends with and no longer returns what it said is refused where
+it was written, and every caller is spared finding out.
 
 ### What is an error
 

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -130,7 +130,7 @@ which is the same thing since a scope's value is its index. Nothing else:
 - a name bound inside a block or a deferred body belongs to the scope that binds it, and is
   gone when that scope is;
 - a `shape`'s **name** stays in the file that declared it, and is written elsewhere as the
-  module's: `g.Square` builds one, names one with `as`, and promises one with `returns`;
+  module's: `g.Square` builds one, names one with `as`, and declares one with `returns`;
 - an import is not passed on. If `main` uses `a` and `a` uses `b`, then `main` does not reach
   `b` — it writes its own `use b as ...;`. Every file declares what it needs, and a name used
   in a file has its origin declared in that file.
@@ -155,10 +155,10 @@ use geometry as g;
 printd g.area(1, 2);
 ```
 
-### A shape crosses with the promise that names it
+### A shape crosses with the scope that returns it
 
-A scope that says what it answers with hands the shape over, so whoever imports it reads the
-fields without naming anything:
+What a scope returns hands the shape over, so whoever imports it reads the fields without
+naming anything:
 
 ```
 #- src/os.ar
@@ -166,7 +166,7 @@ shape Env { found, value };
 
 ident lookup = defer {
   Env{1, 42};
-} returns Env;
+};
 ```
 
 ```
@@ -178,12 +178,16 @@ printd r.found;
 printd r.value;
 ```
 
-Nothing in `main.ar` mentions `Env`, and nothing has to. What crossed is the promise — the
-shape and the fields it is made of — which is what turns `found` into the first tape of the
-run.
+Nothing in `main.ar` mentions `Env`, and nothing has to. What crossed is what `lookup`
+returns — the shape and the fields it is made of — which is what turns `found` into the first
+tape of the run. Nothing in `os.ar` says it either: the compiler read what the body ends with.
+Writing `returns Env` on it changes nothing about what crosses; it is a declaration `os.ar` is
+held to, so a change to that body that stops returning an `Env` is refused in the file that
+made the mistake.
 
-A scope that promised nothing hands over a run of tapes and no shape, exactly as it did
-before: the file reading it has to name one.
+What does not cross is a scope whose shape nothing says — one ending with arithmetic, which is
+a tape and not a run. It hands over the tapes and no shape, and the file reading it has to
+name one.
 
 ### And a shape can be named
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -63,6 +63,30 @@ this.
 
 ---
 
+## Shapes
+
+Which shape a value is, is worked out while compiling. A call has a shape because the
+compiler reads what the scope's body ends with, looking through an `if` when both arms agree,
+so a field is reached off a call without anybody writing a word — across a module too, since
+what a scope returns is what crosses. `returns` is a declaration the compiler keeps, not the
+way to be understood, and `as` is for a value the program never says the shape of.
+
+Three places it stops, and each of them falls back on `as` or `returns`, which is what those
+are for:
+
+- **A scope written further down the file is not known yet.** `ident a = defer { b(); };`
+  before `b` is bound reads a table that has no `b` in it, so `a` returns nothing as far as
+  the compiler is concerned. Reading a file twice would answer it, and nothing reads a file
+  twice today.
+- **A scope that calls itself is not known either**, for the same reason and by the same
+  mechanism: the name is not in the table while its own body is being read. This is what
+  keeps the walk from being a recursion at all, so it is a limit bought on purpose.
+- **The editor still reads tokens, not the compiler.** The language server builds its own
+  table by matching patterns over the tokens, which recognises less than the compiler does —
+  no block, no `if` whose arms agree, no chain of bindings. It has to keep something like it,
+  because completing a name has to work in a document half-typed that does not parse; what it
+  does not have to do is use it when the parse succeeded.
+
 ## Modules
 
 A program is as many files as it needs. `use a/b/c as x;` reads `a/b/c.ar` from the source

--- a/examples/project/src/geometry.ar
+++ b/examples/project/src/geometry.ar
@@ -8,8 +8,9 @@
 #-
 #- A file that imports this one writes the shape as g.Square, never as Square: the name of a
 #- shape carries the module it was declared in, so a Square here and a Square there are two
-#- shapes. It does not have to write it at all — new_square promises one, and a promise
-#- carries the fields with it.
+#- shapes. It does not have to write it at all — what new_square returns crosses with the
+#- fields, and the "returns Square" below is not what makes that happen: the compiler reads
+#- what the body ends with. What the word does is hold this file to it.
 #-
 #- It prints nothing on its own, so it declares no output: a module of declarations does its
 #- work when somebody imports it.

--- a/examples/project/src/main.ar
+++ b/examples/project/src/main.ar
@@ -4,12 +4,12 @@
 #- What it multiplies comes from a module: "use geometry as g;" reads src/geometry.ar, and g
 #- is the only way to reach what is inside it. The alias is this file's alone.
 #-
-#- Nothing here names Square, and nothing has to: what crossed is the promise — new_square
-#- says it answers with a Square, and the fields came along with it, which is what lets
-#- s.width be read as the first tape of the run.
+#- Nothing here names Square, and nothing has to: what crossed is what new_square returns —
+#- the shape and the fields it is made of — which is what lets s.width be read as the first
+#- tape of the run.
 #-
 #- Naming it is possible too, through the alias and only through it: g.Square{30, 20} builds
-#- one, as g.Square claims one, returns g.Square promises one.
+#- one, as g.Square claims one, returns g.Square declares one.
 #-
 #- Modules resolve from src/ under the directory the command was run in, so this one is run
 #- from the project root.

--- a/examples/shapes.ar
+++ b/examples/shapes.ar
@@ -67,13 +67,17 @@ ident single = 7 as Point;
 printd single.y;
 
 
-#- "as" is what whoever reads a value claims about it. "returns" is what a block
-#- promises about itself, and the compiler refuses the block that does not keep
-#- it — so a scope that says it answers with a Result and ends with a number
-#- does not compile.
+#- A call already has a shape without anybody saying so: the compiler reads what
+#- the body ends with, so divide could drop the "returns Result" below and
+#- r.value would still be the second tape.
 #-
-#- What it buys is the other end: a call to a scope that promised has a shape,
-#- so nobody has to claim one at every call site.
+#- What "returns" adds is being held to it. The compiler refuses the block that
+#- does not keep what it declared, so a scope that says it returns a Result and
+#- ends with a number does not compile — the mistake is caught in the file that
+#- made it rather than at a call somewhere else.
+#-
+#- "as" is the third thing, and the only one that is a claim: it is for a value
+#- whose shape nothing in the program says.
 shape Result { failed, value };
 
 ident divide = defer {

--- a/hosting/cli/docs_test.go
+++ b/hosting/cli/docs_test.go
@@ -146,7 +146,7 @@ func runSnippet(t *testing.T, doc string, s snippet) {
 		}
 		return
 	}
-	// The block says it fails, so passing is the failure — and the message it promises has
+	// The block says it fails, so passing is the failure — and the message it declares has
 	// to be the message it gets.
 	if err == nil {
 		t.Errorf("%s:%d says it fails with %q, and it ran\n%s", doc, s.line, s.wantErr, s.code)

--- a/hosting/cli/examples_test.go
+++ b/hosting/cli/examples_test.go
@@ -148,7 +148,7 @@ func declaredOutput(t *testing.T, source string) []string {
 }
 
 // Every example says what it prints, and that block is pasted from a real run. This is what
-// keeps the promise: the header is compared against the output, so an example cannot drift
+// keeps them honest: the header is compared against the output, so an example cannot drift
 // from the language without the suite noticing.
 //
 // It caught three of them the day text stopped being a reel, which is exactly the drift it

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -239,12 +239,12 @@ func TestAShapeValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
 	})
 }
 
-// A shape crosses a module with the promise that names it.
+// A shape crosses a module with the scope that returns it.
 //
 // The shape is declared in one file and read in another, and nothing in the reading file
-// names it: what crossed is the promise the scope made, with the fields of the shape it
+// names it: what crossed is the declaration the scope made, with the fields of the shape it
 // returns — which is what turns a field name into the index of a tape.
-func TestAPromisedShapeCrossesAModule(t *testing.T) {
+func TestADeclaredShapeCrossesAModule(t *testing.T) {
 	projectOf(t, map[string]string{
 		"src/os.ar": "shape Env { found, value };\n" +
 			"ident lookup = defer {\n" +
@@ -265,9 +265,9 @@ func TestAPromisedShapeCrossesAModule(t *testing.T) {
 	}
 }
 
-// A field the promised shape does not have is refused where it was written, naming what the
+// A field the declared shape does not have is refused where it was written, naming what the
 // shape is made of — the same refusal a local shape gets.
-func TestAFieldThePromiseDoesNotHave(t *testing.T) {
+func TestAFieldTheDeclarationDoesNotHave(t *testing.T) {
 	projectOf(t, map[string]string{
 		"src/os.ar":   "shape Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;",
 		"src/main.ar": "use os as o;\nident r = o.lookup(1);\nprintd r.missing;",
@@ -318,12 +318,12 @@ func TestAScopeWhoseShapeNothingSaysCrossesNothing(t *testing.T) {
 	}
 }
 
-// A test reads a promised shape like anybody else, because it imports like anybody else.
-func TestATestReadsAPromisedShape(t *testing.T) {
+// A test reads a declared shape like anybody else, because it imports like anybody else.
+func TestATestReadsADeclaredShape(t *testing.T) {
 	projectOf(t, map[string]string{
 		"src/os.ar":        "shape Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;",
 		"src/main.ar":      "printd 1;",
-		"src/main.test.ar": "use os as o;\nident r = o.lookup(0);\nassert(r.value equals 42, \"the field is read through the promise\");",
+		"src/main.test.ar": "use os as o;\nident r = o.lookup(0);\nassert(r.value equals 42, \"the field is read through what lookup returns\");",
 	})
 
 	report, err := tested(t, "", sessionOpts{asserts: true})
@@ -335,7 +335,7 @@ func TestATestReadsAPromisedShape(t *testing.T) {
 	}
 }
 
-// Naming a shape another module declared: built, claimed with `as`, and promised with
+// Naming a shape another module declared: built, claimed with `as`, and declared with
 // `returns` — the three places a shape's name is written, all reading the qualified form the
 // way a qualified value already did.
 func TestNamingAShapeOfAnotherModule(t *testing.T) {
@@ -357,7 +357,7 @@ func TestNamingAShapeOfAnotherModule(t *testing.T) {
 			want:   "7",
 		},
 		{
-			name: "promised with returns",
+			name: "declared with returns",
 			source: "use geometry as g;\n" +
 				"ident make = defer { g.Square{2, 3}; } returns g.Square;\n" +
 				"ident s = make();\nprintd s.width;",

--- a/hosting/cli/modules_test.go
+++ b/hosting/cli/modules_test.go
@@ -225,15 +225,15 @@ func TestAShapeValueCrossesAModuleButItsDeclarationDoesNot(t *testing.T) {
 		}
 	})
 
-	t.Run("and the field name has nowhere to be resolved", func(t *testing.T) {
+	t.Run("and the name of the shape is still not there", func(t *testing.T) {
 		reading := map[string]string{
 			"src/a/b.ar":  files["src/a/b.ar"],
-			"src/main.ar": "use a/b as x;\nident r = x.make();\nprintd r.value;",
+			"src/main.ar": "use a/b as x;\nident r = x.make() as Result;\nprintd r.value;",
 		}
 		projectOf(t, reading)
 		if _, err := run(t, "src/main.ar"); err == nil {
-			t.Fatal("the field was read without a shape")
-		} else if !strings.Contains(err.Error(), "nothing says which shape this value is") {
+			t.Fatal("a shape this file never declared was named")
+		} else if !strings.Contains(err.Error(), "Result is not a declared shape") {
 			t.Errorf("error = %q", err)
 		}
 	})
@@ -282,17 +282,36 @@ func TestAFieldThePromiseDoesNotHave(t *testing.T) {
 	}
 }
 
-// A scope that promised nothing hands over a run of tapes and no shape, which is what it did
-// before any of this: the reading file has to name one, and there is nothing to name.
-func TestAScopeThatPromisedNothingCrossesNothing(t *testing.T) {
+// A scope that wrote no `returns` crosses anyway, because the compiler read what its body
+// ends with — and what crosses is what a declaration would have sent: the shape and its
+// fields, so the reading file turns a field name into an index without naming anything.
+func TestAScopeThatDeclaredNothingCrossesWhatItReturns(t *testing.T) {
 	projectOf(t, map[string]string{
 		"src/os.ar":   "shape Env { found, value };\nident lookup = defer { Env{1, 42}; };",
+		"src/main.ar": "use os as o;\nident r = o.lookup(1);\nprintd r.value;",
+	})
+
+	printed, err := run(t, "src/main.ar")
+	if err != nil {
+		t.Fatalf("running: %v", err)
+	}
+	if strings.TrimSpace(printed) != "42" {
+		t.Errorf("printed %q, want the second tape of the run", printed)
+	}
+}
+
+// What still crosses as nothing is a scope whose shape nobody could work out: its body ends
+// with arithmetic, which is a tape and not a run. The reading file has to name a shape and
+// there is nothing to name — which is where `returns` earns its place.
+func TestAScopeWhoseShapeNothingSaysCrossesNothing(t *testing.T) {
+	projectOf(t, map[string]string{
+		"src/os.ar":   "shape Env { found, value };\nident lookup = defer { feed(0) * 2; };",
 		"src/main.ar": "use os as o;\nident r = o.lookup(1);\nprintd r.found;",
 	})
 
 	_, err := run(t, "src/main.ar")
 	if err == nil {
-		t.Fatal("a field was read off a scope that promised nothing")
+		t.Fatal("a field was read off a scope whose shape nothing says")
 	}
 	if !strings.Contains(err.Error(), "nothing says which shape this value is") {
 		t.Errorf("error = %q", err)

--- a/hosting/cli/shape_test.go
+++ b/hosting/cli/shape_test.go
@@ -192,9 +192,9 @@ func TestAShapeComesOutOfAScope(t *testing.T) {
 	}
 }
 
-// A promise, kept, and the claim gone from the call site: the shape is known because the
+// A declaration, kept, and the claim gone from the call site: the shape is known because the
 // scope said so, and the compiler checked that it said the truth.
-func TestAPromisedShapeIsReadWithoutAClaim(t *testing.T) {
+func TestADeclaredShapeIsReadWithoutAClaim(t *testing.T) {
 	const source = "shape Result { failed, value };\n" +
 		"ident divide = defer {\n" +
 		"  if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; };\n" +

--- a/hosting/cli/test_test.go
+++ b/hosting/cli/test_test.go
@@ -186,7 +186,7 @@ assert(a bigger 0, "still runs after a failure");
 	}
 }
 
-// A shape crosses from the module a test names, which is how a test builds one: the promise
+// A shape crosses from the module a test names, which is how a test builds one: the shape
 // and the name both travel, and a field is an index resolved while parsing.
 func TestAShapeCrossesFromTheModuleATestNames(t *testing.T) {
 	dir := project(t)

--- a/hosting/repl/session_test.go
+++ b/hosting/repl/session_test.go
@@ -284,9 +284,9 @@ func TestASessionWithoutAResolverRefusesToPretend(t *testing.T) {
 	}
 }
 
-// A shape crosses into a session with the promise that names it, so a field is read off an
+// A shape crosses into a session with the scope that returns it, so a field is read off an
 // imported scope without anybody naming the shape.
-func TestASessionReadsAPromisedShape(t *testing.T) {
+func TestASessionReadsAReturnedShape(t *testing.T) {
 	dir := withModule(t, "shape Env { found, value };\nident lookup = defer { Env{1, 42}; } returns Env;")
 	got := typedIn(t, dir, "use geometry as g;\nident r = g.lookup(0);\nprintd r.value;\n", 0)
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -726,14 +726,14 @@ func (p *pr) parseBlock() (ast.BlockExpression, error) {
 		return ast.BlockExpression{}, err
 	}
 
-	// The promise is read here, which is the one place it is written. The body of an if is
+	// The declaration is read here, which is the one place it is written. The body of an if is
 	// read straight rather than through here, so it never takes one.
-	promised, err := p.parseReturns(exprs, closing)
+	declared, err := p.parseReturns(exprs, closing)
 	if err != nil {
 		return ast.BlockExpression{}, err
 	}
 
-	return ast.BlockExpression{Body: exprs, Returns: promised}, nil
+	return ast.BlockExpression{Body: exprs, Returns: declared}, nil
 }
 
 func (p *pr) ParseDefer() (ast.Node, error) {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -821,10 +821,16 @@ func (p *pr) ParseIdent() (ast.Node, error) {
 	if shape := p.shapeOf(expr); shape != "" {
 		p.declarations.Reads[name] = shape
 	}
-	// A scope that promised is not itself a shape — its value is an index — so what is
-	// written down is what calling it answers with.
-	if scope, ok := expr.(ast.DeferExpression); ok && scope.Block.Returns != "" {
-		p.declarations.Returns[name] = scope.Block.Returns
+	// A scope is not itself a shape — its value is an index — so what is written down is
+	// what calling it returns. The `returns` says it when it is there, and when it is not
+	// the shape is worked out from what the body ends with, which is the same walk that
+	// checks the declaration. So a caller reads a field of what came back either way, and
+	// writing `returns` is a constraint the compiler keeps rather than the only way to be
+	// understood.
+	if scope, ok := expr.(ast.DeferExpression); ok {
+		if shape := p.shapeOf(scope.Block); shape != "" {
+			p.declarations.Returns[name] = Return{Shape: shape, Declared: scope.Block.Returns != ""}
+		}
 	}
 	return ast.IdentLiteral{Id: name, Token: id, Value: expr}, nil
 }

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -73,8 +73,8 @@ func TestWhatItReturnsIsOnTheBlock(t *testing.T) {
 	}
 }
 
-// A block that promises nothing is a block, and answers with a run of tapes as it always did.
-func TestABlockWithoutAPromiseIsUnchanged(t *testing.T) {
+// A block that declares nothing is a block, and returns a run of tapes as it always did.
+func TestABlockWithoutADeclarationIsUnchanged(t *testing.T) {
 	nodes := parse(t, person+"{ Person{\"Joana\"}; };")
 
 	if block := nodes[1].(ast.BlockExpression); block.Returns != "" {
@@ -82,8 +82,8 @@ func TestABlockWithoutAPromiseIsUnchanged(t *testing.T) {
 	}
 }
 
-// Every way of breaking the promise, and what it says.
-var brokenPromises = []struct {
+// Every way of breaking a declaration, and what it says.
+var brokenDeclarations = []struct {
 	name   string
 	source string
 	want   string
@@ -134,7 +134,7 @@ var brokenPromises = []struct {
 }
 
 func TestABlockThatDoesNotKeepItsDeclaration(t *testing.T) {
-	for _, tc := range brokenPromises {
+	for _, tc := range brokenDeclarations {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := parseSource(t, tc.source, "main.ar")
 			if err == nil {
@@ -151,9 +151,9 @@ func TestABlockThatDoesNotKeepItsDeclaration(t *testing.T) {
 	}
 }
 
-// A scope that promised gives its callers a shape, so the claim disappears from the place it
+// A scope that declared gives its callers a shape, so the claim disappears from the place it
 // used to be repeated once per call.
-func TestACallToAScopeThatPromisedHasAShape(t *testing.T) {
+func TestACallToAScopeThatDeclaredHasAShape(t *testing.T) {
 	const source = result +
 		"ident divide = defer {\n" +
 		"if feed(1) equals 0 { Result{1, 0}; } else { Result{0, feed(0) / feed(1)}; };\n" +
@@ -174,7 +174,7 @@ func TestACallToAScopeThatPromisedHasAShape(t *testing.T) {
 // A scope that wrote no `returns` is understood anyway, because the compiler reads what its
 // body ends with — which is the same walk that checks a `returns` when there is one.
 //
-// So the claim disappears from the caller without the scope having to make a promise. What
+// So the claim disappears from the caller without the scope having to declare anything. What
 // `returns` is for is what a walk cannot reach.
 func TestACallToAScopeThatDeclaredNothing(t *testing.T) {
 	const source = result + "ident divide = defer { Result{0, 5}; };\nident r = divide(10, 2);\nprintd r.value;"
@@ -199,8 +199,8 @@ func TestACallToAScopeWhoseShapeNothingSays(t *testing.T) {
 	}
 }
 
-// A block bound to a name is the run of tapes itself, so the promise is the name's own shape.
-func TestABlockBoundToANameCarriesItsPromise(t *testing.T) {
+// A block bound to a name is the run of tapes itself, so what it returns is the name's own shape.
+func TestABlockBoundToANameCarriesWhatItReturns(t *testing.T) {
 	if _, err := parseSource(t, person+"ident p = { Person{\"Joana\"}; } returns Person;\nprintc p.name;", "main.ar"); err != nil {
 		t.Errorf("parsing: %v", err)
 	}

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -171,10 +171,24 @@ func TestACallToAScopeThatPromisedHasAShape(t *testing.T) {
 	}
 }
 
-// A scope that promised nothing gives nothing away, and reading a field off it still asks for
-// the claim — which is the half of the rule that does not change.
-func TestACallToAScopeThatPromisedNothing(t *testing.T) {
+// A scope that wrote no `returns` is understood anyway, because the compiler reads what its
+// body ends with — which is the same walk that checks a `returns` when there is one.
+//
+// So the claim disappears from the caller without the scope having to make a promise. What
+// `returns` is for is what a walk cannot reach.
+func TestACallToAScopeThatDeclaredNothing(t *testing.T) {
 	const source = result + "ident divide = defer { Result{0, 5}; };\nident r = divide(10, 2);\nprintd r.value;"
+
+	if _, err := parseSource(t, source, "main.ar"); err != nil {
+		t.Errorf("parsing: %v", err)
+	}
+}
+
+// What is still not known is a body that ends with something that is not a shape, and reading
+// a field off it is refused where it was written — which is the half of the rule that does not
+// change, and the reason the message is still worth having.
+func TestACallToAScopeWhoseShapeNothingSays(t *testing.T) {
+	const source = result + "ident divide = defer { feed(0) / feed(1); };\nident r = divide(10, 2);\nprintd r.value;"
 
 	_, err := parseSource(t, source, "main.ar")
 	if err == nil {
@@ -189,5 +203,47 @@ func TestACallToAScopeThatPromisedNothing(t *testing.T) {
 func TestABlockBoundToANameCarriesItsPromise(t *testing.T) {
 	if _, err := parseSource(t, person+"ident p = { Person{\"Joana\"}; } returns Person;\nprintc p.name;", "main.ar"); err != nil {
 		t.Errorf("parsing: %v", err)
+	}
+}
+
+// What a scope returns says who worked it out, which is the only difference between the two
+// ways of knowing.
+//
+// It exists so somebody can be shown what the compiler knows and where it got it — an editor
+// telling a shape apart from a claim, a message about a `returns` that was not kept. The shape
+// itself is used the same either way, which is the point of inferring it.
+func TestWhatAScopeReturnsSaysWhoSaidIt(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		source   string
+		declared bool
+	}{
+		{
+			name:     "the file wrote it",
+			source:   person + "ident make = defer { Person{\"Joana\"}; } returns Person;",
+			declared: true,
+		},
+		{
+			name:     "the compiler read the body",
+			source:   person + "ident make = defer { Person{\"Joana\"}; };",
+			declared: false,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			tree, err := parseSource(t, tc.source, "main.ar")
+			if err != nil {
+				t.Fatalf("parsing: %v", err)
+			}
+			if len(tree.Returns) != 1 {
+				t.Fatalf("the tree carries %d, want the one scope", len(tree.Returns))
+			}
+			returns := tree.Returns[0]
+			if returns.Scope != "make" || returns.Shape != "Person" {
+				t.Errorf("%s returns %q, want make returning Person", returns.Scope, returns.Shape)
+			}
+			if returns.Declared != tc.declared {
+				t.Errorf("declared = %v, want %v", returns.Declared, tc.declared)
+			}
+		})
 	}
 }

--- a/parser/returns_test.go
+++ b/parser/returns_test.go
@@ -114,6 +114,14 @@ var brokenPromises = []struct {
 		want:   "the if returns a number",
 	},
 	{
+		// Deeper than one arm. What a body returns is decided in one place, and this is the
+		// other walk — the one that only runs once it is already broken, to say where. It has
+		// to keep descending, or a break far enough in would be reported as the whole if.
+		name:   "an arm of an inner if that returns something else",
+		source: person + "{ if true { if true { 0; } else { Person{\"Joana\"}; }; } else { Person{\"Joana\"}; }; } returns Person;",
+		want:   "the if returns a number",
+	},
+	{
 		name:   "a shape nobody declared",
 		source: "{ 10; } returns Person;",
 		want:   "Person is not a declared shape",

--- a/parser/shapes.go
+++ b/parser/shapes.go
@@ -36,10 +36,10 @@ type Declarations struct {
 	// Modules is what `use` declared: alias -> specifier. It belongs to the file that wrote
 	// it and to no other, which is the whole point of the alias being mandatory.
 	Modules map[string]string
-	// Returns is the name of a scope -> the shape calling it returns. It is not the shape of
+	// Returns is the name of a scope -> what calling it returns. It is not the shape of
 	// the name itself — a deferred scope is an index —
 	// but the shape of what comes back from it.
-	Returns map[string]string
+	Returns map[string]Return
 }
 
 func NewDeclarations() *Declarations {
@@ -47,7 +47,7 @@ func NewDeclarations() *Declarations {
 		Shapes:  make(map[string][]string),
 		Reads:   make(map[string]string),
 		Modules: make(map[string]string),
-		Returns: make(map[string]string),
+		Returns: make(map[string]Return),
 	}
 }
 
@@ -65,7 +65,7 @@ func (d *Declarations) Import(specifier string, offer ast.Offer) {
 		// fields come with it rather than being looked up.
 		shape := module.Qualify(module.ID(specifier), returns.Shape)
 		d.Shapes[shape] = returns.Fields
-		d.Returns[module.Qualify(module.ID(specifier), returns.Scope)] = shape
+		d.Returns[module.Qualify(module.ID(specifier), returns.Scope)] = Return{Shape: shape, Declared: returns.Declared}
 	}
 }
 
@@ -328,8 +328,8 @@ func (p *pr) shapeOf(node ast.Node) string {
 		return p.shapeOfLast(n.Body)
 	case ast.CalleeLiteral:
 		// Not the shape of the name, which is a deferred scope, but of what calling it
-		// returns — which is only known because the scope declared it.
-		return p.declarations.Returns[n.Id.Value]
+		// returns — whether the scope declared it or the compiler worked it out.
+		return p.declarations.Returns[n.Id.Value].Shape
 	case ast.IfExpression:
 		if n.Else == nil {
 			return ""
@@ -371,14 +371,15 @@ func (p *pr) returns(nodes []ast.Node) []ast.Returns {
 		if !ok {
 			continue
 		}
-		shape, known := p.declarations.Returns[binding.Id]
+		returns, known := p.declarations.Returns[binding.Id]
 		if !known {
 			continue
 		}
 		found = append(found, ast.Returns{
-			Scope:  p.bare(binding.Id),
-			Shape:  shape,
-			Fields: p.declarations.Shapes[shape],
+			Scope:    p.bare(binding.Id),
+			Shape:    returns.Shape,
+			Fields:   p.declarations.Shapes[returns.Shape],
+			Declared: returns.Declared,
 		})
 	}
 	return found
@@ -510,4 +511,14 @@ func describeReturn(node ast.Node) string {
 		return "a comparison"
 	}
 	return "something no shape was named for"
+}
+
+// Return is what calling a scope gives back: which shape, and who said so.
+//
+// Both are one fact and are read the same way — a field is reached on a call whether the
+// shape was declared or worked out. Declared is there because the two are told apart when
+// somebody is being shown what the compiler knows, and when a `returns` has to be kept.
+type Return struct {
+	Shape    string
+	Declared bool
 }

--- a/parser/shapes.go
+++ b/parser/shapes.go
@@ -418,7 +418,7 @@ func (p *pr) parseReturns(body []ast.Node, closing token.Token) (string, error) 
 	if err != nil {
 		return "", err
 	}
-	if err := p.returnsWhatItDeclared(body, declared, "", closing); err != nil {
+	if err := p.returnsWhatItDeclared(body, declared, closing); err != nil {
 		return "", err
 	}
 	return declared, nil
@@ -426,9 +426,26 @@ func (p *pr) parseReturns(body []ast.Node, closing token.Token) (string, error) 
 
 // returnsWhatItDeclared refuses a body that ends with something other than what was declared.
 //
-// A `where` names the arm being read, so a declaration broken inside a branch says which one; the
-// block itself has no name and simply ends.
-func (p *pr) returnsWhatItDeclared(body []ast.Node, declared, where string, at token.Token) error {
+// What a body returns is worked out by shapeOfLast, and that is the only thing that decides
+// whether the declaration was kept. It used to be decided here instead, by a walk of its own
+// that went through the arms of an if the same way shapeOfLast does — two descriptions of one
+// traversal, which is how a compiler comes to accept in one place what it refuses in another.
+//
+// What is left below runs only when the declaration was broken, and it is about saying where.
+func (p *pr) returnsWhatItDeclared(body []ast.Node, declared string, at token.Token) error {
+	if p.shapeOfLast(body) == declared {
+		return nil
+	}
+	return p.whereItBroke(body, declared, "", at)
+}
+
+// whereItBroke names the place a declaration was not kept, for somebody reading the error.
+//
+// A `where` names the arm being read, so a declaration broken inside a branch says which one;
+// the block itself has no name and simply ends. It walks the same shape shapeOfLast walks, and
+// it may only do that because it never decides anything — by the time it runs, the answer is
+// already known and this is looking for the words.
+func (p *pr) whereItBroke(body []ast.Node, declared, where string, at token.Token) error {
 	if len(body) == 0 {
 		return brokenDeclaration(at, declared, where, "nothing")
 	}
@@ -442,10 +459,10 @@ func (p *pr) returnsWhatItDeclared(body []ast.Node, declared, where string, at t
 			return token.NewError(at, "this block returns %s and its if has no else at line %d and column %d: one path returns nothing",
 				declared, at.GetLine(), at.GetColumn())
 		}
-		if err := p.returnsWhatItDeclared(answer.Body, declared, "the if", at); err != nil {
+		if err := p.whereItBroke(answer.Body, declared, "the if", at); err != nil {
 			return err
 		}
-		return p.returnsWhatItDeclared(answer.Else.Body, declared, "the else", at)
+		return p.whereItBroke(answer.Else.Body, declared, "the else", at)
 	}
 
 	if p.shapeOf(last) == declared {

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -29,14 +29,14 @@ type Read func(path string) ([]byte, error)
 
 // Parse turns one module's source into a tree. Filename is where it came from, which is what
 // positions and file-scoped rules are about; ID is the module the names inside belong to; and
-// imports is what the modules it names promised, which it needs while parsing because a shape
+// imports is what the modules it names offer, which it needs while parsing because a shape
 // is resolved there and a shape's name never leaves the file that declared it.
 type Parse func(filename string, id module.ID, source []byte, imports map[string]ast.Offer) (ast.AST, error)
 
 // Header answers what a source imports, without parsing it.
 //
 // It exists because a module has to be read before whoever imports it — the parse of a file
-// needs what its dependencies promised — and knowing what to read first cannot itself require
+// needs what its dependencies offer — and knowing what to read first cannot itself require
 // a parse. The declarations are the top of the file, so reading the top is enough.
 type Header func(source []byte) ([]ast.UseDeclaration, error)
 
@@ -193,7 +193,7 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 	}
 
 	// Everything this module names is read before it is, which is what lets its parse be
-	// handed what they promised.
+	// handed what they offer.
 	state.open = append(state.open, id)
 	for _, use := range uses {
 		if err := r.resolveOne(state, use); err != nil {

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -34,8 +34,8 @@ Java e TypeScript — porque os dois adiam para um alvo que carrega nomes, e a E
 
 Antes dela, `returns.md` — um bloco promete a forma que responde, e o compilador recusa o
 bloco que não cumpre. Foi implementada no mesmo dia em que foi escrita, e o que ficou decidido
-está em [docs/language-design.md](../docs/language-design.md), na seção "Promising a shape with
-`returns`" — incluindo o que ela decidiu **contra**: a promessa não é exigida, e não será nunca,
+está em [docs/language-design.md](../docs/language-design.md), na seção "Declaring a shape with
+`returns`" — incluindo o que ela decidiu **contra**: o `returns` não é exigido, e não será nunca,
 porque um escopo não tem assinatura e exigir que ele declare o que responde seria declarar uma
 ponta e não a outra.
 

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -279,6 +279,11 @@ type Returns struct {
 	Scope  string   `json:"scope"`
 	Shape  string   `json:"shape"`
 	Fields []string `json:"fields"`
+	// Declared says whether the module's own file wrote the `returns`, or the compiler
+	// worked the shape out from what the scope ends with. The shape is the same fact
+	// either way and is used the same way; this only says who said it, which is what an
+	// editor shows and what a message about a mismatch can lean on.
+	Declared bool `json:"declared"`
 }
 
 // A Reference is one qualified name, and where it was written.

--- a/wire/ir/ir_test.go
+++ b/wire/ir/ir_test.go
@@ -8,7 +8,7 @@ import (
 // The IR is what the phases agree on, and until it moved here it had no tests of its own: the
 // emitter and the builder each tested what they made of it, and nobody tested the thing
 // itself. What follows is the contract — that an instruction never holds nothing where it
-// promised bytes, that every opcode answers to a name, and that a program written down reads
+// bytes it says, that every opcode answers to a name, and that a program written down reads
 // the same way every time.
 
 // An instruction is handed to a builder and to an evaluator, and both index into its


### PR DESCRIPTION
## O que o usuário ganha

Ler um campo do que uma chamada devolve, sem escrever nada:

```aurora
shape Square { width, height };

ident new_square = defer { Square{feed(0), feed(1)}; };

ident s = new_square(30, 20);
printd s.width;    #- 30
```

Hoje isso **não compila** — sem `returns Square` no escopo, cada chamador tinha que
repetir `as Square`, que é exatamente a afirmação que o `returns` existia para tirar,
devolvida uma chamada por vez.

Atravessa módulo do mesmo jeito, e nenhum dos dois arquivos escreve uma palavra:

```aurora
#- src/os.ar
shape Env { found, value };
ident lookup = defer { Env{1, 42}; };
```
```aurora
#- src/main.ar
use os as o;
ident r = o.lookup(1);
printd r.value;    #- 42
```

## O que o `returns` passa a ser

Uma **restrição que o compilador cumpre**, não a fonte do fato. Escrever `returns Env`
não muda o que atravessa; o que ele faz é prender o arquivo àquilo — um corpo que muda
e deixa de devolver um `Env` é recusado no arquivo que errou, e não numa chamada em
outro. Continua não sendo exigido, e não será.

O que segue desconhecido segue recusado: um corpo que termina em aritmética é uma tape,
não uma run. É aí, e só aí, que quem lê um campo escreve `as`.

## Os commits

1. **`refactor`** — a checagem de uma declaração percorria o corpo por conta própria,
   através dos braços de um `if`, para descobrir o que ele devolvia; é a mesma travessia
   que o `shapeOfLast` já fazia. Duas descrições de uma coisa é como um compilador passa
   a aceitar num lugar o que recusa noutro, e esta estava prestes a ganhar um segundo
   leitor. Agora quem decide é o `shapeOfLast`; o segundo passeio ficou, mas só roda
   depois que já se sabe que quebrou, e só para dizer onde.
2. **`feat`** — a inferência, e `Declared` viajando ao lado do shape para dizer quem
   descobriu. Os dois são o mesmo fato e são lidos igual; `Declared` é para mostrar a
   alguém de onde veio.
3. **`docs`** — a documentação ensinava o contrário disso, e os exemplos repetiam nos
   próprios comentários. Junto vai a palavra "promise", que já tinha saído dos nomes e
   tinha ficado nos comentários e nos nomes de teste.
4. **`docs`** — os três lugares onde o compilador para, no roadmap.

## O que mudou de comportamento, e por quê

Três testes afirmavam que um escopo sem `returns` não dá nada. Eram a descrição certa
de ontem, e foram reancorados no que continua verdadeiro: `TestAScopeWhoseShapeNothingSaysCrossesNothing`
e `TestACallToAScopeWhoseShapeNothingSays` cobrem o corpo que ninguém consegue resolver,
e `TestAShapeValueCrossesAModuleButItsDeclarationDoesNot` passou a provar a metade que
não mudou — nomear `Result` no arquivo que importa continua recusado.

`examples/project/src/geometry.ar` continua com `returns Square`, continua compilando e
continua sendo **conferido**: inferir não virou aceitar declaração errada.

## Verificação

`make check` verde a cada commit. O exemplo novo de `language-design.md` roda no
`docs_test`, então a saída documentada é comparada com a real.

## O que este PR não faz

O LSP continua montando a tabela dele varrendo tokens, que reconhece menos do que o
compilador. Ele precisa continuar tendo algo assim — completar nome tem que funcionar
em documento meio digitado, que não parseia — mas não precisa usar isso quando o parse
deu certo. É o próximo passo da [RFC](rfcs/shape_inference.md), e é por isso que a
palavra "promise" ficou só naquele pacote: o arquivo é reescrito lá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)