### PR TITLE
A block says how many tapes the run it returns is made of

### DIFF
--- a/docs/contributing/ir.md
+++ b/docs/contributing/ir.md
@@ -59,6 +59,92 @@ consumer never has to recognise that a run of instructions was one thing.
 
 Every opcode `wire/ir` declares computes a value. There is no opcode for control.
 
+### An effect says what else it does
+
+An instruction computes a value. Some of them also **do** something, and that is a different
+fact about the same instruction:
+
+```go
+ir.EffectOf(op)   // Pure, Reads, Writes or Escapes
+ir.MayCross(a, b) // whether two instructions may be put in the other order
+```
+
+| effect | means | what has it |
+|---|---|---|
+| `Pure` | the value it leaves is all it does | arithmetic, comparison, logic, the tape operations, a literal, a call |
+| `Reads` | depends on state something else can change | `OpLoad`, which reads the frame |
+| `Writes` | changes that state, or says something whose order matters | `OpIdent`, which writes the frame; the three prints |
+| `Escapes` | leaves the program: another contract runs, and may come back in | nothing yet |
+
+**An effect is not a value.** It is not a tape, not a run, it reaches no bytecode, and a
+program cannot name it — the language has no types and this does not add one under the floor.
+It exists while compiling, to answer one question, and then it is gone. It is metadata about
+the instruction, of the same kind as the `Origin` that says which line it came from.
+
+#### Why it exists
+
+Because a consumer is allowed to move instructions, and until it was written down, nothing
+said which ones. `builder/evm` holds an instruction back and emits it next to whoever takes
+its value, because the EVM wants operands on the stack in an order the program was not written
+in. That is sound for an instruction whose value is the whole of what it does. For one that
+writes, it is a different program:
+
+```
+printd a;
+printd b;
+```
+
+What kept that from happening was three lists of opcodes inside `builder/evm`, and **a list of
+opcodes is how this project has been wrong before**: the lowering once decided which operands
+named values by a list of the four arithmetic instructions, so a name bound inside a scope was
+not on it, and `ident x = feed(0); x + feed(1);` answered 4 on a chain where the program
+answers 7. Whoever writes the next opcode has to remember every list, and nothing reminds
+them. An effect is the same fact said once, next to the opcode, where forgetting it is
+visible.
+
+#### What it buys somebody writing Aurora
+
+Nothing they can see today, and that is worth being honest about: the only instruction whose
+order matters right now is the print, and a print does not reach a chain by decision. Nobody
+has been bitten.
+
+It buys the next thing. The moment a program can touch state that outlives one expression —
+
+```
+s.set("balance", 100);
+s.get("balance");
+```
+
+— the order those two run **is** the program, and there is no way to notice afterwards that a
+backend swapped them: the contract answers a number either way. This is exactly the class of
+failure Aurora exists to remove, since the whole point of the backend is that the same program
+answers the same thing on a chain and off it. So the rule lands before storage does, rather
+than after the first program gets it wrong.
+
+#### The rule
+
+Two instructions may swap unless one of them changes something the other would notice. The
+sixteen pairs are derived from that rather than listed:
+
+```go
+func MayCross(a, b Effect) bool { return !disturbs(a, b) && !disturbs(b, a) }
+func disturbs(a, b Effect) bool { return changes(a) && notices(b) }
+```
+
+It started stricter — swap only if one of them is `Pure` — and a measurement over real
+programs said stricter was wrong. `a - b` puts the two loads on the stack in the order the
+subtraction wants, which swaps two `Reads`, which is safe. Two reads of the frame commute; the
+strict rule refused them, in the most ordinary program there is.
+
+The effect is a function of the opcode, not a field on the instruction. A field is filled by
+whoever builds the instruction, so it can be filled wrong and nothing notices; an opcode has
+one effect wherever it appears. The day an instruction's effect depends on more than its
+opcode, the field arrives then and has a reason to.
+
+`require` is not an effect and will not become one. It does not compute and it does not
+annotate — it **branches**, to a block that reverts, and control has lived outside the
+instructions since a block gained a terminator.
+
 ### Operands say what they are
 
 This is the part that most repays reading. The same bytes mean different things, and the kind
@@ -250,6 +336,8 @@ The shortest honest list:
 4. For a call, resolve the name to a block number and run it.
 5. If you keep values under names, follow the open/close rule above. If you keep them on a
    stack, you do not need it.
+6. If you move an instruction — and you will, if you emit for a stack — ask `ir.MayCross`
+   first. Never keep your own list of which opcodes are safe to move.
 
 And one warning worth its own line: **anything you derive rather than read is a second
 description of the same program, and two descriptions drift.** Every silent bug this compiler

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -506,6 +506,57 @@ func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLit
 
 }
 
+// widened says how many tapes each block returns, for the scopes the file said something
+// about.
+//
+// The tree already knows: what a scope returns crosses a module with the fields of the shape,
+// and since the compiler works that out rather than waiting for a `returns`, it knows it for
+// most scopes rather than the few that declared. This is that fact reaching the blocks, where
+// a backend can read it.
+//
+// The way from a name to a block is two steps, because that is how a scope is bound: a save
+// carries the block under a label, and a binding carries the name and a ref to that label.
+func widened(blocks []ir.Block, returns []ast.Returns) []ir.Block {
+	tapes := make(map[string]int, len(returns))
+	for _, each := range returns {
+		tapes[each.Scope] = len(each.Fields)
+	}
+	if len(tapes) == 0 {
+		return blocks
+	}
+
+	for _, block := range blocks {
+		for name, id := range scopesBoundIn(block) {
+			if wide, said := tapes[name]; said && int(id) < len(blocks) {
+				blocks[id].Tapes = wide
+			}
+		}
+	}
+	return blocks
+}
+
+// scopesBoundIn answers which block each name in this block was bound to, for the names bound
+// to a scope. A name bound to anything else is not here, and neither is a block nobody named.
+func scopesBoundIn(block ir.Block) map[string]ir.BlockID {
+	held := make(map[string]ir.BlockID)
+	for _, inst := range block.Insts {
+		if inst.GetOpCode() == ir.OpSave && inst.GetLeft().Kind() == ir.KindBlock {
+			held[byteutil.ToHex(inst.GetLabel())] = inst.GetLeft().Block()
+		}
+	}
+
+	bound := make(map[string]ir.BlockID)
+	for _, inst := range block.Insts {
+		if inst.GetOpCode() != ir.OpIdent || inst.GetRight().Kind() != ir.KindRef {
+			continue
+		}
+		if id, isScope := held[byteutil.ToHex(inst.GetRight().Bytes())]; isScope {
+			bound[string(inst.GetLeft().Bytes())] = id
+		}
+	}
+	return bound
+}
+
 func (e *emt) Emit(tree ast.AST) ([]ir.Block, error) {
 	program, err := e.EmitProgram(tree)
 	if err != nil {
@@ -568,6 +619,7 @@ func (e *emt) EmitProgram(tree ast.AST) (ir.Program, error) {
 	warnings = append(warnings, checkAppliedValues(tree.Nodes)...)
 
 	blocks, places := placedBlocksOf(insts)
+	blocks = widened(blocks, tree.Returns)
 
 	return ir.Program{
 		Blocks:      blocks,

--- a/emitter/tapes_test.go
+++ b/emitter/tapes_test.go
@@ -1,0 +1,96 @@
+package emitter
+
+import (
+	"testing"
+
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// A block says how many tapes the value it returns is made of.
+//
+// A construction says its width by having that many operands and a field read carries the
+// width of the run it comes out of, so the one place nothing said it was the value coming
+// back from a call. That is a fact about the scope, which is why it is on the block.
+func TestABlockSaysHowWideTheRunItReturnsIs(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name:   "a scope that declared",
+			source: "shape P { a, b };\nident make = defer { P{1, 2}; } returns P;",
+			want:   2,
+		},
+		{
+			// The compiler works this out rather than waiting for a `returns`, so most
+			// scopes that return a run say so without the file writing a word.
+			name:   "a scope that declared nothing",
+			source: "shape P { a, b, c };\nident make = defer { P{1, 2, 3}; };",
+			want:   3,
+		},
+		{
+			name:   "a scope that returns a tape",
+			source: "ident add = defer { feed(0) + feed(1); };",
+			want:   0,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := blocksOfSource(t, tc.source)
+
+			widest := 0
+			for _, block := range blocks {
+				if block.Tapes > widest {
+					widest = block.Tapes
+				}
+			}
+			if widest != tc.want {
+				t.Errorf("the widest block returns %d tapes, want %d", widest, tc.want)
+			}
+		})
+	}
+}
+
+// The width lands on the scope's own block, and not on the one that binds it.
+//
+// Binding a scope to a name is an instruction of the block doing the binding; the run comes
+// back from the block that computes it, and that is the one a caller has to copy from.
+func TestTheWidthIsOnTheScopeAndNotOnWhoeverBoundIt(t *testing.T) {
+	blocks := blocksOfSource(t, "shape P { a, b };\nident make = defer { P{1, 2}; };\nmake();")
+
+	if len(blocks) < 2 {
+		t.Fatalf("a program with a scope came out as %d blocks", len(blocks))
+	}
+	if blocks[0].Tapes != 0 {
+		t.Errorf("the top of the program says %d tapes, and it returns no run", blocks[0].Tapes)
+	}
+
+	said := 0
+	for _, block := range blocks[1:] {
+		if block.Tapes == 2 {
+			said++
+		}
+	}
+	if said != 1 {
+		t.Errorf("%d blocks say they return two tapes, want the one scope", said)
+	}
+}
+
+func blocksOfSource(t *testing.T, source string) []ir.Block {
+	t.Helper()
+	tokens, err := lexer.New().GetFilledTokens([]byte(source))
+	if err != nil {
+		t.Fatalf("reading: %v", err)
+	}
+	tree, err := parser.New().Parse(parser.ParseInput{Filename: "main.ar", Tokens: tokens})
+	if err != nil {
+		t.Fatalf("parsing: %v", err)
+	}
+	program, err := New(NewEmitterOptions{}).EmitProgram(tree)
+	if err != nil {
+		t.Fatalf("emitting: %v", err)
+	}
+	return program.Blocks
+}

--- a/rfcs/effect.md
+++ b/rfcs/effect.md
@@ -169,7 +169,17 @@ Isso é a RFC seguinte, não esta.
    produz hoje, para todo programa do corpus, e diz o que ela recusaria. Ele é o que decide se
    o item 1 foi aditivo, e continua valendo depois como o teste que prova que a regra é
    cumprida — sem ele, o item 1 é uma anotação em que ninguém confia.
-3. **O IR diz quantos tapes um operando tem**, quando ele é um run.
+3. ~~O IR diz quantos tapes um operando tem, quando ele é um run.~~ **O bloco diz quantos
+   tapes ele retorna.** A forma estava errada, e escrever mostrou por quê: a largura já viaja
+   em dois dos três lugares. Uma construção diz a dela por **ter aquele tanto de operandos**, e
+   uma leitura de campo carrega a largura da run de onde ela sai — é o terceiro operando do
+   `OpField`, e ele existe exatamente por isto. O único lugar em que nada dizia é **o valor que
+   volta de uma chamada**, e isso é fato do escopo, não de nenhuma instrução dentro dele. Então
+   é `ir.Block.Tapes`, e não um operando.
+
+   Vale dizer de onde vem: o emitter lê `tree.Returns`, que é o que a `shape_inference` acabou
+   de encher. Antes dela isso valeria só para os escopos que escreveram `returns`; agora vale
+   para quase todos, sem o arquivo dizer nada.
 4. **O run vai para a memória**, e o teto de 32 bytes sai — com o harness diferencial provando
    um shape de cinco campos e um de oito.
 

--- a/wire/ir/block.go
+++ b/wire/ir/block.go
@@ -42,6 +42,18 @@ type Block struct {
 	Insts  []Instruction
 	Term   Terminator
 	Origin Origin
+	// Tapes is how many tapes the value this block returns is made of.
+	//
+	// One is a tape, which is every ordinary value; more than one is a run, which is what a
+	// shape is. Zero says nothing worked it out, and a consumer that does not care reads all
+	// three the same way — the value is bytes either way.
+	//
+	// It is here rather than on the instruction because it is the one place the width was
+	// missing. A construction says it by having that many operands, and a field read carries
+	// the width of the run it reads from; what nothing said is how wide the value coming back
+	// from a call is, and that is a fact about the scope rather than about any instruction in
+	// it. A target that keeps a run as bytes somewhere has to know how many to copy back.
+	Tapes int
 }
 
 // A TermKind is how a block ends. There are three, and there is no fourth: a block either


### PR DESCRIPTION
Dois commits: a documentação do `Effect` que você pediu, e o passo 3 da
[RFC](rfcs/effect.md) — que mudou de forma ao ser escrito.

## O que um `Effect` é, escrito onde ele mora

`docs/contributing/ir.md` ganhou uma seção, e ela abre dizendo o que ele **não** é:

> **An effect is not a value.** It is not a tape, not a run, it reaches no bytecode, and
> a program cannot name it — the language has no types and this does not add one under
> the floor.

Depois, por que existe (um consumidor pode mover instrução e nada dizia quais; o que
segurava eram três listas de opcodes, que é como este repositório já errou — o contrato
que respondeu 4 onde o programa responde 7), e **o que ele traz para quem escreve
Aurora**, dito com honestidade:

> Nothing they can see today (…) It buys the next thing.

`s.set("balance", 100)` seguido de `s.get("balance")`: a ordem **é** o programa, e não há
como perceber depois que o backend inverteu — o contrato responde um número de qualquer
jeito. Por isso a regra chega antes do storage, e não depois do primeiro programa errado.

A lista de "escrevendo um consumidor" ganhou uma sexta linha: pergunte ao `MayCross`,
nunca mantenha sua própria lista.

## O passo 3 estava com a forma errada

A RFC dizia "o IR diz quantos tapes um **operando** tem". Escrevendo, a largura já viaja
em dois dos três lugares:

- uma construção diz a dela por **ter aquele tanto de operandos**;
- uma leitura de campo carrega a largura da run de onde sai — é o terceiro operando do
  `OpField`, e ele existe exatamente para isso.

O único lugar em que nada dizia é **o valor que volta de uma chamada**, e isso é fato do
escopo, não de instrução nenhuma dentro dele. Então é `ir.Block.Tapes`.

De onde vem vale a pena: o emitter lê `tree.Returns`. Antes da `shape_inference` isso
valeria só para os escopos que escreveram `returns`; agora vale para quase todos, sem o
arquivo dizer nada. Tem um teste para cada metade.

## O que ainda não faz

Ninguém lê o `Tapes`. Quem lê é o passo 4, quando a run vai para a memória e quem chamou
precisa saber quanto copiar de volta — que é onde o teto de 32 bytes cai.

🤖 Generated with [Claude Code](https://claude.com/claude-code)