### PR TITLE
The standard library is on disk, and storage is its first module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,23 @@ wasm:
 
 build-force: clean aurora aurorals
 
+# What comes with the language, put where the binary looks for it.
+#
+# AURORA_ROOT is where somebody chose to keep it, and $HOME/.aurora is where the binary looks
+# when nobody chose — the same two the binary itself reads, so building and running agree
+# without either being told what the other did.
+#
+# It copies rather than links because a link into a working tree makes the installed standard
+# library change when a branch is checked out, which is a way to debug the wrong thing for an
+# afternoon.
+AURORA_ROOT ?= $(HOME)/.aurora
+
+install-std:
+	@rm -rf $(AURORA_ROOT)/lib/std
+	@mkdir -p $(AURORA_ROOT)/lib
+	@cp -R lib/std $(AURORA_ROOT)/lib/std
+	@echo "the standard library is in $(AURORA_ROOT)/lib/std"
+
 aurora: $(BIN)/aurora
 
 $(BIN)/aurora: $(SOURCES)
@@ -109,4 +126,4 @@ $(GODEPGRAPH_BIN):
 	@echo "==> Installing godepgraph..."
 	@go install github.com/kisielk/godepgraph@latest
 
-.PHONY: all check build wasm build-force aurora aurorals test bench lint complexity act cover-html clean depgraph
+.PHONY: all check build wasm build-force install-std aurora aurorals test bench lint complexity act cover-html clean depgraph

--- a/cmd/aurora/resolver.go
+++ b/cmd/aurora/resolver.go
@@ -6,6 +6,7 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/shared/fileutil"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/module"
 )
@@ -23,7 +24,10 @@ func newResolver(tapeSize int, sourceRoot string) *resolver.Resolver {
 
 	return resolver.New(resolver.Options{
 		SourceRoot: sourceRoot,
-		Read:       os.ReadFile,
+		// Where what comes with the language was installed, read here because reading the
+		// environment is touching the world and a phase does not do that.
+		StdRoot: fileutil.StdRoot(),
+		Read:    os.ReadFile,
 		Parse: func(filename string, id module.ID, source []byte, imports map[string]ast.Offer) (ast.AST, error) {
 			tokens, err := lx.GetFilledTokens(source)
 			if err != nil {

--- a/cmd/aurorals/modules.go
+++ b/cmd/aurorals/modules.go
@@ -10,6 +10,7 @@ import (
 	"github.com/guiferpa/aurora/lexer"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/shared/fileutil"
 	"github.com/guiferpa/aurora/wire/ast"
 	"github.com/guiferpa/aurora/wire/module"
 )
@@ -32,7 +33,10 @@ func resolveModules(s *state.State) textdoc.Resolve {
 	return func(doc textdoc.Document, uses []ast.UseDeclaration) ([]module.Module, error) {
 		return resolver.New(resolver.Options{
 			SourceRoot: sourceRootFor(doc.Filename),
-			Read:       readThroughBuffers(s),
+			// The editor reaches the language's own modules the same way a build does, so a
+			// name inside one is offered after the dot and jumps to where it was written.
+			StdRoot: fileutil.StdRoot(),
+			Read:    readThroughBuffers(s),
 			Parse: func(filename string, id module.ID, source []byte, imports map[string]ast.Offer) (ast.AST, error) {
 				tokens, err := lx.GetFilledTokens(source)
 				if err != nil {

--- a/docs/modules.md
+++ b/docs/modules.md
@@ -189,6 +189,53 @@ What does not cross is a scope whose shape nothing says — one ending with arit
 a tape and not a run. It hands over the tapes and no shape, and the file reading it has to
 name one.
 
+### What comes with the language
+
+A module whose name starts with `std/` is read from where the toolchain installed it, not from
+under the program:
+
+```
+use std/evm/storage as s;
+
+ident deposit = defer { s.set(1, s.get(1) + feed(0)); };
+ident balance = defer { s.get(1); };
+```
+
+The prefix is the whole of what says so, and everything after that is the same: it is an
+ordinary Aurora file, parsed the same way, offering what it binds at the top the same way, and
+reached under an alias the importing file chose.
+
+**The second segment names the target.** `std/evm` is written over the EVM's own instructions
+and means nothing anywhere else, so a module that cannot cross is marked as not crossing rather
+than found out at the far end. Another machine gets its own `std/<target>/storage` offering the
+same two names, and what a program writes stays the same.
+
+Where it is installed is `$AURORA_ROOT/lib`, or `$HOME/.aurora/lib` when `AURORA_ROOT` says
+nothing — so `std/evm/storage` reads `$HOME/.aurora/lib/std/evm/storage.ar`. One directory and
+no search: a list of places to look is how a machine ends up running the standard library of a
+toolchain that was uninstalled a year ago. `make install-std` puts it there.
+
+That is also the whole of the versioning story, and it is the same one C has: what answers
+`use std/evm/storage` is what the `aurora` on this machine shipped with, and there is no way
+for a program to ask for another.
+
+A module of the language that is not installed is refused where it was imported, naming the
+file it looked for — which says the toolchain is half installed rather than that the name was
+typed wrong.
+
+#### What `std/evm/storage` is
+
+Two scopes over the two instructions, and it is worth reading because it is short:
+
+```
+ident set = defer { sstore feed(0) feed(1); };
+ident get = defer { sload feed(0); };
+```
+
+That is the point of it. `sload` and `sstore` are the machine's, and how a key becomes a slot
+is decided in this one file — so it can change without a single program that keeps something
+changing with it. A program that wrote `sstore` directly would have to change.
+
 ### And a shape can be named
 
 A shape's name belongs to the file that declared it, so elsewhere it is written as the

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -125,6 +125,15 @@ What it does not do yet:
   directory and invalidated by the manifest's mtime.
 - **Nothing lists a dependency but the file system.** There are no third-party packages, so
   there is nothing for the manifest to name yet.
+- **The playground has no standard library.** What comes with the language is read from a
+  directory the toolchain installed, and the playground is wasm in a browser, where there is
+  none. So `use std/evm/storage` works everywhere `aurora` runs and nowhere the playground
+  does. What would close it is embedding the same files in the binary and reading the directory
+  over them when it is there — one source, two ways to reach it — and it waits until somebody
+  wants the standard library in the playground.
+- **Nothing installs the standard library but `make install-std`.** A release ships a binary
+  and not the files beside it, so somebody who downloads one has the language and not its
+  library. What that needs is the release carrying both, and a first run that says so.
 
 Two things are decided against rather than missing. **An import is not passed on**: if `main`
 uses `a` and `a` uses `b`, `main` writes its own line for `b`, so a name used in a file has

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -30,16 +30,20 @@ type sessionOpts struct {
 	// asserts turns assertions on and sends what a program prints nowhere, which is what
 	// "aurora test" does: a test says what held, not what was printed on the way.
 	asserts bool
+	// stdRoot is where the modules that come with the language are read from. Empty is a
+	// toolchain with none installed, which is what most of these tests are.
+	stdRoot string
 }
 
 // newTestResolver puts the front of the pipeline together the way cmd/aurora does: a test
 // wires what main wires, since a host is handed its phases rather than building them.
-func newTestResolver(tapeSize int) *resolver.Resolver {
+func newTestResolver(tapeSize int, stdRoot string) *resolver.Resolver {
 	lx := lexer.New()
 	ps := parser.New()
 
 	return resolver.New(resolver.Options{
 		SourceRoot: manifest.DefaultSourceRoot,
+		StdRoot:    stdRoot,
 		Read:       os.ReadFile,
 		Parse: func(filename string, id module.ID, source []byte, imports map[string]ast.Offer) (ast.AST, error) {
 			tokens, err := lx.GetFilledTokens(source)
@@ -81,7 +85,7 @@ func newSession(t *testing.T, o sessionOpts) *Session {
 		Lexer:    lexer.New(),
 		Parser:   parser.New(),
 		Emitter:  emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
-		Resolver: newTestResolver(size),
+		Resolver: newTestResolver(size, o.stdRoot),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{
 				PrintBytes:   printer.Bytes(printed, size),

--- a/hosting/cli/std_test.go
+++ b/hosting/cli/std_test.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"bytes"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// What comes with the language is read from where the toolchain installed it, and not from
+// under the program.
+//
+// `std/` is the whole of what says so — the same way Go tells its own library from everything
+// else by what the import path looks like. The second segment names the target: std/evm is
+// written over the EVM's own instructions and means nothing anywhere else, so a module that
+// cannot cross is marked as not crossing rather than found out at the far end.
+func TestAModuleOfTheLanguageIsReadFromWhereItWasInstalled(t *testing.T) {
+	root := stdRootOf(t)
+
+	for _, tc := range []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{
+			name:   "kept and read back",
+			source: "use std/evm/storage as s;\ns.set(1, 42);\nprintd s.get(1);",
+			want:   "42",
+		},
+		{
+			// A set returns what it kept, so it stands where any other value does.
+			name:   "a set is worth what it kept",
+			source: "use std/evm/storage as s;\nprintd s.set(1, 41) + 1;",
+			want:   "42",
+		},
+		{
+			name:   "a key nothing was kept under",
+			source: "use std/evm/storage as s;\ns.set(1, 42);\nprintd s.get(2);",
+			want:   "0",
+		},
+		{
+			// Read, add, keep — and inside the wrapper the reading needs no parentheses,
+			// which is one of the things the wrapper is for.
+			name: "read, added to, and kept again",
+			source: "use std/evm/storage as s;\n" +
+				"ident bump = defer { s.set(1, s.get(1) + feed(0)); };\n" +
+				"s.set(1, 40);\nbump(2);\nprintd s.get(1);",
+			want: "42",
+		},
+		{
+			// The alias belongs to the file, the way it does for every other import.
+			name:   "under an alias of the file's own",
+			source: "use std/evm/storage as chain;\nchain.set(1, 42);\nprintd chain.get(1);",
+			want:   "42",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			projectOf(t, map[string]string{"src/main.ar": tc.source})
+			printed, err := runWithStd(t, "src/main.ar", root)
+			if err != nil {
+				t.Fatalf("running: %v", err)
+			}
+			if got := strings.Fields(printed); len(got) == 0 || got[len(got)-1] != tc.want {
+				t.Errorf("printed %q, want it to end with %s", printed, tc.want)
+			}
+		})
+	}
+}
+
+// A module of the language that is not installed is refused where it was imported, naming the
+// file it looked for — which is what tells somebody the toolchain is half installed rather
+// than that they typed the name wrong.
+func TestAModuleOfTheLanguageThatIsNotInstalled(t *testing.T) {
+	projectOf(t, map[string]string{"src/main.ar": "use std/evm/nothing as n;\nprintd n.get(1);"})
+
+	_, err := runWithStd(t, "src/main.ar", stdRootOf(t))
+	if err == nil {
+		t.Fatal("a module nobody installed was imported")
+	}
+	if !strings.Contains(err.Error(), "std/evm/nothing") {
+		t.Errorf("error = %q, want it to name the module", err)
+	}
+}
+
+// runWithStd runs a program that can reach what comes with the language.
+func runWithStd(t *testing.T, entry, stdRoot string) (string, error) {
+	t.Helper()
+
+	var stdout bytes.Buffer
+	err := newSession(t, sessionOpts{stdout: &stdout, stdRoot: stdRoot}).Run(t.Context(), filepath.FromSlash(entry))
+	return stdout.String(), err
+}
+
+// stdRootOf answers the repository's own lib, so the test reads the same files `make
+// install-std` copies. Reading them where they are written is what keeps this from passing
+// against a stale copy somebody installed months ago.
+func stdRootOf(t *testing.T) string {
+	t.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", "lib"))
+	if err != nil {
+		t.Fatalf("finding the standard library: %v", err)
+	}
+	return root
+}

--- a/lib/std/evm/storage.ar
+++ b/lib/std/evm/storage.ar
@@ -1,0 +1,32 @@
+#- What a chain keeps between one transaction and the next, as a map.
+#-
+#- This is the standard library, which is why it is written in Aurora rather than in the
+#- compiler: sload and sstore are the machine's own instructions, and everything a program
+#- should write sits on this side of them.
+#-
+#- That is the whole point of the wrapper. How a key becomes a slot is decided here, in one
+#- place, so it can change — hashed, prefixed, packed — without a single program that keeps
+#- something changing with it. A program that wrote sstore directly would have to change.
+#-
+#- It is under std/evm because it is written over the EVM's instructions and means nothing
+#- anywhere else. A backend for another machine gets its own std/<target>/storage, offering
+#- the same two names, so what a program writes stays the same.
+#-
+#- Output:
+#-   (nothing: a module of declarations does its work when somebody imports it)
+
+#- Keeps a value under a key, and returns the value it kept.
+#-
+#- It returns it because everything in Aurora is an expression, so `s.set(1, 41) + 1` is
+#- forty-two, and because a scope that answered nothing would be the only one here that does.
+ident set = defer {
+  sstore feed(0) feed(1);
+};
+
+#- Reads what is kept under a key.
+#-
+#- A key nothing was ever kept under reads as the neutral tape, which is what a slot never
+#- written answers on a chain and what reading past the end of a run answers off one.
+ident get = defer {
+  sload feed(0);
+};

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -45,20 +45,28 @@ type Options struct {
 	// SourceRoot is the directory module names resolve from, and `a/b/c` under it is
 	// a/b/c.ar. Empty means the caller's own directory.
 	SourceRoot string
-	Read       Read
-	Parse      Parse
-	Header     Header
+	// StdRoot is where the modules that come with the language are installed, and `std/evm/x`
+	// under it is std/evm/x.ar — the prefix stays in the path, because it is part of the name.
+	//
+	// It is given rather than found because finding it means reading the environment, and a
+	// vital package does not touch the world. Empty is a toolchain with none installed, and a
+	// program importing one is refused where it wrote the import.
+	StdRoot string
+	Read    Read
+	Parse   Parse
+	Header  Header
 }
 
 type Resolver struct {
 	sourceRoot string
+	stdRoot    string
 	read       Read
 	parse      Parse
 	header     Header
 }
 
 func New(opts Options) *Resolver {
-	return &Resolver{sourceRoot: opts.SourceRoot, read: opts.Read, parse: opts.Parse, header: opts.Header}
+	return &Resolver{sourceRoot: opts.SourceRoot, stdRoot: opts.StdRoot, read: opts.Read, parse: opts.Parse, header: opts.Header}
 }
 
 // resolution is one call to Resolve: what has been found, what is being looked at right now,
@@ -216,8 +224,16 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 }
 
 // Filename is the file a module name reads: a/b/c under the source root, with the extension
-// back on.
+// back on — or under the root the language's own modules were installed in, when the name says
+// it is one of those.
+//
+// Which root a name reads from is the only thing the prefix decides. Everything after that is
+// the same: a module of the standard library is an ordinary Aurora file, parsed the same way,
+// offering what it binds at the top the same way.
 func (r *Resolver) Filename(id module.ID) string {
+	if module.IsStd(id) {
+		return path.Join(r.stdRoot, string(id)+Extension)
+	}
 	return path.Join(r.sourceRoot, string(id)+Extension)
 }
 

--- a/shared/fileutil/aurora_root.go
+++ b/shared/fileutil/aurora_root.go
@@ -1,0 +1,47 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// Where the toolchain keeps what comes with the language.
+//
+// It is one directory and everything under it belongs to the version of the toolchain that
+// installed it, which is the whole of the versioning story: there is no way for a program to
+// ask for another version, the way there is none in C. What answers `use std/evm/storage` is
+// what the aurora on this machine shipped with.
+
+// AuroraRootVariable is what somebody sets to keep it somewhere else.
+const AuroraRootVariable = "AURORA_ROOT"
+
+// AuroraRoot answers where the toolchain's own files live: what AURORA_ROOT says, or
+// $HOME/.aurora when it says nothing.
+//
+// A machine with neither answers empty rather than guessing, and a program that imports a
+// module of the language is refused where it wrote the import — which says more than a path
+// that was never going to exist.
+func AuroraRoot() string {
+	if named := os.Getenv(AuroraRootVariable); named != "" {
+		return named
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".aurora")
+}
+
+// StdRoot answers the directory the language's own modules read from, which is lib under the
+// root: `std/evm/storage` is $AURORA_ROOT/lib/std/evm/storage.ar.
+//
+// The prefix stays in the path rather than being stripped, because it is part of the module's
+// name — two files at lib/std/evm/storage.ar and lib/evm/storage.ar would be two modules, and
+// only one of them is importable.
+func StdRoot() string {
+	root := AuroraRoot()
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, "lib")
+}

--- a/shared/fileutil/aurora_root_test.go
+++ b/shared/fileutil/aurora_root_test.go
@@ -1,0 +1,52 @@
+package fileutil
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// Where the toolchain's own files live: what somebody chose, or one place under the home
+// directory when nobody chose.
+//
+// There is no third answer and no search. A list of places to look is how a machine ends up
+// running the standard library of a toolchain that was uninstalled a year ago, and the point
+// of one directory is that the version question has one answer.
+func TestWhereTheToolchainKeepsItsOwnFiles(t *testing.T) {
+	t.Run("what somebody chose", func(t *testing.T) {
+		chosen := t.TempDir()
+		t.Setenv(AuroraRootVariable, chosen)
+
+		if got := AuroraRoot(); got != chosen {
+			t.Errorf("the root is %q, want %q", got, chosen)
+		}
+		if got, want := StdRoot(), filepath.Join(chosen, "lib"); got != want {
+			t.Errorf("the modules read from %q, want %q", got, want)
+		}
+	})
+
+	t.Run("and where it looks when nobody did", func(t *testing.T) {
+		t.Setenv(AuroraRootVariable, "")
+
+		home, err := os.UserHomeDir()
+		if err != nil {
+			t.Skip("this machine has no home directory to look under")
+		}
+		if got, want := AuroraRoot(), filepath.Join(home, ".aurora"); got != want {
+			t.Errorf("the root is %q, want %q", got, want)
+		}
+	})
+}
+
+// The prefix stays in the path rather than being stripped.
+//
+// It is part of the module's name: lib/std/evm/storage.ar and lib/evm/storage.ar would be two
+// files, and only the first of them is what `use std/evm/storage` means.
+func TestTheStdPrefixIsPartOfThePath(t *testing.T) {
+	chosen := t.TempDir()
+	t.Setenv(AuroraRootVariable, chosen)
+
+	if got, want := StdRoot(), filepath.Join(chosen, "lib"); got != want {
+		t.Errorf("the modules read from %q, want %q — the std stays in the module name", got, want)
+	}
+}

--- a/wire/module/module.go
+++ b/wire/module/module.go
@@ -36,6 +36,22 @@ func (m Module) IsEntry() bool {
 	return m.ID == ""
 }
 
+// StdPrefix marks a module that comes with the language rather than with the program.
+//
+// `use std/evm/storage as s;` reads a file the toolchain installed, not one under the
+// program's source root, and the prefix is the whole of what says so — the same way Go tells
+// its standard library from everything else by what the import path looks like.
+//
+// The second segment names the target the module is written for. `std/evm` is written over the
+// EVM's own instructions and means nothing anywhere else, so a module that cannot cross is
+// marked as not crossing rather than found out at the far end.
+const StdPrefix = "std/"
+
+// IsStd says whether a module comes with the language.
+func IsStd(id ID) bool {
+	return strings.HasPrefix(string(id), StdPrefix)
+}
+
 // Separator is what stands between a module and a name inside it: a/b/c.add.
 //
 // It is a character no identifier can hold — the lexer takes letters, digits and _ - ? ! > <


### PR DESCRIPTION
```aurora
use std/evm/storage as s;

ident deposit = defer { s.set(1, s.get(1) + feed(0)); };
ident balance = defer { s.get(1); };
```

Lê `$AURORA_ROOT/lib/std/evm/storage.ar`, com `$HOME/.aurora` de padrão. Exatamente o que
você especificou.

## O módulo, que é curto de propósito

```aurora
ident set = defer { sstore feed(0) feed(1); };
ident get = defer { sload feed(0); };
```

Isso é o wrapper que você descreveu, e vale dizer por que ele paga: **como uma chave vira
um slot está decidido neste arquivo só.** Pode virar hash, ganhar prefixo, empacotar — e
nenhum programa que guarda alguma coisa muda junto. Um programa que escrevesse `sstore`
direto teria que mudar.

## Um diretório, sem busca

Nada de lista de caminhos. Lista de lugares onde procurar é como uma máquina acaba rodando
a std de um toolchain desinstalado há um ano — e assim a pergunta de versão tem **uma**
resposta: o que o `aurora` desta máquina trouxe. É a mesma história do C, e pelo mesmo
motivo: não há como um programa pedir outra versão.

O `evm/` faz o que você queria: um módulo que não atravessa plataforma **diz isso no nome**,
em vez de ser descoberto do outro lado. Outra máquina ganha `std/<alvo>/storage` oferecendo
os mesmos dois nomes, e o que o programa escreve continua igual.

## O resolver continuou puro

Qual raiz um nome lê é um `path.Join`; **onde** essa raiz fica vem do ambiente, lido no
`main`, que é a única camada que toca o mundo. Nenhuma exceção à arquitetura.

## Dois limites, no roadmap em vez de descobertos depois

- **O playground não tem std**, como você decidiu — é wasm, não há diretório. O que fecharia
  isso está escrito lá (embutir os mesmos arquivos e deixar o diretório sobrepor), esperando
  alguém querer.
- **Só o `make install-std` instala.** Um release entrega binário sem os arquivos ao lado,
  então quem baixa tem a linguagem e não a biblioteca. Está nomeado.

## Testes

Cinco casos lendo a std de verdade — inclusive `s.set(1, s.get(1) + feed(0))` dentro de um
escopo, que é a forma que todo contrato que conta alguma coisa tem. Mais o módulo não
instalado (a mensagem nomeia o arquivo procurado, que é o que diz "toolchain pela metade" em
vez de "você digitou errado"), e a descoberta da raiz com e sem `AURORA_ROOT`.

## O que falta para fechar a missão 3

`SSTORE`/`SLOAD` no bytecode e um caso no harness. Depois disso o contrato guarda de verdade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)