### PR TITLE
sload and sstore reach what the chain keeps

### DIFF
--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -62,12 +62,13 @@ var offChain = map[byte]string{
 // the IR names it. Instructions that come from one feature share a name, so a feature is one
 // warning rather than one per opcode it lowers to.
 //
-// It is empty. Every instruction the emitter produces reaches the bytecode now, which is the
-// news — and it is also what makes the entry below matter more than it did: an opcode in
-// neither list is warned about under the name the IR gives it, rather than passed over. A gap
-// nobody remembered to write down here is still a gap, and the point of this file is that a
-// gap is never silent.
-var pending = map[byte]string{}
+// An opcode in neither list is warned about under the name the IR gives it rather than passed
+// over: a gap nobody remembered to write down here is still a gap, and the point of this file
+// is that a gap is never silent.
+var pending = map[byte]string{
+	ir.OpStorageGet: "sload does not reach the bytecode yet: a contract using it compiles, and reads the neutral tape on chain",
+	ir.OpStorageSet: "sstore does not reach the bytecode yet: a contract using it compiles, and keeps nothing on chain",
+}
 
 // Warnings reports what a program uses that does not reach the bytecode.
 //

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -496,6 +496,41 @@ fail, and would give up the only thing the declaration does.
 
 See [examples/shapes.ar](../examples/shapes.ar).
 
+## What the chain keeps
+
+Two instructions reach what a chain keeps between one transaction and the next:
+
+```
+sstore 1 42;      #- keeps 42 under the key 1, and is worth 42
+sload 1;          #- 42
+```
+
+A key is a tape and so is a value, and a key is anything a program works out — `sload k` after
+`ident k = 3 * 4;` reads what `sstore 12 ...` kept. A key nothing was ever kept under reads as
+the neutral tape, the same as reading past the end of a run, and the same as a slot never
+written on a chain.
+
+`sstore` is worth what it kept, because everything here is an expression and a write is no
+exception.
+
+Both take what follows them the way `printd` does — as much of it as is an expression — so
+`sload 1 + 2` reads the key three. Adding to what was read is written with the read closed
+first:
+
+```
+sstore 1 ((sload 1) + 2);
+```
+
+**These are the machine's instructions and not a library.** They are the two EVM opcodes under
+the names they have there, the way inline assembly is in C, and a program is not meant to write
+them directly: what it uses is a module written over them, where how a key becomes a slot is
+decided in one place and can change without every program that keeps something changing with
+it.
+
+Off a chain they are simulated by a map, for one run of a program — what a single transaction
+sees. A second run starts empty and a chain does not, which is the honest limit of simulating a
+call off a chain.
+
 ## Arithmetic Operations
 
 Arithmetic reads a tape as an unsigned big-endian integer and writes the result back as a tape, wrapping at the tape width.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -162,6 +162,11 @@ written down:
   storage, no event, no caller, and no way to refuse a transaction. Each of them is its own
   decision, and each has the same question under it: what does it mean off a chain, where
   there is no storage, no log, and nobody calling. `rfcs/` is where those are argued.
+- **`sload` and `sstore` do not reach the bytecode yet.** They run off a chain, where a map
+  simulates what one transaction sees, so a contract using them compiles and keeps nothing on
+  chain — said out loud at build time, under the names the source used. What is left is the two
+  EVM opcodes and a case in the harness. The ordering they need is already written down: they
+  share no value, so only their effects keep them in the order they were written.
 - **Only a scope bound at the top of a program can be called.** A scope written inside another
   is not written at all: on a chain the name it was bound to holds the neutral value, and
   calling it is refused rather than written as a jump to an address no scope has.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -83,6 +83,10 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 		return emitUseDeclaration(tc, insts, n, tapeSize)
 	case ast.ShapeLiteral:
 		return emitShapeLiteral(tc, insts, n, tapeSize)
+	case ast.SloadExpression:
+		return emitSload(tc, insts, n, tapeSize)
+	case ast.SstoreExpression:
+		return emitSstore(tc, insts, n, tapeSize)
 	case ast.FieldExpression:
 		return emitFieldExpression(tc, insts, n, tapeSize)
 	case ast.ShapedExpression:
@@ -260,6 +264,29 @@ func emitUseDeclaration(tc *int, insts *[]ir.Instruction, _ ast.UseDeclaration, 
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
 	return l
 
+}
+
+// emitSload reads what the chain keeps under a key.
+func emitSload(tc *int, insts *[]ir.Instruction, n ast.SloadExpression, tapeSize int) ir.Label {
+	key := operandFor(tc, insts, n.Key, tapeSize)
+
+	l := GenerateLabel(tc)
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpStorageGet, key, ir.Nothing()).At(originOf(n.Token)))
+	return l
+}
+
+// emitSstore keeps a value under a key, and leaves the value.
+//
+// The key is emitted before the value, which is the order they were written: two instructions
+// that compute them cannot be told apart by this one, and reading them in the order the line
+// has is what keeps a message about either pointing at the right half.
+func emitSstore(tc *int, insts *[]ir.Instruction, n ast.SstoreExpression, tapeSize int) ir.Label {
+	key := operandFor(tc, insts, n.Key, tapeSize)
+	value := operandFor(tc, insts, n.Value, tapeSize)
+
+	l := GenerateLabel(tc)
+	*insts = append(*insts, ir.NewInstruction(l, ir.OpStorageSet, key, value).At(originOf(n.Token)))
+	return l
 }
 
 // emitShapeLiteral lays one tape per field, end to end.

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -34,7 +34,10 @@ type Evaluator struct {
 	printChars    Printer
 	printDecimal  Printer
 	environ       *environ.Environ
-	tapeSize      int
+	// storage is what a chain keeps between transactions, kept here for one run of a program.
+	// It is by the key as bytes, because a key is a tape and a tape is not a map key.
+	storage  map[string][]byte
+	tapeSize int
 }
 
 // TapeSize is the width, in bytes, of every value this evaluator handles.
@@ -519,6 +522,10 @@ func init() {
 		ir.OpHead:  (*Evaluator).EvaluateHead,
 		ir.OpTail:  (*Evaluator).EvaluateTail,
 
+		// Storage
+		ir.OpStorageGet: (*Evaluator).EvaluateStorageGet,
+		ir.OpStorageSet: (*Evaluator).EvaluateStorageSet,
+
 		// Assertions
 		ir.OpAssert: (*Evaluator).EvaluateAssert,
 	}
@@ -703,6 +710,7 @@ func New(options NewEvaluatorOptions) *Evaluator {
 	return &Evaluator{
 		assertResults: make([]eval.AssertResult, 0),
 		asserts:       options.Asserts,
+		storage:       make(map[string][]byte),
 		printBytes:    options.PrintBytes,
 		printChars:    options.PrintChars,
 		printDecimal:  options.PrintDecimal,

--- a/evaluator/storage.go
+++ b/evaluator/storage.go
@@ -1,0 +1,51 @@
+package evaluator
+
+import (
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// What a chain keeps between one transaction and the next, off a chain.
+//
+// The point of the backend is that the same program answers the same thing on a chain and off
+// it, and storage is where that stops being about arithmetic: a program that reads what an
+// earlier write left can only be simulated by something that keeps it. A map does, for as long
+// as the evaluator lives, which is one run of a program.
+//
+// A second run starts empty and a chain does not, and that difference is not hidden: what is
+// simulated here is what one transaction sees, which is exactly what simulating a call off a
+// chain is for.
+
+// EvaluateStorageGet answers what is kept under a key.
+//
+// A key nothing was ever written under answers the neutral tape, which is what a slot never
+// written answers on a chain, and what reading past the end of a run answers here.
+func (e *Evaluator) EvaluateStorageGet(label []byte, left, right ir.Operand) error {
+	kept, written := e.storage[byteutil.ToHex(e.slot(left))]
+	if !written {
+		kept = byteutil.FalseTape(e.tapeSize)
+	}
+	e.environ.SetTemp(byteutil.ToHex(label), kept)
+	return nil
+}
+
+// EvaluateStorageSet keeps a value under a key, and leaves the value.
+//
+// It leaves it because everything in Aurora is an expression and a write is no exception, so
+// `sstore 1 41 + 1` is forty-two — and because a write that answered nothing would be the only
+// instruction in the language that answers nothing.
+func (e *Evaluator) EvaluateStorageSet(label []byte, left, right ir.Operand) error {
+	value := byteutil.PaddingTape(e.value(right), e.tapeSize)
+	e.storage[byteutil.ToHex(e.slot(left))] = value
+	e.environ.SetTemp(byteutil.ToHex(label), value)
+	return nil
+}
+
+// slot answers the tape a key is, as wide as every other value.
+//
+// It is padded rather than taken as it comes because a chain keeps its keys at a fixed width,
+// where two that differ only in leading zeros are one key. Doing the same here is what keeps
+// the two from disagreeing about which keys are the same key.
+func (e *Evaluator) slot(operand ir.Operand) []byte {
+	return byteutil.PaddingTape(e.value(operand), e.tapeSize)
+}

--- a/hosting/cli/build_test.go
+++ b/hosting/cli/build_test.go
@@ -163,6 +163,18 @@ func TestBuildSaysWhatTheBackendDoesNotCarry(t *testing.T) {
 			source: "ident show = defer { printd feed(0); };\n",
 			want:   "printd is ignored in compiled code",
 		},
+		{
+			// Said under the name the source used, and not under the one the IR uses: whoever
+			// reads this wrote sload, and has never heard of an OpStorageGet.
+			name:   "a read of what the chain keeps",
+			source: "ident kept = defer { sload feed(0); };\n",
+			want:   "sload does not reach the bytecode yet",
+		},
+		{
+			name:   "a write of it",
+			source: "ident keep = defer { sstore feed(0) feed(1); };\n",
+			want:   "sstore does not reach the bytecode yet",
+		},
 	}
 
 	for _, tc := range cases {

--- a/hosting/cli/effect_test.go
+++ b/hosting/cli/effect_test.go
@@ -33,6 +33,18 @@ func TestTheLoweringMovesNothingItMayNotMove(t *testing.T) {
 		{name: "a shape and a field", source: `shape P { a, b };` + "\n" + `ident f = defer { ident p = P{feed(0), feed(1)}; p.a + p.b; };`},
 		{name: "the tape operations", source: "ident f = defer { ident x = feed(0); ident a = head x 1; ident b = tail x 1; a + b; };"},
 		{name: "a print over a name", source: `ident f = defer { ident x = feed(0); printd x; };`},
+		{
+			// The case the rule was written for, and the first one to reach it. These two
+			// share no value, so nothing about what they leave says which ran first — and a
+			// read moved in front of the write it follows reads what was there before, while
+			// the contract answers a number either way.
+			name:   "a write to the chain and a read after it",
+			source: "ident f = defer { sstore 1 feed(0); sload 1; };",
+		},
+		{
+			name:   "two writes to the chain",
+			source: "ident f = defer { sstore 1 feed(0); sstore 1 2; sload 1; };",
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			dir := t.TempDir()

--- a/hosting/cli/storage_test.go
+++ b/hosting/cli/storage_test.go
@@ -1,0 +1,85 @@
+package cli
+
+import (
+	"strings"
+	"testing"
+)
+
+// The two instructions that reach what a chain keeps between one transaction and the next.
+//
+// They are the machine's, not a library's — the EVM opcodes under the names they have there —
+// and what makes them usable is a module written over them. That module is next; this is what
+// it will be written over.
+func TestWhatTheChainKeepsBetweenTransactions(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "kept and read back",
+			source: "sstore 1 42;\nprintd sload 1;",
+			want:   "42",
+		},
+		{
+			// A write is an expression like everything else, so it is worth what it kept.
+			name:   "a write is worth what it kept",
+			source: "printd sstore 1 41 + 1;",
+			want:   "42",
+		},
+		{
+			name:   "a key nothing was kept under reads as nothing",
+			source: "sstore 1 42;\nprintd sload 2;",
+			want:   "0",
+		},
+		{
+			name:   "kept over",
+			source: "sstore 1 42;\nsstore 1 7;\nprintd sload 1;",
+			want:   "7",
+		},
+		{
+			// The keys are values a program works out, which is what makes it a map rather
+			// than a fixed set of places.
+			name:   "a key a program worked out",
+			source: "ident k = 3 * 4;\nsstore k 42;\nprintd sload 12;",
+			want:   "42",
+		},
+		{
+			// Read, add, keep: the shape every contract that counts something has.
+			//
+			// The parentheses are not decoration. Both of these take what follows them the way
+			// printd does — as much of it as is an expression — so `sload 1 + 2` reads the key
+			// three, and the sum has to be put outside the read.
+			name:   "read, added to, and kept again",
+			source: "sstore 1 40;\nsstore 1 ((sload 1) + 2);\nprintd sload 1;",
+			want:   "42",
+		},
+		{
+			// Said out loud, because somebody will write it: a read takes as much as it can,
+			// which is the same rule every other instruction written this way follows.
+			name:   "a read takes as much as follows it",
+			source: "sstore 3 42;\nprintd sload 1 + 2;",
+			want:   "42",
+		},
+		{
+			// A scope reaches them like it reaches anything, which is what lets a module wrap
+			// them: one scope writes, another reads, and the chain is what is between.
+			name: "a scope keeps and another reads",
+			source: "ident put = defer { sstore 1 feed(0); };\n" +
+				"ident got = defer { sload 1; };\n" +
+				"put(9);\nprintd got();",
+			want: "9",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			projectOf(t, map[string]string{"src/main.ar": tc.source})
+			printed, err := run(t, "src/main.ar")
+			if err != nil {
+				t.Fatalf("running: %v", err)
+			}
+			if got := strings.Fields(printed); len(got) == 0 || got[len(got)-1] != tc.want {
+				t.Errorf("printed %q, want it to end with %s", printed, tc.want)
+			}
+		})
+	}
+}

--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -141,7 +141,7 @@ func semanticTypeOf(tag string) (int, bool) {
 	case token.IDENT, token.IF, token.ELSE, token.BRANCH, token.DEFER,
 		token.PRINTB, token.PRINTC, token.PRINTD, token.ASSERT, token.FEED,
 		token.HEAD, token.TAIL, token.PUSH, token.PULL, token.TRUE, token.FALSE,
-		token.SHAPE, token.AS, token.USE, token.RETURNS:
+		token.SHAPE, token.AS, token.USE, token.RETURNS, token.SLOAD, token.SSTORE:
 		return SemanticKeyword, true
 	case token.NUMBER:
 		return SemanticNumber, true

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -23,6 +23,10 @@ var keywordTags = []token.Tag{
 	token.TagTail,
 	token.TagPush,
 	token.TagPull,
+	// Before the identifiers, like every other word: what makes a word a keyword is being
+	// looked for first.
+	token.TagSload,
+	token.TagSstore,
 	token.TagFeed,
 	token.TagAssert,
 	token.TagShape,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -879,6 +879,12 @@ func (p *pr) ParseExpr() (ast.Node, error) {
 	if lookahead.GetTag().Id == token.PUSH {
 		return p.ParsePush()
 	}
+	if lookahead.GetTag().Id == token.SLOAD {
+		return p.ParseSload()
+	}
+	if lookahead.GetTag().Id == token.SSTORE {
+		return p.ParseSstore()
+	}
 	return p.ParseBoolExpr()
 }
 

--- a/parser/storage.go
+++ b/parser/storage.go
@@ -1,0 +1,51 @@
+package parser
+
+import (
+	"github.com/guiferpa/aurora/wire/ast"
+	"github.com/guiferpa/aurora/wire/token"
+)
+
+// The two instructions that reach what a chain keeps between one transaction and the next.
+//
+// They are instructions of the machine, not a library: `sstore k v` and `sload k` are the two
+// EVM opcodes under the names they have there. What makes them usable is a module written over
+// them — the standard library's storage is two scopes doing exactly that — and the wrapper is
+// the point. How a key becomes a slot can change inside it without every program that keeps
+// something changing with it.
+//
+// They are written like the other instructions that take what follows them rather than
+// parentheses: `sload k` reads as `printd x` does, and `sstore k v` as `head x 1`.
+
+// ParseSload reads `sload k`.
+func (p *pr) ParseSload() (ast.Node, error) {
+	at, err := p.EatToken(token.SLOAD)
+	if err != nil {
+		return nil, err
+	}
+	key, err := p.ParseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return ast.SloadExpression{Key: key, Token: at}, nil
+}
+
+// ParseSstore reads `sstore k v`.
+//
+// The key is read as a whole expression and the value after it, which is the same shape the
+// tape operations have. Nothing separates the two, so `sstore a + 1 b` keeps b under a + 1 —
+// the reading a person gets from the line, since the key comes first.
+func (p *pr) ParseSstore() (ast.Node, error) {
+	at, err := p.EatToken(token.SSTORE)
+	if err != nil {
+		return nil, err
+	}
+	key, err := p.ParseExpr()
+	if err != nil {
+		return nil, err
+	}
+	value, err := p.ParseExpr()
+	if err != nil {
+		return nil, err
+	}
+	return ast.SstoreExpression{Key: key, Value: value, Token: at}, nil
+}

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -341,6 +341,29 @@ type ShapedExpression struct {
 	Token      token.Token `json:"-"`
 }
 
+// SloadExpression reads what the chain keeps under a key: `sload k`.
+//
+// It is an instruction of the machine and not a library, the way inline assembly is in C. What
+// makes it usable is a module written over it — the standard library's storage is two scopes
+// wrapping these two — and the wrapper is what lets how a key becomes a slot change without
+// every program that stores something changing with it.
+type SloadExpression struct {
+	mark
+	Key   Node        `json:"key"`
+	Token token.Token `json:"-"`
+}
+
+// SstoreExpression keeps a value under a key: `sstore k v`.
+//
+// It returns the value it kept, because everything in Aurora is an expression and a write is
+// no exception.
+type SstoreExpression struct {
+	mark
+	Key   Node        `json:"key"`
+	Value Node        `json:"value"`
+	Token token.Token `json:"-"`
+}
+
 // UseDeclaration brings a module in under an alias: `use a/b/c as x;`.
 //
 // It declares rather than binds. The alias names something only the compiler resolves — a

--- a/wire/ir/effect.go
+++ b/wire/ir/effect.go
@@ -71,6 +71,12 @@ var effects = map[byte]Effect{
 	OpIdent: Writes,
 	OpLoad:  Reads,
 
+	// Storage is state in the plainest sense: it outlives the transaction, and two of these in
+	// the other order is a different program. They are what the rule was written for, before
+	// there was anything for it to hold.
+	OpStorageGet: Reads,
+	OpStorageSet: Writes,
+
 	// A print says something, and when it says it is the whole of what it is for. It never
 	// reaches the backend that reorders — a chain has nowhere to put a log, by decision — so
 	// this costs nothing and is still the truth.

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -62,4 +62,15 @@ const (
 	// Reading past the end gives the neutral value rather than failing.
 	OpJoin  // Ref, Ref -> the run with one more tape at its end
 	OpField // Ref, Const, Const -> the tape at that index of a run of that many tapes
+
+	// Storage, which is what a chain keeps between one transaction and the next. A key is a
+	// tape and so is a value, and a key nothing was ever written under reads as the neutral
+	// tape — the same answer reading past the end of anything else gives.
+	//
+	// These are the first instructions whose order is the program. Nothing about the value
+	// either of them leaves says when it ran, and they share no value between them, so what
+	// keeps a read from being written before the write it follows is their effect and nothing
+	// else.
+	OpStorageGet // Ref -> what is kept under that key
+	OpStorageSet // Ref, Ref -> keeps the value under the key, and leaves the value
 )

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -47,6 +47,8 @@ const (
 	SUB          = "SUB"       // -
 	SUM          = "SUM"       // +
 	TAIL         = "TAIL"      // tail
+	SLOAD        = "SLOAD"     // sload
+	SSTORE       = "SSTORE"    // sstore
 	TRUE         = "TRUE"      // true
 	USE          = "USE"       // use - brings a module in under an alias
 	WHITESPACE   = "WHITESPACE"
@@ -105,6 +107,8 @@ var (
 	TagSub        = Tag{SUB, "-", ""}
 	TagSum        = Tag{SUM, "+", ""}
 	TagTail       = Tag{TAIL, "tail", "Get right to left nth items from a tape"}
+	TagSload      = Tag{SLOAD, "sload", "Read what the chain keeps under a key"}
+	TagSstore     = Tag{SSTORE, "sstore", "Keep a value under a key, between transactions"}
 	TagTrue       = Tag{TRUE, "true", ""}
 	TagUse        = Tag{USE, "use", "Bring a module in under an alias"}
 	TagWhitespace = Tag{WHITESPACE, " ", ""}
@@ -125,6 +129,8 @@ var processableTags = []Tag{
 	TagTail,
 	TagPush,
 	TagPull,
+	TagSload,
+	TagSstore,
 	TagShape,
 	TagAs,
 	TagUse,


### PR DESCRIPTION
Primeiro dos dois. Aqui estão as **instruções**; o módulo `std/evm/storage` que as embrulha
é o próximo.

```aurora
sstore 1 42;      #- guarda 42 sob a chave 1, e vale 42
sload 1;          #- 42
```

Chave é tape, valor é tape, e chave é qualquer coisa que o programa calcula. Chave sob a
qual nada foi guardado lê o tape neutro — igual a ler além do fim de uma run, e igual ao que
um slot nunca escrito responde numa chain.

`sstore` vale o que guardou, porque tudo aqui é expressão.

## Uma coisa que um teste pegou e virou documentação

As duas pegam o que vem depois delas como o `printd` pega — o máximo que for expressão.
Então **`sload 1 + 2` lê a chave três**, não "o que está em 1, mais 2". Somar ao que foi lido
se escreve fechando a leitura:

```aurora
sstore 1 ((sload 1) + 2);
```

Escrevi um caso de teste com a leitura errada sem perceber e ele respondeu 0. Ficaram os
dois casos: o certo, e um dizendo em voz alta o que a leitura gulosa faz.

## São do maquinário, não da biblioteca

São os dois opcodes da EVM sob o nome que eles têm lá — é o `asm` do C, não o `unsafe` do Go.
Um programa não é para escrever isso direto: o que ele usa é o módulo por cima, onde *como
uma chave vira um slot* é decidido num lugar só e pode mudar sem todo programa que guarda
algo mudar junto. Que é exatamente o wrapper que você descreveu.

Como combinado, elas são **globais** — qualquer módulo pode escrever. O `evm/` no caminho da
std marca a fronteira do módulo, não da instrução.

## Fora da chain

O evaluator simula com um mapa, por uma execução de programa — o que **uma transação** vê. Um
segundo `aurora run` começa vazio e uma chain não; isso está na documentação, não escondido.

O builder ainda não escreve e avisa no build, **sob o nome que o fonte usou**: quem escreveu
`sload` nunca ouviu falar de `OpStorageGet`.

## O `Effect` paga aqui

As duas não compartilham valor nenhum, então nada sobre o que elas deixam diz qual rodou
primeiro. A lowering pode mover as duas, e uma leitura movida para antes da escrita que ela
segue lê o que estava lá antes — **com o contrato respondendo um número dos dois jeitos**.

Dois casos entraram no corpus que roda a regra sobre programas reais.

## Próximo

`$AURORA_ROOT/lib/std/evm/storage.ar`, com `$HOME/.aurora` de padrão, e o prefixo `std/`
reservado. Playground sem std por ora, como você decidiu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)