### PR TITLE
The editor reads what the compiler knows

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -81,11 +81,12 @@ are for:
 - **A scope that calls itself is not known either**, for the same reason and by the same
   mechanism: the name is not in the table while its own body is being read. This is what
   keeps the walk from being a recursion at all, so it is a limit bought on purpose.
-- **The editor still reads tokens, not the compiler.** The language server builds its own
-  table by matching patterns over the tokens, which recognises less than the compiler does —
-  no block, no `if` whose arms agree, no chain of bindings. It has to keep something like it,
-  because completing a name has to work in a document half-typed that does not parse; what it
-  does not have to do is use it when the parse succeeded.
+- **The editor knows what the compiler knows, and reads tokens where it did not get there.**
+  The language server hands the parser its table and reads it back, so what the compiler
+  worked out is what the editor offers — and because the table is filled as the file is read,
+  a parse that broke on the line being typed still leaves everything above it understood. The
+  walk of the tokens stays underneath, matching patterns, for the document that breaks before
+  the parser reads anything at all. It recognises less, and less is all it has to be.
 
 ## Modules
 

--- a/hosting/lsp/textdoc/definition_test.go
+++ b/hosting/lsp/textdoc/definition_test.go
@@ -198,7 +198,7 @@ func TestDefinitionInsideAModule(t *testing.T) {
 	}
 }
 
-// A shape written as the module's — built, claimed or promised — is declared over there too.
+// A shape written as the module's — built, claimed or declared — is declared over there too.
 func TestDefinitionOfAShapeNamedThroughItsModule(t *testing.T) {
 	session := withModuleFiles(map[string]string{"src/geometry.ar": "shape Square { width, height };\n"})
 	found, ok := session.DefinitionFor(Document{

--- a/hosting/lsp/textdoc/modules.go
+++ b/hosting/lsp/textdoc/modules.go
@@ -105,7 +105,7 @@ func exportCompletions(analysis *Analysis, specifier string) []CompletionItem {
 			Kind:   Variable,
 		})
 	}
-	// The shapes a module declares can be written now — built, claimed with as, promised
+	// The shapes a module declares can be written now — built, claimed with as, declared
 	// with returns — so they are offered, and offering them is telling the truth.
 	for _, shape := range found.Tree.Shapes {
 		items = append(items, CompletionItem{
@@ -161,13 +161,22 @@ func exportedValue(found module.Module, name string) ast.Node {
 }
 
 // shapesOf is everything the editor knows about shapes while a document is being edited:
-// what the modules it imports offer, and then what the document itself says on top.
+// what the modules it imports offer, what a walk of the tokens could make out, and then what
+// the compiler worked out on top of both.
 //
-// The order is the point. A name bound here can be read as a shape declared over there —
-// `ident s = g.new_square(1, 2);` — and the reader of the tokens only knows what that call
-// returns if the promise is already written down when it walks past the call.
+// The order is the point, and each step is there because the one before it cannot do
+// everything. The imports come first because a name bound here can be read as a shape
+// declared over there — `ident s = g.new_square(1, 2);` — and the walk of the tokens only
+// knows what that call returns if it is already written down when it walks past the call.
+// The compiler comes last because when it has an answer, it is the answer: it reads a block,
+// an if whose arms agree, and a chain of bindings, none of which a walk of the tokens can
+// follow.
+//
+// The walk stays because completion is wanted exactly when the document does not parse — the
+// moment somebody types `p.` there is no field name yet — and then the compiler has nothing
+// to say about the rest of the file.
 func shapesOf(analysis *Analysis, aliases moduleAliases) shapeTable {
-	return importedShapes(analysis, aliases).scan(analysis.Tokens)
+	return importedShapes(analysis, aliases).scan(analysis.Tokens).adopt(analysis.Declarations, aliases)
 }
 
 // importedShapes is what the modules a document imports offer, written the way this document
@@ -175,9 +184,9 @@ func shapesOf(analysis *Analysis, aliases moduleAliases) shapeTable {
 // through the alias or not at all.
 //
 // It is the parser's own Import with the alias in front instead of the specifier — the same
-// two halves, read for the same reason. The shapes say what a construction is made of; the
-// returns say what a call gives back, which is the only shape a name bound from another
-// module's scope ever has.
+// two halves, read for the same reason. The shapes say what a construction is made of; what
+// a scope returns says what a call gives back, which is the only shape a name bound from
+// another module's scope ever has.
 func importedShapes(analysis *Analysis, aliases moduleAliases) shapeTable {
 	shapes := newShapeTable()
 	for alias, specifier := range aliases {

--- a/hosting/lsp/textdoc/modules_test.go
+++ b/hosting/lsp/textdoc/modules_test.go
@@ -295,7 +295,7 @@ func TestWithoutThePortNothingIsResolved(t *testing.T) {
 }
 
 // A module's shapes are offered after the dot too, now that they can be written: built,
-// claimed with as, or promised with returns.
+// claimed with as, or declared with returns.
 func TestTheEditorOffersAModuleShapes(t *testing.T) {
 	session := withModuleFiles(map[string]string{
 		"src/geometry.ar": "shape Square { width, height };\nident area = defer { feed(0); };",
@@ -326,7 +326,7 @@ func TestTheEditorOffersAModuleShapes(t *testing.T) {
 
 // And a name whose shape came from another file returns its fields after the dot, which
 // is the whole point of the shape crossing: however the name got it — built here, claimed
-// with as, or promised by the scope that answered.
+// with as, or read from the scope that returned it.
 func TestCompletionOnAShapeFromAnotherModule(t *testing.T) {
 	const geometry = "shape Square { width, height };\n" +
 		"ident new_square = defer { Square{feed(0), feed(1)}; } returns Square;\n" +
@@ -341,7 +341,7 @@ func TestCompletionOnAShapeFromAnotherModule(t *testing.T) {
 			source: "use geometry as g;\nident s = g.Square{4, 5};\nprintd s.",
 		},
 		{
-			name:   "answered by a scope that promised",
+			name:   "returned by a scope that declared",
 			source: "use geometry as g;\nident s = g.new_square(4, 5);\nprintd s.",
 		},
 		{
@@ -349,7 +349,7 @@ func TestCompletionOnAShapeFromAnotherModule(t *testing.T) {
 			source: "use geometry as g;\nident s = feed(0) as g.Square;\nprintd s.",
 		},
 		{
-			name:   "promised by a scope written here",
+			name:   "declared by a scope written here",
 			source: "use geometry as g;\nident make = defer { g.Square{1, 2}; } returns g.Square;\nident s = make();\nprintd s.",
 		},
 	} {

--- a/hosting/lsp/textdoc/shapes.go
+++ b/hosting/lsp/textdoc/shapes.go
@@ -4,6 +4,10 @@ import (
 	"slices"
 	"strconv"
 
+	"strings"
+
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/module"
 	"github.com/guiferpa/aurora/wire/token"
 )
 
@@ -48,7 +52,7 @@ func (found shapeTable) scan(tokens []token.Token) shapeTable {
 			}
 		case token.IDENT:
 			// `ident p = Point{`, `ident p = <anything> as Point` and a call to a scope that
-			// promised all say what p is; `ident f = defer { ... } returns Point` says what
+			// declared all say what p is; `ident f = defer { ... } returns Point` says what
 			// calling f will.
 			name, shape, declared, called := readBinding(tokens, i)
 			if declared != "" {
@@ -64,6 +68,57 @@ func (found shapeTable) scan(tokens []token.Token) shapeTable {
 	}
 
 	return found
+}
+
+// adopt writes what the compiler worked out over what the tokens suggested.
+//
+// The compiler wins wherever it has something to say, and says nothing where it did not get
+// that far — a parse that failed halfway leaves what it read up to there, and the walk of the
+// tokens keeps answering for the rest. Nothing is removed, because a table with less in it
+// than a keystroke ago is an editor that forgets.
+//
+// A shape of another module arrives under the specifier the import named, and goes back under
+// the alias, because that is the only way the document can write it and the name is shown to
+// somebody. Everything else is already written the way it was typed: the language server
+// parses with no module of its own, so nothing local is qualified.
+func (found shapeTable) adopt(known *parser.Declarations, aliases moduleAliases) shapeTable {
+	if known == nil {
+		return found
+	}
+	written := writtenAs(aliases)
+	for name, fields := range known.Shapes {
+		found.fields[written(name)] = fields
+	}
+	for name, shape := range known.Reads {
+		found.reads[written(name)] = written(shape)
+	}
+	for name, returns := range known.Returns {
+		found.returns[written(name)] = written(returns.Shape)
+	}
+	return found
+}
+
+// writtenAs turns a name the parser qualified by specifier into the one the document typed.
+//
+// A name of this document comes back untouched, and so does one of a module the document
+// does not import — there is no way to write that one at all, and inventing one would offer
+// a completion that cannot be accepted.
+func writtenAs(aliases moduleAliases) func(string) string {
+	bySpecifier := make(map[string]string, len(aliases))
+	for alias, specifier := range aliases {
+		bySpecifier[specifier] = alias
+	}
+	return func(name string) string {
+		index := strings.LastIndex(name, module.Separator)
+		if index < 0 {
+			return name
+		}
+		alias, imported := bySpecifier[name[:index]]
+		if !imported {
+			return name
+		}
+		return alias + module.Separator + name[index:][1:]
+	}
 }
 
 // readDeclaration reads `shape Name { a, b }` starting at the shape token.
@@ -94,7 +149,7 @@ func readDeclaration(tokens []token.Token, i int) (string, []string, int) {
 // Only what sits at the top of the value is read. A body between braces is another scope's
 // business — the semicolons in it do not end this statement, and a construction inside it says
 // what that scope returns rather than what this name is.
-func readBinding(tokens []token.Token, i int) (name, shape, promised, called string) {
+func readBinding(tokens []token.Token, i int) (name, shape, declared, called string) {
 	if i+2 >= len(tokens) || tokens[i+1].GetTag().Id != token.ID || tokens[i+2].GetTag().Id != token.ASSIGN {
 		return "", "", "", ""
 	}
@@ -109,11 +164,11 @@ func readBinding(tokens []token.Token, i int) (name, shape, promised, called str
 			depth--
 		case token.SEMICOLON:
 			if depth <= 0 {
-				return name, shape, promised, called
+				return name, shape, declared, called
 			}
 		case token.RETURNS:
 			if claimed := claimedAt(tokens, j+1); depth == 0 && claimed != "" {
-				promised = claimed
+				declared = claimed
 			}
 		case token.AS:
 			// The nearest `as` wins, which is the one the value ends up with.
@@ -129,12 +184,12 @@ func readBinding(tokens []token.Token, i int) (name, shape, promised, called str
 				// A construction: the name of a shape in front of a brace.
 				shape = nameAt(tokens, j)
 			case token.O_PAREN:
-				// A call: what it returns is known when that scope promised.
+				// A call: what it returns is known when that scope declared.
 				called = nameAt(tokens, j)
 			}
 		}
 	}
-	return name, shape, promised, called
+	return name, shape, declared, called
 }
 
 // nameAt reads the name at this position the way the document wrote it: `Square`, or

--- a/hosting/lsp/textdoc/shapes_test.go
+++ b/hosting/lsp/textdoc/shapes_test.go
@@ -138,10 +138,14 @@ func TestSemanticTokensForShapes(t *testing.T) {
 	}
 }
 
-// A promise reaches the editor too, and it reaches it from the tokens: a document being
-// edited does not parse, and the moment somebody types a dot is the moment they want to be
-// told what is there.
-func TestTheEditorReadsAPromise(t *testing.T) {
+// What a scope returns reaches the editor, and it reaches it from the compiler — even here,
+// where the document does not parse.
+//
+// That is the point of handing the parser its table rather than letting it keep its own: it
+// is filled as the file is read, so the three lines before the broken one are understood and
+// only the broken one is lost. A document being edited is broken most of the time, and the
+// moment somebody types a dot is the moment they want to be told what is there.
+func TestTheEditorReadsWhatAScopeReturns(t *testing.T) {
 	const source = "shape Result { failed, value };\n" +
 		"ident divide = defer {\n" +
 		"  if feed(1) equals 0 { Result{1, 0}; } else { Result{0, 1}; };\n" +
@@ -162,9 +166,12 @@ func TestTheEditorReadsAPromise(t *testing.T) {
 	}
 }
 
-// And a scope that promised nothing gives the editor nothing, the same way it gives the
-// compiler nothing.
-func TestTheEditorReadsNoPromiseWhereThereIsNone(t *testing.T) {
+// A scope that wrote no `returns` is understood too, because the editor reads what the
+// compiler worked out and the compiler reads what the body ends with.
+//
+// The walk of the tokens never could: it matches `returns Result` and nothing else. This is
+// the whole reason for asking the compiler first.
+func TestTheEditorReadsAScopeThatDeclaredNothing(t *testing.T) {
 	const source = "shape Result { failed, value };\n" +
 		"ident divide = defer { Result{1, 0}; };\n" +
 		"ident r = divide(10, 2);\n" +
@@ -173,9 +180,44 @@ func TestTheEditorReadsNoPromiseWhereThereIsNone(t *testing.T) {
 	document := Document{Filename: "main.ar", Source: source}
 	items := session().CompletionItemsFor(document, lsp.Position{Line: 3, Character: 9}, false)
 
-	for _, item := range items {
-		if item.Label == "failed" || item.Label == "value" {
-			t.Errorf("offered %q for a scope that promised nothing", item.Label)
+	if len(items) != 2 {
+		t.Fatalf("offered %d items after the dot, want the two fields: %+v", len(items), items)
+	}
+	for i, want := range []string{"failed", "value"} {
+		if items[i].Label != want {
+			t.Errorf("offered %q, want %q", items[i].Label, want)
+		}
+	}
+}
+
+// And the walk of the tokens still answers where the compiler never arrived.
+//
+// The first line here is broken, so the parser reads nothing at all and its table is empty —
+// which is the case the walk exists for. It knows less than the compiler does, and less is
+// the whole of what it has to beat: completing a name has to work in a document that does
+// not parse, which is most of them while somebody is typing.
+func TestTheEditorFallsBackToTheTokens(t *testing.T) {
+	const source = "ident broken = ;\n" +
+		"shape Point { x, y };\n" +
+		"ident p = feed(0) as Point;\n" +
+		"printd p."
+
+	document := Document{Filename: "main.ar", Source: source}
+
+	// Said out loud, or the test passes for the wrong reason: both sources would offer x and
+	// y here, and this is the one that has to.
+	if left := session().Analyze(document).Declarations; len(left.Shapes) != 0 || len(left.Reads) != 0 {
+		t.Fatalf("the parser got somewhere after all: %v %v", left.Shapes, left.Reads)
+	}
+
+	items := session().CompletionItemsFor(document, lsp.Position{Line: 3, Character: 9}, false)
+
+	if len(items) != 2 {
+		t.Fatalf("offered %d items after the dot, want the two fields: %+v", len(items), items)
+	}
+	for i, want := range []string{"x", "y"} {
+		if items[i].Label != want {
+			t.Errorf("offered %q, want %q", items[i].Label, want)
 		}
 	}
 }

--- a/hosting/lsp/textdoc/validator.go
+++ b/hosting/lsp/textdoc/validator.go
@@ -47,6 +47,14 @@ type Analysis struct {
 	// a word that a parse cannot see, because they are about the whole of a tree rather
 	// than about a token.
 	Warnings []diag.Warning
+	// Declarations is what the parser worked out while reading this document: which shape
+	// each name is, and which shape calling each scope returns.
+	//
+	// It is here because the compiler is better at this than anything the editor could do
+	// on its own — it reads a block, an if whose arms agree, a chain of bindings — and
+	// because it is filled as the file is read, so a parse that failed in the middle still
+	// leaves what it understood before that.
+	Declarations *parser.Declarations
 }
 
 // module answers the module of a specifier among the ones this document imports.
@@ -96,13 +104,19 @@ func (s *Session) Analyze(doc Document) *Analysis {
 
 	// How wide a value is decides what fits in one, so the document is read in the dialect it
 	// belongs to rather than in the default.
+	//
+	// Declarations is handed in rather than left nil so it can be read back afterwards: the
+	// parser fills it as it goes, which means it is worth reading even when the parse ends
+	// in an error.
+	analysis.Declarations = parser.NewDeclarations()
 	tree, err := s.parser.Parse(parser.ParseInput{
 		Filename: doc.Filename,
 		Tokens:   tokens,
 		TapeSize: doc.TapeSize,
-		// What the modules it imports promised, which the resolution above just found: a
+		// What the modules it imports offer, which the resolution above just found: a
 		// shape is resolved while parsing, so it has to be in hand by now.
-		Imports: resolver.OffersOf(analysis.Modules),
+		Imports:      resolver.OffersOf(analysis.Modules),
+		Declarations: analysis.Declarations,
 	})
 	if err != nil {
 		analysis.Err = err


### PR DESCRIPTION
## O que o usuário ganha

Autocompletar de campo funciona onde antes não funcionava — escopo sem `returns`,
bloco, `if` cujos braços concordam, cadeia de ligações:

```aurora
shape Result { failed, value };
ident divide = defer { Result{1, 0}; };
ident r = divide(10, 2);
printd r.        #- agora oferece failed, value
```

O LSP montava a própria tabela casando padrões sobre os tokens — `shape N {`, `as N`,
`returns N` e nada mais. É uma cópia fraca do que o parser já faz, e depois do #146
ela ficou fraca de vez: um escopo que devolve um shape sem dizer isso é a maioria
deles agora.

## Como

O servidor passa uma `Declarations` no `ParseInput` e lê ela de volta. Isso importa
mais do que parece: **a tabela é preenchida conforme o arquivo é lido**, então um
parse que quebrou na linha que a pessoa está digitando ainda deixa tudo acima dela
entendido — que é exatamente a situação em que se quer completar.

O passeio de tokens **fica**, embaixo, para o documento que quebra antes do parser
chegar a qualquer lugar. Completar nome tem que funcionar aí também.

## O detalhe que quase passou

O parser qualifica pelo *specifier* (`geometry.Square`); o editor mostra o *alias*
(`g.Square`). Adotar a tabela crua fazia o hover dizer `geometry.Square` e o "ir para
definição" não achar nada — dois testes pegaram. O `adopt` traduz de volta para o
nome que o documento tem como escrever, porque esse nome é lido por uma pessoa.

## Testes

- `TestTheEditorReadsWhatAScopeReturns` — o caso com `returns`, num documento que
  não parseia, provando que o pedaço lido antes da quebra vale.
- `TestTheEditorReadsAScopeThatDeclaredNothing` — o que o passeio de tokens nunca
  conseguiu.
- `TestTheEditorFallsBackToTheTokens` — o documento quebrado na primeira linha.
  Ele **afirma antes** que a tabela do parser voltou vazia: as duas fontes ofereceriam
  os mesmos dois campos ali, então sem isso o teste passaria pelo motivo errado.

`make check` verde.

## Com isso a `rfcs/shape_inference.md` fecha

Os quatro passos entregues. O que sobra está nomeado em `docs/roadmap.md`, na seção
"Shapes": referência para frente e escopo que chama a si mesmo, os dois a um `returns`
de distância.

🤖 Generated with [Claude Code](https://claude.com/claude-code)