### PR TITLE
A shape has no ceiling, because it lives in memory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,10 +40,13 @@ finds the frame written. The convention is in [rfcs/if_and_call.md](rfcs/if_and_
 One limit is worth knowing: only a scope bound at the top of a program can be called, and
 anything else is refused rather than written.
 
-`shape` is written too. A run is its tapes and nothing else, so it is one word with the first
-tape at the far end — the same number the evaluator answers — and a field is a shift and a
-mask. That is also its ceiling: a run past thirty-two bytes is refused rather than written
-short, which is four fields at the default tape.
+`shape` is written too, and it has no ceiling. A run is its tapes and nothing else, and it
+lives in **memory** rather than on the stack: laid tape after tape in the order it was written,
+which is the order the evaluator lays them, so a contract hands back the same bytes rather than
+the same number. A field is an address and a read. It used to be one word, which is four tapes
+at the default and a ceiling nobody chose — a run past thirty-two bytes was refused rather than
+written short, so a program ran off a chain and could not reach one. Nothing goes on the stack
+even when it fits: a run kept two ways is two things a consumer has to tell apart.
 
 The tape operations are written too, and with them **the backend carries every feature a
 program can use**. All four rest on one thing: how much of a value means something, which off

--- a/builder/evm/blocks.go
+++ b/builder/evm/blocks.go
@@ -123,11 +123,11 @@ func writeTerminator(bs io.Writer, term ir.Terminator, order []ir.BlockID, at ma
 				return err
 			}
 		}
-		write := WriteReturnToCaller
 		if scope.Answers {
-			write = WriteReturnToChain
+			_, err := WriteReturnToChain(bs, scope.Tapes, scope.TapeSize)
+			return err
 		}
-		_, err := write(bs)
+		_, err := WriteReturnToCaller(bs)
 		return err
 
 	case ir.Br:

--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -54,8 +54,8 @@ const (
 	// FRAME_START_SIZE is what writing where the first frame begins measures: a push of the
 	// address, a push of the slot, and the store.
 	FRAME_START_SIZE = PUSH_TWO_SIZE + PUSH_ONE_SIZE + 1
-	// RETURN_TO_CHAIN_SIZE is what handing a value to the chain measures.
-	RETURN_TO_CHAIN_SIZE = PUSH_ONE_SIZE + 1 + PUSH_ONE_SIZE + PUSH_ONE_SIZE + 1
+	// RETURN_TO_CHAIN_SIZE is what handing an ordinary value to the chain measures. A run
+	// measures something else, and ReturnToChainSize answers for both by writing it.
 )
 
 type Dispatcher struct {
@@ -167,7 +167,7 @@ func (b *Builder) PickRuntimeCode() (*RuntimeCode, error) {
 
 	for at := range dispatchers {
 		d := &dispatchers[at]
-		internal, err := ScopeInternalAt(referenced+d.Offset, len(b.blocks[d.Entry].Params), b.tapeSize)
+		internal, err := ScopeInternalAt(referenced+d.Offset, len(b.blocks[d.Entry].Params), b.tapeSize, b.blocks[d.Entry].Tapes)
 		if err != nil {
 			return nil, err
 		}

--- a/builder/evm/builder_test.go
+++ b/builder/evm/builder_test.go
@@ -101,7 +101,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteReturnToChain(want)
+				WriteReturnToChain(want, 0, byteutil.DefaultTapeSize)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}
@@ -121,7 +121,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 0}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteReturnToChain(want)
+				WriteReturnToChain(want, 0, byteutil.DefaultTapeSize)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}
@@ -144,7 +144,7 @@ func TestPickRuntimeCode(t *testing.T) {
 				want.Write([]byte{OpJumpDestiny})
 				WriteIdent(want, map[string]int{"a": 2 * MEMORY_SLOT_SIZE}, []byte("a"))
 				WritePush(want, nil, byteutil.DefaultTapeSize)
-				WriteReturnToChain(want)
+				WriteReturnToChain(want, 0, byteutil.DefaultTapeSize)
 				if !bytes.Equal(got, want.Bytes()) {
 					return fmt.Errorf("expected: %v, got: %v", byteutil.ToUpperHex(want.Bytes()), byteutil.ToUpperHex(got))
 				}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -122,7 +122,17 @@ func WriteLoad(w io.Writer, names map[string]int, ident []byte) (int, error) {
 // It goes through a slot of its own rather than through the first one, which holds where the
 // running scope's frame starts: writing the answer there would lose the frame in the act of
 // answering.
-func WriteReturnToChain(w io.Writer) (int, error) {
+func WriteReturnToChain(w io.Writer, tapes, tapeSize int) (int, error) {
+	// A run is already in memory and what is on the stack is where it starts, so it is handed
+	// back from there, as the bytes it is. That is the same run the evaluator returns, byte for
+	// byte, which is stronger than the two agreeing on a number.
+	if tapes > 1 {
+		if _, err := WritePush2(w, tapes*byteutil.TapeSize(tapeSize)); err != nil {
+			return 0, err
+		}
+		return w.Write([]byte{OpSwap1, OpReturn})
+	}
+
 	if _, err := w.Write([]byte{OpPush1, RETURN_SCRATCH}); err != nil {
 		return 0, err
 	}
@@ -130,6 +140,19 @@ func WriteReturnToChain(w io.Writer) (int, error) {
 		return 0, err
 	}
 	return w.Write([]byte{OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn})
+}
+
+// ReturnToChainSize answers what handing a value to the chain measures, which depends on
+// whether the value is a run.
+//
+// It is measured rather than added up, for the reason every size here is: a table of sizes is
+// a second description of the same bytes, and two descriptions drift.
+func ReturnToChainSize(tapes, tapeSize int) (int, error) {
+	var measured counter
+	if _, err := WriteReturnToChain(&measured, tapes, tapeSize); err != nil {
+		return 0, err
+	}
+	return int(measured), nil
 }
 
 // WriteReturn ends a scope: the value it returns is on the stack, and the address to go
@@ -228,8 +251,8 @@ func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal
 // It is here and not at the end of the body because the body does not know who called it. A
 // scope called by another has to hand its value back and let that one carry on; only the way
 // in from a transaction ends the call.
-func WriteScopeEpilogue(w io.Writer) error {
-	_, err := WriteReturnToChain(w)
+func WriteScopeEpilogue(w io.Writer, tapes, tapeSize int) error {
+	_, err := WriteReturnToChain(w, tapes, tapeSize)
 	return err
 }
 
@@ -494,92 +517,90 @@ func writeRemainingLength(w io.Writer, inst ir.Instruction, tapeSize int) error 
 	return err
 }
 
-// WriteJoin lays tapes end to end into one value.
+// WriteJoin lays a run in memory and leaves where it starts.
 //
-// A run has no header, no length and no tag — it is the tapes and nothing else, which is what
-// the language says a shape is. So on a chain it is a word like every other value, with the
-// first tape at the far end and the last one at the bottom, which is where a tape sits inside
-// a word anyway. Point{10, 20} at a tape of eight bytes is 10 << 64 | 20, the same number the
-// evaluator answers, so a scope returning a run answers the same thing on both sides.
+// A run is tapes end to end, and it does not go on the stack. A stack item is exactly a word,
+// which is four tapes of eight and one tape of thirty-two, and a shape wider than that used to
+// be refused rather than written — a program that ran off a chain and could not reach one,
+// which is the one thing this backend may not do.
 //
-// That is also the ceiling: a word is thirty-two bytes and a run is as many tapes as it has,
-// so a shape of five fields at the default tape does not fit, and the builder refuses it
-// rather than writing a value with the first field shifted off the end.
+// Nothing is on the stack even when it would fit. A run kept two ways is two things a consumer
+// has to tell apart, and telling things apart by looking is how this backend has been wrong
+// before.
 //
-// It is built from the last tape back, because that is the order the stack offers them. The
-// ones another instruction worked out are on it already, put there in field order by the
-// lowering, so the last of them is on top; the ones the program wrote down reach the stack
-// here. Either way what has been built so far sits under what comes next, which is why a tape
-// taken off the stack changes places with it and one pushed does not.
-func WriteJoin(w io.Writer, inst ir.Instruction, tapeSize int) error {
+// The tapes are laid in the order they were written, which is the order the evaluator lays
+// them, so what a contract hands back is the same bytes rather than the same number. Each one
+// is laid with MSTORE, which writes a word, so laying one writes past it — and the next one
+// written puts that right. What the last one writes past the end lands in the room RunRoom
+// gave it.
+func WriteJoin(w io.Writer, inst ir.Instruction, tapeSize, base int) error {
 	tapes := valueOperands(inst)
-	if run := len(tapes) * tapeSize; run > byteutil.MaxTapeSize {
-		return fmt.Errorf(
-			"a run of %d tapes is %d bytes and a word is %d: a shape this wide does not reach the bytecode",
-			len(tapes), run, byteutil.MaxTapeSize)
-	}
 
+	// Backwards, because that is the order the values are on the stack: whoever computed them
+	// went left to right, so the last one is on top.
 	for at := len(tapes) - 1; at >= 0; at-- {
-		tape := tapes[at]
-		switch {
-		case tape.Kind() == ir.KindImm:
+		if tape := tapes[at]; tape.Kind() == ir.KindImm {
 			if _, err := WritePush(w, tape.Bytes(), tapeSize); err != nil {
 				return err
 			}
-		case at < len(tapes)-1:
-			// It is under what has been built so far, and it is what the shift applies to.
-			if _, err := w.Write([]byte{OpSwap1}); err != nil {
-				return err
-			}
 		}
 
-		// A tape wider than the tape size is cut to it, which is what the evaluator does
-		// when it lays one into a run: a run of tapes holds tapes.
+		// A tape wider than the tape size is cut to it, which is what the evaluator does when
+		// it lays one into a run: a run of tapes holds tapes.
 		if _, err := WriteMask(w, tapeSize); err != nil {
 			return err
 		}
-
-		if bits := (len(tapes) - 1 - at) * tapeSize * BYTE_SIZE; bits > 0 {
-			if _, err := WritePush(w, byteutil.FromUint64(uint64(bits)), 1); err != nil {
-				return err
-			}
-			if _, err := w.Write([]byte{OpShiftLeft}); err != nil {
-				return err
-			}
+		// MSTORE writes a word and the tape is in the last bytes of one, so the word is put
+		// where its end is the tape's end. What that writes over in front is the tape before,
+		// which is laid next.
+		if err := WriteFrameAddress(w, base+(at+1)*byteutil.TapeSize(tapeSize)-MEMORY_SLOT_SIZE); err != nil {
+			return err
 		}
-
-		if at < len(tapes)-1 {
-			if _, err := w.Write([]byte{OpOr}); err != nil {
-				return err
-			}
+		if _, err := w.Write([]byte{OpMemoryStore}); err != nil {
+			return err
 		}
 	}
 
-	return nil
+	return WriteFrameAddress(w, base)
 }
 
-// WriteField takes one tape out of a run.
-//
-// The run is on the stack and the two numbers are the instruction's own: which tape, and how
-// many the run has. Both are needed because a run is counted from its first tape and kept from
-// its last — nothing in the value says where it ends, so the only way to the tape at index i
-// is to know there are n of them and count back.
-func WriteField(w io.Writer, inst ir.Instruction, tapeSize int) error {
-	operands := inst.GetOperands()
-	at := int(byteutil.ToUint64(operands[1].Bytes()))
-	tapes := int(byteutil.ToUint64(operands[2].Bytes()))
+// writeShift moves a value by a number of bits, in the direction the opcode says. Nothing is
+// written for a shift of none, which is what a tape as wide as a word asks for.
+func writeShift(w io.Writer, bits int, op byte) error {
+	if bits <= 0 {
+		return nil
+	}
+	if _, err := WritePush(w, byteutil.FromUint64(uint64(bits)), 1); err != nil {
+		return err
+	}
+	_, err := w.Write([]byte{op})
+	return err
+}
 
-	if bits := (tapes - 1 - at) * tapeSize * BYTE_SIZE; bits > 0 {
-		if _, err := WritePush(w, byteutil.FromUint64(uint64(bits)), 1); err != nil {
+// WriteField reads one tape out of a run, given where the run starts.
+//
+// The run is in memory and what is on the stack is where it starts, so a field is an address
+// and a read rather than a shift over a word. MLOAD answers the word beginning at the tape,
+// which is the tape and whatever follows it, and shifting that down to the bottom leaves the
+// tape and drops the rest — so there is no mask to write.
+//
+// Reading past the end of the run answers the neutral value, the way it does off a chain: what
+// is there is the room RunRoom left, and it was never written.
+func WriteField(w io.Writer, inst ir.Instruction, tapeSize int) error {
+	at := int(byteutil.ToUint64(inst.GetOperands()[1].Bytes()))
+
+	if at > 0 {
+		if _, err := WritePush2(w, at*byteutil.TapeSize(tapeSize)); err != nil {
 			return err
 		}
-		if _, err := w.Write([]byte{OpShiftRight}); err != nil {
+		if _, err := w.Write([]byte{OpAdd}); err != nil {
 			return err
 		}
 	}
-
-	_, err := WriteMask(w, tapeSize)
-	return err
+	if _, err := w.Write([]byte{OpMemoryLoad}); err != nil {
+		return err
+	}
+	return writeShift(w, (MEMORY_SLOT_SIZE-byteutil.TapeSize(tapeSize))*BYTE_SIZE, OpShiftRight)
 }
 
 // WriteCall enters another scope of this contract and comes back with what it answered.
@@ -718,14 +739,18 @@ func writeFrameMove(w io.Writer, by int, op byte) error {
 //
 // It is measured rather than added up from a table of sizes, for the reason every address here
 // is: a table is a second description of the same bytes, and two descriptions drift.
-func ScopeInternalAt(base, params, tapeSize int) (int, error) {
+func ScopeInternalAt(base, params, tapeSize, tapes int) (int, error) {
 	var measured counter
 	if err := WriteScopePrologue(&measured, params, tapeSize, 0, 0); err != nil {
 		return 0, err
 	}
+	returning, err := ReturnToChainSize(tapes, tapeSize)
+	if err != nil {
+		return 0, err
+	}
 	// The way in opens with a JUMPDEST the dispatcher lands on; the prologue follows; what it
 	// comes back to opens with one of its own, and the way in from another scope with a third.
-	return base + 1 + int(measured) + 1 + RETURN_TO_CHAIN_SIZE, nil
+	return base + 1 + int(measured) + 1 + returning, nil
 }
 
 // WriteScope emits a scope whole: the way in from a transaction, what that way comes back to,
@@ -738,11 +763,15 @@ func WriteScope(bs io.Writer, blocks []ir.Block, entry ir.BlockID, tapeSize, bas
 	order := layoutOf(blocks, entry)
 	scope := ScopeOf(blocks, order, tapeSize, entries, false)
 
-	internal, err := ScopeInternalAt(base, scope.Params, tapeSize)
+	internal, err := ScopeInternalAt(base, scope.Params, tapeSize, scope.Tapes)
 	if err != nil {
 		return err
 	}
-	epilogue := internal - 1 - RETURN_TO_CHAIN_SIZE
+	returning, err := ReturnToChainSize(scope.Tapes, tapeSize)
+	if err != nil {
+		return err
+	}
+	epilogue := internal - 1 - returning
 
 	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
 		return err
@@ -753,7 +782,7 @@ func WriteScope(bs io.Writer, blocks []ir.Block, entry ir.BlockID, tapeSize, bas
 	if _, err := bs.Write([]byte{OpJumpDestiny}); err != nil {
 		return err
 	}
-	if err := WriteScopeEpilogue(bs); err != nil {
+	if err := WriteScopeEpilogue(bs, scope.Tapes, tapeSize); err != nil {
 		return err
 	}
 
@@ -1030,6 +1059,17 @@ type Scope struct {
 	Params int
 	// Names answers where in the frame each name this scope binds is kept.
 	Names map[string]int
+	// Tapes is how many tapes the value this scope returns is made of, which is one for an
+	// ordinary value and more for a run. It decides how much a return hands to the chain.
+	Tapes int
+	// Runs answers where in the frame each construction of a run lays its tapes, by the label
+	// the construction leaves its value under.
+	//
+	// A run is tapes end to end, and on a chain that is memory rather than a stack item: a
+	// stack item is exactly a word, and four tapes of eight fill one. Where each one goes is
+	// decided here rather than while the program runs, because both things it takes are known
+	// now — how many constructions a scope has, and how wide each one is.
+	Runs map[string]int
 	// Frame is how much memory this scope keeps: the values applied to it, then its names. A
 	// call puts the frame of whoever it calls right after this one.
 	Frame int
@@ -1057,24 +1097,31 @@ type Entry struct {
 // of it is what makes that possible, and it is the thing an instruction list could not offer —
 // there, a name in a block that had not been reached yet was a name nobody knew about.
 func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[string]Entry, answers bool) Scope {
-	params := 0
+	params, tapes := 0, 0
 	if len(order) > 0 {
 		params = len(blocks[order[0]].Params)
+		tapes = blocks[order[0]].Tapes
 	}
 
 	names := make(map[string]int)
+	runs := make(map[string]int)
 	offset := params * MEMORY_SLOT_SIZE
 	for _, id := range order {
 		for _, inst := range blocks[id].Insts {
-			if inst.GetOpCode() != ir.OpIdent {
-				continue
+			switch inst.GetOpCode() {
+			case ir.OpIdent:
+				name := string(inst.GetLeft().Bytes())
+				if _, bound := names[name]; bound {
+					continue
+				}
+				names[name] = offset
+				offset += MEMORY_SLOT_SIZE
+			case ir.OpJoin:
+				// The run starts past the room in front of it, and that is the address
+				// everything else means when it means the run.
+				runs[byteutil.ToHex(inst.GetLabel())] = offset + RunLeadIn(tapeSize)
+				offset += RunRoom(len(valueOperands(inst)), tapeSize)
 			}
-			name := string(inst.GetLeft().Bytes())
-			if _, bound := names[name]; bound {
-				continue
-			}
-			names[name] = offset
-			offset += MEMORY_SLOT_SIZE
 		}
 	}
 
@@ -1082,7 +1129,9 @@ func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[st
 		TapeSize: tapeSize,
 		Answers:  answers,
 		Params:   params,
+		Tapes:    tapes,
 		Names:    names,
+		Runs:     runs,
 		Frame:    offset,
 		Entries:  entries,
 	}
@@ -1195,7 +1244,7 @@ func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, s
 	}
 
 	if op == ir.OpJoin {
-		if err := WriteJoin(bs, inst, scope.TapeSize); err != nil {
+		if err := WriteJoin(bs, inst, scope.TapeSize, scope.Runs[byteutil.ToHex(inst.GetLabel())]); err != nil {
 			return err
 		}
 	}
@@ -1230,4 +1279,23 @@ func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, s
 	}
 
 	return nil
+}
+
+// RunRoom answers how much memory a run of this many tapes takes: the tapes, and a word less
+// a tape of room in front of them.
+//
+// That room is not a margin. A tape is laid with MSTORE, which writes a whole word — the tape
+// in the last bytes of it and zeros before — so laying one writes over what is in front of it.
+// The tapes are laid last to first, so each of those is a tape laid again straight after, and
+// the room is where the first one writes over nothing.
+//
+// It has to be in front rather than behind because the order is not a choice: the values are
+// on the stack with the last one on top.
+func RunRoom(tapes, tapeSize int) int {
+	return RunLeadIn(tapeSize) + tapes*byteutil.TapeSize(tapeSize)
+}
+
+// RunLeadIn is the room in front of a run, which is what a word has over a tape.
+func RunLeadIn(tapeSize int) int {
+	return MEMORY_SLOT_SIZE - byteutil.TapeSize(tapeSize)
 }

--- a/builder/evm/writer_test.go
+++ b/builder/evm/writer_test.go
@@ -211,15 +211,45 @@ func TestWriteReturnToCaller(t *testing.T) {
 // of answering.
 func TestWriteReturnToChain(t *testing.T) {
 	bs := bytes.NewBuffer(make([]byte, 0))
-	if _, err := WriteReturnToChain(bs); err != nil {
+	if _, err := WriteReturnToChain(bs, 0, 8); err != nil {
 		t.Fatalf("writing the answer: %v", err)
 	}
 	expected := []byte{OpPush1, RETURN_SCRATCH, OpMemoryStore, OpPush1, 0x20, OpPush1, RETURN_SCRATCH, OpReturn}
 	if got := bs.Bytes(); !bytes.Equal(got, expected) {
 		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
 	}
-	if bs.Len() != RETURN_TO_CHAIN_SIZE {
-		t.Errorf("it measures %d and says it measures %d", bs.Len(), RETURN_TO_CHAIN_SIZE)
+}
+
+// A run does not go through that slot, because it is not in one: it is already in memory, and
+// what is on the stack is where it starts. So it is handed back from there, as many bytes as
+// it has tapes — the same run the evaluator returns, byte for byte.
+func TestAReturnOfARunHandsBackTheRunItself(t *testing.T) {
+	bs := bytes.NewBuffer(make([]byte, 0))
+	if _, err := WriteReturnToChain(bs, 5, 8); err != nil {
+		t.Fatalf("writing the answer: %v", err)
+	}
+	// Forty bytes, which is more than a word — the size that used to be refused.
+	expected := []byte{OpPush2, 0x00, 40, OpSwap1, OpReturn}
+	if got := bs.Bytes(); !bytes.Equal(got, expected) {
+		t.Errorf("got %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(expected))
+	}
+}
+
+// What a return measures is what it writes, for the reason every size here is measured: a
+// table of sizes is a second description of the same bytes.
+func TestWhatAReturnMeasuresIsWhatItWrites(t *testing.T) {
+	for _, tapes := range []int{0, 1, 2, 5, 8} {
+		var bs bytes.Buffer
+		if _, err := WriteReturnToChain(&bs, tapes, 8); err != nil {
+			t.Fatalf("writing for %d tapes: %v", tapes, err)
+		}
+		measured, err := ReturnToChainSize(tapes, 8)
+		if err != nil {
+			t.Fatalf("measuring for %d tapes: %v", tapes, err)
+		}
+		if measured != bs.Len() {
+			t.Errorf("%d tapes: it writes %d bytes and says %d", tapes, bs.Len(), measured)
+		}
 	}
 }
 
@@ -389,46 +419,65 @@ func TestACallToSomethingThatIsNotAScopeIsRefused(t *testing.T) {
 	}
 }
 
-// A run is its tapes and nothing else, so how wide it is follows from how many it has. A word
-// is thirty-two bytes, so five tapes of eight do not fit — and a shape that wide is refused
-// rather than written with its first field shifted off the end.
-func TestARunWiderThanAWordIsRefused(t *testing.T) {
-	tapes := make([]ir.Operand, 0, 5)
-	for at := 0; at < 5; at++ {
+// A run wider than a word reaches the bytecode, because it never goes in a word.
+//
+// Five tapes of eight is forty bytes, and that used to be refused rather than written — a
+// program that ran off a chain and could not reach one, which is the one thing this backend
+// may not do. The tapes are in memory now, so how many there are is only a question of how
+// much room the run gets.
+func TestARunWiderThanAWordIsWritten(t *testing.T) {
+	tapes := make([]ir.Operand, 0, 8)
+	for at := 0; at < 8; at++ {
 		tapes = append(tapes, ir.Imm(uint64(at), 8))
 	}
 
-	err := WriteJoin(io.Discard, ir.NewInstructionOver([]byte("00"), ir.OpJoin, tapes...), 8)
-	if err == nil {
-		t.Fatal("it wrote a run of forty bytes into a word of thirty-two")
-	}
-	if !strings.Contains(err.Error(), "40") {
-		t.Errorf("it says %q, and never says how wide the run was", err)
-	}
-
-	// Four of them is exactly a word, which is the widest that does fit.
-	if err := WriteJoin(io.Discard, ir.NewInstructionOver([]byte("00"), ir.OpJoin, tapes[:4]...), 8); err != nil {
-		t.Errorf("it refused a run that fills a word exactly: %v", err)
+	for _, count := range []int{1, 4, 5, 8} {
+		inst := ir.NewInstructionOver([]byte("00"), ir.OpJoin, tapes[:count]...)
+		if err := WriteJoin(io.Discard, inst, 8, RunLeadIn(8)); err != nil {
+			t.Errorf("a run of %d tapes: %v", count, err)
+		}
 	}
 }
 
-// A field counts back from the last tape of the run, so where it reads depends on how many
-// tapes the run has and not only on the index. The first field of a run of two is shifted down
-// by one tape; the last field of any run is not shifted at all.
-func TestAFieldCountsBackFromTheEndOfTheRun(t *testing.T) {
-	cases := []struct {
+// The room a run takes is its tapes, and what a word has over a tape in front of them.
+func TestHowMuchRoomARunTakes(t *testing.T) {
+	for _, tc := range []struct {
+		tapes, tapeSize, want int
+	}{
+		{tapes: 1, tapeSize: 8, want: 24 + 8},
+		{tapes: 4, tapeSize: 8, want: 24 + 32},
+		{tapes: 5, tapeSize: 8, want: 24 + 40},
+		// A tape as wide as a word needs no room in front: the word is the tape.
+		{tapes: 2, tapeSize: 32, want: 64},
+	} {
+		if got := RunRoom(tc.tapes, tc.tapeSize); got != tc.want {
+			t.Errorf("%d tapes of %d take %d, want %d", tc.tapes, tc.tapeSize, got, tc.want)
+		}
+	}
+}
+
+// A field counts forward from where the run starts, and how many tapes the run has does not
+// come into it.
+//
+// It used to count back from the end, because the run was a word and a field was a shift: the
+// first of two was shifted down by a tape, the first of three by two, so the same index read a
+// different place depending on how long the run was. In memory it is an address — the index
+// times a tape from the start — and the run's length is only about where it ends.
+func TestAFieldCountsForwardFromTheStartOfTheRun(t *testing.T) {
+	for _, tc := range []struct {
 		name  string
 		at    uint64
 		tapes uint64
 		want  []byte
 	}{
-		{name: "the first of two", at: 0, tapes: 2, want: []byte{OpPush1, 64, OpShiftRight}},
-		{name: "the last of two", at: 1, tapes: 2, want: nil},
-		{name: "the middle of three", at: 1, tapes: 3, want: []byte{OpPush1, 64, OpShiftRight}},
-		{name: "the first of three", at: 0, tapes: 3, want: []byte{OpPush1, 128, OpShiftRight}},
-	}
-
-	for _, tc := range cases {
+		{name: "the first of two", at: 0, tapes: 2, want: []byte{OpMemoryLoad, OpPush1, 192, OpShiftRight}},
+		{name: "the last of two", at: 1, tapes: 2, want: []byte{OpPush2, 0, 8, OpAdd, OpMemoryLoad, OpPush1, 192, OpShiftRight}},
+		// The same index of a longer run reads the same place, which is the whole difference.
+		{name: "the middle of three", at: 1, tapes: 3, want: []byte{OpPush2, 0, 8, OpAdd, OpMemoryLoad, OpPush1, 192, OpShiftRight}},
+		{name: "the last of three", at: 2, tapes: 3, want: []byte{OpPush2, 0, 16, OpAdd, OpMemoryLoad, OpPush1, 192, OpShiftRight}},
+		// Past four tapes, which is where a run stopped reaching the bytecode at all.
+		{name: "the seventh of eight", at: 6, tapes: 8, want: []byte{OpPush2, 0, 48, OpAdd, OpMemoryLoad, OpPush1, 192, OpShiftRight}},
+	} {
 		t.Run(tc.name, func(t *testing.T) {
 			bs := bytes.NewBuffer(make([]byte, 0))
 			inst := ir.NewInstructionOver([]byte("00"), ir.OpField,
@@ -436,14 +485,24 @@ func TestAFieldCountsBackFromTheEndOfTheRun(t *testing.T) {
 			if err := WriteField(bs, inst, 8); err != nil {
 				t.Fatalf("writing the field: %v", err)
 			}
-
-			// The mask follows the shift and is the same for every case, so what is compared
-			// is the shift alone.
-			shift := bs.Bytes()[:len(tc.want)]
-			if !bytes.Equal(shift, tc.want) {
-				t.Errorf("it shifts by %v, want %v", byteutil.ToUpperHex(shift), byteutil.ToUpperHex(tc.want))
+			if got := bs.Bytes(); !bytes.Equal(got, tc.want) {
+				t.Errorf("it writes %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(tc.want))
 			}
 		})
+	}
+}
+
+// A tape as wide as a word is the word, so a field of it is a read and nothing after it.
+func TestAFieldOfAWordWideTapeIsJustTheRead(t *testing.T) {
+	bs := bytes.NewBuffer(make([]byte, 0))
+	inst := ir.NewInstructionOver([]byte("00"), ir.OpField,
+		ir.RefTo([]byte("01")), ir.Const(1, 32), ir.Const(2, 32))
+	if err := WriteField(bs, inst, 32); err != nil {
+		t.Fatalf("writing the field: %v", err)
+	}
+	want := []byte{OpPush2, 0, 32, OpAdd, OpMemoryLoad}
+	if got := bs.Bytes(); !bytes.Equal(got, want) {
+		t.Errorf("it writes %v, want %v", byteutil.ToUpperHex(got), byteutil.ToUpperHex(want))
 	}
 }
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -143,8 +143,17 @@ tape width — a result that leaves the width is cut back to it, the way the eva
 names bound inside a scope, branches, the comparisons and `and`/`or`, a scope calling another
 as deep as it nests, shapes, and the tape operations.
 
-Nothing a program can write is missing from it any more. What a contract does not get is what
-was decided not to reach a chain, and two limits that are written down:
+Nothing a program can write is missing from it any more, and a shape is no longer the
+exception it used to be: **a run of any width reaches a chain**. It lives in memory rather than
+on the stack, laid tape after tape in the order it was written, so what a contract hands back
+is the same bytes the evaluator does rather than the same number. A stack item is exactly a
+word, which is four tapes of eight, and a shape wider than that used to be refused rather than
+written — a program that ran off a chain and could not reach one. Nothing goes on the stack
+even when it would fit, because a run kept two ways is two things every consumer has to tell
+apart.
+
+What a contract does not get is what was decided not to reach a chain, and two limits that are
+written down:
 
 - **A scope only reaches what it bound itself**, so everything a scope works on arrives as a
   value applied to it. What would let a scope read a name from around it is a static link —
@@ -153,9 +162,6 @@ was decided not to reach a chain, and two limits that are written down:
   storage, no event, no caller, and no way to refuse a transaction. Each of them is its own
   decision, and each has the same question under it: what does it mean off a chain, where
   there is no storage, no log, and nobody calling. `rfcs/` is where those are argued.
-- **A shape reaches the chain while its run fits a word.** A run is its tapes and nothing else,
-  so a shape of five fields at the default tape of eight is forty bytes and is refused rather
-  than written short. Four fields fill a word exactly.
 - **Only a scope bound at the top of a program can be called.** A scope written inside another
   is not written at all: on a chain the name it was bound to holds the neutral value, and
   calling it is refused rather than written as a jump to an address no scope has.

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"fmt"
 	"math/big"
 	"os"
@@ -451,11 +452,12 @@ ident outer = defer { middle(feed(0)) + middle(1); };`
 }
 
 // A shape reaches the chain. It is not a new kind of value: Point{10, 20} is two tapes laid
-// end to end, and on a chain that is one word with the first tape at the far end — the same
-// number the evaluator returns, which is what lets a scope hand a run back either way.
+// end to end, and on a chain that is memory — the tapes in the order they were written, which
+// is the order the evaluator lays them, so the two hand back the same bytes.
 //
-// Reading a field is counting back from the last tape, which is why the instruction says how
-// many the run has: nothing in the value marks where it ends.
+// A shape never goes on the stack, not even when it would fit. A stack item is exactly a word
+// and a run kept two ways is two things a consumer has to tell apart, which is how this
+// backend has been wrong before.
 func TestAShapeAnswersTheSameOnChainAndOff(t *testing.T) {
 	const source = `shape Point { x, y };
 ident first = defer { ident p = Point{feed(0), 20}; p.x; };
@@ -488,6 +490,71 @@ ident first = defer { ident l = Line{1, 2, feed(0)}; l.a; };`
 		t.Run(name, func(t *testing.T) {
 			agree(t, source, name, []string{"9"}, 1)
 		})
+	}
+}
+
+// A shape wider than a word, which is what this was all for.
+//
+// Five tapes of eight is forty bytes and a word is thirty-two, so this program ran off a chain
+// and was refused by it — "a shape this wide does not reach the bytecode". Nothing about it is
+// special now: the run is in memory, and forty bytes of memory is the same kind of thing as
+// eight.
+func TestAShapeWiderThanAWordAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `shape Five { a, b, c, d, e };
+ident last = defer { ident f = Five{1, 2, 3, 4, feed(0)}; f.e; };
+ident first = defer { ident f = Five{feed(0), 2, 3, 4, 5}; f.a; };
+ident fourth = defer { ident f = Five{1, 2, 3, feed(0), 5}; f.d; };`
+
+	for _, name := range []string{"last", "first", "fourth"} {
+		t.Run(name, func(t *testing.T) {
+			agree(t, source, name, []string{"42"}, 0)
+		})
+	}
+}
+
+// Twice as wide again, so that five is not the number that happens to work.
+func TestAShapeOfEightFieldsAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `shape Eight { a, b, c, d, e, f, g, h };
+ident seventh = defer { ident v = Eight{1, 2, 3, 4, 5, 6, feed(0), 8}; v.g; };`
+
+	agree(t, source, "seventh", []string{"77"}, 0)
+}
+
+// A shape at the widest tape, where a run of two is already twice a word.
+//
+// This was the sharpest edge of the old ceiling: at a tape of thirty-two, a shape of two
+// fields did not reach a chain at all, so `shape` was unusable in that dialect.
+func TestAShapeAtTheWidestTapeAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `shape Pair { a, b };
+ident second = defer { ident p = Pair{1, feed(0)}; p.b; };`
+
+	agree(t, source, "second", []string{"5"}, 32)
+}
+
+// A whole run handed back, rather than a field of one — and compared as bytes.
+//
+// Every other case here compares what came back as a number, which is enough for a field
+// because a field is a tape. A run is not a number: the evaluator hands back its bytes, and
+// the point of putting it in memory is that the chain hands back the same ones. So this is the
+// case that says so, and it says it byte for byte.
+func TestAWholeWideRunIsTheSameBytesOnChainAndOff(t *testing.T) {
+	const source = `shape Five { a, b, c, d, e };
+ident build = defer { Five{1, 2, 3, 4, feed(0)}; };`
+
+	// Five tapes of eight, in the order they were written: forty bytes, where a word is
+	// thirty-two. This is what used to be refused.
+	want := make([]byte, 0, 40)
+	for _, tape := range []byte{1, 2, 3, 4, 9} {
+		want = append(want, 0, 0, 0, 0, 0, 0, 0, tape)
+	}
+
+	if got := onChain(t, source, "build", []string{"9"}, 0); !bytes.Equal(got, want) {
+		t.Errorf("the chain handed back %x, want %x", got, want)
+	}
+
+	// And the evaluator reads those same bytes as the five tapes they are.
+	if printed := strings.TrimSpace(offChain(t, source, "build", []string{"9"}, 0)); printed != "1 2 3 4 9" {
+		t.Errorf("the evaluator answered %q, want the five tapes", printed)
 	}
 }
 


### PR DESCRIPTION
**Missão 2 das três: o teto de 32 bytes num shape acabou.**

```aurora
shape Five { a, b, c, d, e };
ident build = defer { Five{1, 2, 3, 4, feed(0)}; };
```

Cinco tapes de oito são quarenta bytes. Isso rodava no evaluator e era **recusado** pela
chain — *"a shape this wide does not reach the bytecode"*. Agora não é nada de especial:
a run está na memória, e quarenta bytes de memória são o mesmo tipo de coisa que oito.

E o pior caso era pior do que cinco campos: com `tape_size` 32, um shape de **dois**
campos já passava de uma palavra, então `shape` era inutilizável naquele dialeto.

## Ninguém decidiu esse teto

Ele caiu de sobra: todo valor morava na pilha, e quando `shape` chegou foi enfiado no
mesmo molde — os tapes empilhados numa palavra com máscara, shift e OR. Um item da pilha
tem exatamente uma palavra. A recusa que existia era um guarda para não escrever curto e
mentir, não um design.

## Memória sempre, sem híbrido

Nada vai para a pilha nem quando caberia. Uma run guardada de dois jeitos são duas coisas
que todo consumidor tem que distinguir olhando — que é exatamente como este backend já
errou antes.

Onde cada run mora é decidido **na hora de escrever**, como um nome ligado: as duas coisas
necessárias são sabidas ali (quantas construções um escopo tem, e a largura de cada uma).
Sem alocador, sem nada decidindo endereço em runtime.

Um campo virou endereço e leitura. Antes ele contava **de trás para frente** e dependia de
quantos tapes a run tinha; agora conta para frente do começo, e o comprimento da run só
diz onde ela acaba.

## O detalhe que me custou um bug

A folga de cada run fica **na frente** dela, e não é margem. `MSTORE` escreve uma palavra
inteira, então assentar um tape escreve por cima do que está antes dele. Os tapes descem
do último para o primeiro — que não é escolha minha, é a ordem em que os valores estão na
pilha — então cada coisa apagada é um tape assentado logo em seguida, e a folga é onde o
primeiro escreve por cima de nada.

Eu tinha posto a folga atrás e escrito os tapes para frente. O harness pegou na hora:
o campo 0 respondia certo e os demais respondiam 0, porque o tape 0, escrito por último,
apagava os outros quatro.

## A prova

O harness, com o que era recusado:

- cinco campos — primeiro, quarto e último
- oito campos
- um shape no tape mais largo (dois campos = 64 bytes)
- **uma run inteira devolvida, comparada byte a byte**

Esse último importa: todos os outros casos comparam como número, o que basta para um campo
porque campo é tape. Run não é número — o evaluator devolve os bytes dela, e o ponto de
pôr na memória é a chain devolver os mesmos. Agora tem um caso dizendo isso byte a byte, e
a comparação ficou mais forte do que era.

## O que não entrou

O `Effect` não encostou aqui, como eu já tinha reconhecido — a dependência de dado já
ordena. Ele vale para a missão 3 (storage), onde `s.set` e `s.get` não têm dependência
nenhuma entre si.

Sobra a missão 3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)