### PR TITLE
A contract keeps things

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,6 +48,15 @@ at the default and a ceiling nobody chose — a run past thirty-two bytes was re
 written short, so a program ran off a chain and could not reach one. Nothing goes on the stack
 even when it fits: a run kept two ways is two things a consumer has to tell apart.
 
+Storage is written, and with it a contract keeps things. `sload` and `sstore` are the two EVM
+opcodes under the names they have there, and `std/evm/storage` is two scopes over them — which
+is where the standard library begins: real Aurora, read from `$AURORA_ROOT/lib`, so how a key
+becomes a slot is decided in one file rather than in every program that keeps something.
+Writing it found an older bug the harness had never covered: a value nothing takes was left on
+the stack, so a scope with a line written for what it does — `sstore 1 42;`, a `printd`, a call
+whose answer nobody wanted — returned to the wrong place and the contract reverted. It is
+dropped where it was computed now.
+
 The tape operations are written too, and with them **the backend carries every feature a
 program can use**. All four rest on one thing: how much of a value means something, which off
 a chain is the length of a slice and on one is worked out from the word by halving, five times,

--- a/builder/evm/blocks.go
+++ b/builder/evm/blocks.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"github.com/guiferpa/aurora/byteutil"
 	"io"
 
 	"github.com/guiferpa/aurora/wire/ir"
@@ -97,6 +98,14 @@ func writeBlock(bs io.Writer, block ir.Block, order []ir.BlockID, at map[ir.Bloc
 	for _, inst := range block.Insts {
 		if err := WriteInstruction(here, scope.Names, inst, scope, here.at); err != nil {
 			return err
+		}
+		// A value nothing takes is dropped where it was computed, or it stays under everything
+		// written after it — and the return that expected the address it came from finds it
+		// instead, which is a jump to nowhere rather than a wrong answer.
+		if scope.Stranded[byteutil.ToHex(inst.GetLabel())] {
+			if _, err := here.Write([]byte{OpPop}); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -85,6 +85,9 @@ func produces(op byte) bool {
 		ir.OpAdd, ir.OpSubtract, ir.OpMultiply, ir.OpDivide, ir.OpExponential,
 		ir.OpEquals, ir.OpDiff, ir.OpBigger, ir.OpSmaller, ir.OpAnd, ir.OpOr,
 		ir.OpJoin, ir.OpField, ir.OpPull, ir.OpPush, ir.OpHead, ir.OpTail,
+		// A read leaves what it read, and a write leaves what it wrote: both are expressions
+		// like everything else here.
+		ir.OpStorageGet, ir.OpStorageSet,
 		// A print writes nothing on a chain and is worth what it was given, so it leaves a
 		// value like anything else — the same value, under a name of its own.
 		ir.OpPrintBytes, ir.OpPrintChars, ir.OpPrintDecimal:

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -42,6 +42,8 @@ var handled = map[byte]bool{
 	ir.OpPush:        true,
 	ir.OpHead:        true,
 	ir.OpTail:        true,
+	ir.OpStorageGet:  true,
+	ir.OpStorageSet:  true,
 }
 
 // offChain is what is meant to be absent from a chain. Saying so is still worth a line: a
@@ -65,10 +67,11 @@ var offChain = map[byte]string{
 // An opcode in neither list is warned about under the name the IR gives it rather than passed
 // over: a gap nobody remembered to write down here is still a gap, and the point of this file
 // is that a gap is never silent.
-var pending = map[byte]string{
-	ir.OpStorageGet: "sload does not reach the bytecode yet: a contract using it compiles, and reads the neutral tape on chain",
-	ir.OpStorageSet: "sstore does not reach the bytecode yet: a contract using it compiles, and keeps nothing on chain",
-}
+// It is empty again. Every instruction the emitter produces reaches the bytecode, and that is
+// what makes this file matter more rather than less: an opcode in neither list is warned about
+// under the name the IR gives it, rather than passed over. A gap nobody remembered to write
+// down here is still a gap, and the point of this file is that a gap is never silent.
+var pending = map[byte]string{}
 
 // Warnings reports what a program uses that does not reach the bytecode.
 //

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -1062,6 +1062,18 @@ type Scope struct {
 	// Tapes is how many tapes the value this scope returns is made of, which is one for an
 	// ordinary value and more for a run. It decides how much a return hands to the chain.
 	Tapes int
+	// Stranded answers which labels leave a value on the stack that nothing ever takes.
+	//
+	// An expression written for what it does rather than for what it is worth leaves one:
+	// `sstore 1 42;` on its own line keeps something and its value goes nowhere. So does
+	// `printd x;`, and so does an arithmetic line somebody wrote and stopped using. Off a
+	// chain the value is a name in a map and is simply never read; on one it sits on the
+	// stack, under everything written after it, and the return that expected to find the
+	// address it came from finds that instead.
+	//
+	// It is worked out here, over the whole scope, because a value left by one block can be
+	// taken by another.
+	Stranded map[string]bool
 	// Runs answers where in the frame each construction of a run lays its tapes, by the label
 	// the construction leaves its value under.
 	//
@@ -1105,6 +1117,7 @@ func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[st
 
 	names := make(map[string]int)
 	runs := make(map[string]int)
+	stranded := strandedIn(blocks, order)
 	offset := params * MEMORY_SLOT_SIZE
 	for _, id := range order {
 		for _, inst := range blocks[id].Insts {
@@ -1132,6 +1145,7 @@ func ScopeOf(blocks []ir.Block, order []ir.BlockID, tapeSize int, entries map[st
 		Tapes:    tapes,
 		Names:    names,
 		Runs:     runs,
+		Stranded: stranded,
 		Frame:    offset,
 		Entries:  entries,
 	}
@@ -1243,6 +1257,18 @@ func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, s
 		}
 	}
 
+	if op == ir.OpStorageGet {
+		if _, err := WriteStorageGet(bs); err != nil {
+			return err
+		}
+	}
+
+	if op == ir.OpStorageSet {
+		if _, err := WriteStorageSet(bs); err != nil {
+			return err
+		}
+	}
+
 	if op == ir.OpJoin {
 		if err := WriteJoin(bs, inst, scope.TapeSize, scope.Runs[byteutil.ToHex(inst.GetLabel())]); err != nil {
 			return err
@@ -1298,4 +1324,80 @@ func RunRoom(tapes, tapeSize int) int {
 // RunLeadIn is the room in front of a run, which is what a word has over a tape.
 func RunLeadIn(tapeSize int) int {
 	return MEMORY_SLOT_SIZE - byteutil.TapeSize(tapeSize)
+}
+
+// WriteStorageGet reads what the chain keeps under a key.
+//
+// The key is on the stack and SLOAD leaves what is kept in its place, so there is nothing to
+// arrange. A slot never written answers zeros, which is the neutral tape — the same answer the
+// evaluator gives, without either being told to agree.
+func WriteStorageGet(w io.Writer) (int, error) {
+	return w.Write([]byte{OpStorageLoad})
+}
+
+// WriteStorageSet keeps a value under a key, and leaves the value.
+//
+// It leaves it because a write is an expression here like everything else, and SSTORE leaves
+// nothing — so the value is copied before it is spent.
+//
+// The stack arrives with the value on top and the key under it, which is the order the two
+// were written. SSTORE wants the key on top and the value under, and wants both gone. So:
+//
+//	value key          the two operands, as they arrive
+//	value value key    DUP1, the copy that survives
+//	key value value    SWAP2, which brings the key up and leaves a copy at the bottom
+//	value              SSTORE, having taken the key and one of the two values
+func WriteStorageSet(w io.Writer) (int, error) {
+	return w.Write([]byte{OpDup1, OpSwap2, OpStorageStore})
+}
+
+// strandedIn answers the labels of the values nothing in this scope ever takes.
+//
+// Everything that could take one is read: the operands of every instruction, and what each
+// terminator carries — the value a block returns, the value a branch chooses on, and the
+// values handed to a block that is gone to. A label under none of those is a value computed
+// and left where nobody looks.
+func strandedIn(blocks []ir.Block, order []ir.BlockID) map[string]bool {
+	taken := make(map[string]bool)
+	for _, id := range order {
+		for _, inst := range blocks[id].Insts {
+			for _, operand := range consumes(inst) {
+				taken[byteutil.ToHex(operand.Bytes())] = true
+			}
+		}
+		for _, operand := range terminatorTakes(blocks[id].Term) {
+			if operand.Kind() == ir.KindRef {
+				taken[byteutil.ToHex(operand.Bytes())] = true
+			}
+		}
+	}
+
+	stranded := make(map[string]bool)
+	for _, id := range order {
+		for _, inst := range blocks[id].Insts {
+			if label := byteutil.ToHex(inst.GetLabel()); leavesAValue(inst.GetOpCode()) && !taken[label] {
+				stranded[label] = true
+			}
+		}
+	}
+	return stranded
+}
+
+// leavesAValue answers whether an instruction leaves something on the stack.
+//
+// It is not the same question as produces, which is about whether an instruction can be held
+// back and emitted next to whoever takes its value. A call leaves a value and cannot be held —
+// it is a jump, and where it sits is where it happens — so it is here and not there, and
+// reading the two as one is how a call written for what it does left something behind.
+func leavesAValue(op byte) bool {
+	return produces(op) || op == ir.OpCall
+}
+
+// terminatorTakes answers every value a terminator reads, whichever of the three it is.
+func terminatorTakes(term ir.Terminator) []ir.Operand {
+	taken := []ir.Operand{term.Cond, term.Value}
+	for _, target := range term.Targets {
+		taken = append(taken, target.Args...)
+	}
+	return taken
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -152,6 +152,12 @@ tape width — a result that leaves the width is cut back to it, the way the eva
 names bound inside a scope, branches, the comparisons and `and`/`or`, a scope calling another
 as deep as it nests, shapes, and the tape operations.
 
+**A contract keeps things now.** `sload` and `sstore` are the two EVM opcodes, and
+`std/evm/storage` is two scopes over them, so `s.set(1, s.get(1) + feed(0))` is a deposit that
+outlives the transaction. The harness proves it: kept, kept over, a key nothing was written
+under, and a running total — through the standard library, which is a call reaching a module
+reaching the machine.
+
 Nothing a program can write is missing from it any more, and a shape is no longer the
 exception it used to be: **a run of any width reaches a chain**. It lives in memory rather than
 on the stack, laid tape after tape in the order it was written, so what a contract hands back
@@ -171,11 +177,6 @@ written down:
   storage, no event, no caller, and no way to refuse a transaction. Each of them is its own
   decision, and each has the same question under it: what does it mean off a chain, where
   there is no storage, no log, and nobody calling. `rfcs/` is where those are argued.
-- **`sload` and `sstore` do not reach the bytecode yet.** They run off a chain, where a map
-  simulates what one transaction sees, so a contract using them compiles and keeps nothing on
-  chain — said out loud at build time, under the names the source used. What is left is the two
-  EVM opcodes and a case in the harness. The ordering they need is already written down: they
-  share no value, so only their effects keep them in the order they were written.
 - **Only a scope bound at the top of a program can be called.** A scope written inside another
   is not written at all: on a chain the name it was bound to holds the neutral value, and
   calling it is refused rather than written as a jump to an address no scope has.

--- a/hosting/cli/build_test.go
+++ b/hosting/cli/build_test.go
@@ -163,18 +163,6 @@ func TestBuildSaysWhatTheBackendDoesNotCarry(t *testing.T) {
 			source: "ident show = defer { printd feed(0); };\n",
 			want:   "printd is ignored in compiled code",
 		},
-		{
-			// Said under the name the source used, and not under the one the IR uses: whoever
-			// reads this wrote sload, and has never heard of an OpStorageGet.
-			name:   "a read of what the chain keeps",
-			source: "ident kept = defer { sload feed(0); };\n",
-			want:   "sload does not reach the bytecode yet",
-		},
-		{
-			name:   "a write of it",
-			source: "ident keep = defer { sstore feed(0) feed(1); };\n",
-			want:   "sstore does not reach the bytecode yet",
-		},
 	}
 
 	for _, tc := range cases {

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -41,6 +41,17 @@ func onChain(t *testing.T, source, function string, args []string, tapeSize int)
 		t.Fatalf("reading the binary: %v", err)
 	}
 
+	return calledOnChain(t, bytecode, function, args, tapeSize)
+}
+
+// calledOnChain deploys a contract to an EVM in memory and calls one of its scopes by name.
+//
+// It is apart from the building so that a program of several files can be deployed too: how a
+// contract is assembled depends on how many files it is, and what happens after it is
+// assembled does not.
+func calledOnChain(t *testing.T, bytecode []byte, function string, args []string, tapeSize int) []byte {
+	t.Helper()
+
 	cfg := &runtime.Config{GasLimit: 10_000_000, Value: big.NewInt(0)}
 	_, address, _, err := runtime.Create(bytecode, cfg)
 	if err != nil {
@@ -83,6 +94,48 @@ func offChain(t *testing.T, source, function string, args []string, tapeSize int
 		t.Fatalf("running: %v", err)
 	}
 	return strings.TrimSpace(out.String())
+}
+
+// agreeThroughTheStandardLibrary runs the same call through both backends, for a program that
+// imports what comes with the language.
+//
+// It needs a project rather than one file, because a module is found from a source root, and a
+// standard library to find — so the two ways in are built here rather than in the helpers
+// above, which know about one file and nothing else.
+func agreeThroughTheStandardLibrary(t *testing.T, source, function string, args []string, tapeSize int) {
+	t.Helper()
+
+	opts := sessionOpts{tapeSize: tapeSize, stdRoot: stdRootOf(t)}
+	entry := filepath.Join("src", "main.ar")
+
+	projectOf(t, map[string]string{"src/main.ar": source})
+	binary := filepath.Join(t.TempDir(), "contract.bin")
+	if _, err := newSession(t, opts).Build(t.Context(), entry, binary); err != nil {
+		t.Fatalf("building: %v", err)
+	}
+	bytecode, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("reading the binary: %v", err)
+	}
+
+	feeds := make([]string, 0, len(args))
+	for i := range args {
+		feeds = append(feeds, fmt.Sprintf("feed(%d)", i))
+	}
+	printed := &strings.Builder{}
+	ran := opts
+	ran.stdout, ran.args = printed, args
+
+	projectOf(t, map[string]string{
+		"src/main.ar": source + "\n" + fmt.Sprintf("printd %s(%s);", function, strings.Join(feeds, ", ")) + "\n",
+	})
+	if err := newSession(t, ran).Run(t.Context(), entry); err != nil {
+		t.Fatalf("running: %v", err)
+	}
+
+	if got := decimalOf(calledOnChain(t, bytecode, function, args, tapeSize)); got != strings.TrimSpace(printed.String()) {
+		t.Errorf("the chain answered %s and the evaluator %s", got, strings.TrimSpace(printed.String()))
+	}
 }
 
 // agree runs the same call through both backends and reports when they answer differently.
@@ -556,6 +609,103 @@ ident build = defer { Five{1, 2, 3, 4, feed(0)}; };`
 	if printed := strings.TrimSpace(offChain(t, source, "build", []string{"9"}, 0)); printed != "1 2 3 4 9" {
 		t.Errorf("the evaluator answered %q, want the five tapes", printed)
 	}
+}
+
+// A value nothing takes is dropped, rather than left under everything written after it.
+//
+// A line written for what it does and not for what it is worth leaves one: `sstore 1 42;` on
+// its own, a `printd`, a call whose answer nobody wanted, or an arithmetic line somebody
+// stopped using. Off a chain it is a name in a map that is never read; on one it sat on the
+// stack, and the return that expected the address it came from found it instead — a jump to
+// nowhere, so the contract reverted rather than answering wrongly.
+//
+// It was true before anything here kept state, and nothing made it likely to be written until
+// something did: nobody writes an arithmetic line for its effect, and `sstore 1 42;` is an
+// ordinary way to write a program.
+func TestAValueNothingTakesIsDropped(t *testing.T) {
+	for _, tc := range []struct{ name, source, args string }{
+		{
+			name:   "an arithmetic line nobody uses",
+			source: `ident f = defer { feed(0) + 1; feed(0) + 2; };`,
+			args:   "5",
+		},
+		{
+			name:   "a write kept for what it does",
+			source: `ident f = defer { sstore 1 feed(0); 7; };`,
+			args:   "42",
+		},
+		{
+			name: "a call whose answer nobody wanted",
+			source: `ident g = defer { feed(0) * 2; };
+ident f = defer { g(feed(0)); 7; };`,
+			args: "42",
+		},
+		{
+			name:   "several of them in a row",
+			source: `ident f = defer { feed(0) + 1; feed(0) + 2; feed(0) + 3; feed(0) + 4; };`,
+			args:   "5",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, tc.source, "f", []string{tc.args}, 0)
+		})
+	}
+}
+
+// What the chain keeps, kept and read back inside one transaction.
+//
+// It is the first thing here that is not a computation: what SSTORE leaves behind outlives the
+// call, and what the evaluator answers comes out of a map. The two agree because they were
+// written to mean the same thing, and this is what says they do.
+func TestWhatTheChainKeepsAnswersTheSameOnChainAndOff(t *testing.T) {
+	const source = `ident keep = defer { sstore 1 feed(0); sload 1; };
+ident over = defer { sstore 1 feed(0); sstore 1 7; sload 1; };
+ident missing = defer { sstore 1 feed(0); sload 2; };
+ident counted = defer { sstore 1 40; sstore 1 ((sload 1) + feed(0)); sload 1; };`
+
+	for _, tc := range []struct{ name, want string }{
+		{name: "keep", want: "42"},
+		{name: "over", want: "7"},
+		// A slot never written is zeros on a chain and the neutral tape off one, and neither
+		// was told to agree with the other.
+		{name: "missing", want: "0"},
+		{name: "counted", want: "42"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			agree(t, source, tc.name, []string{"42"}, 0)
+			if tc.want == "" {
+				t.Skip()
+			}
+		})
+	}
+}
+
+// A write is worth what it wrote, on a chain as much as off one.
+//
+// SSTORE leaves nothing on the stack, so the value is copied before it is spent. Getting that
+// wrong is not a crash: the contract answers whatever was underneath, and a number came back
+// either way.
+func TestAWriteToTheChainIsWorthWhatItWrote(t *testing.T) {
+	const source = `ident kept = defer { sstore 1 feed(0); };
+ident plus = defer { (sstore 1 feed(0)) + 1; };`
+
+	for _, name := range []string{"kept", "plus"} {
+		t.Run(name, func(t *testing.T) {
+			agree(t, source, name, []string{"41"}, 0)
+		})
+	}
+}
+
+// And through the standard library, which is what a program actually writes.
+//
+// The two scopes of std/evm/storage are ordinary scopes, so this is also a call reaching a
+// module reaching the machine — every piece of the language at once.
+func TestTheStandardLibraryKeepsOnChainToo(t *testing.T) {
+	const source = "use std/evm/storage as s;\n" +
+		"ident deposit = defer { s.set(1, s.get(1) + feed(0)); };\n" +
+		"ident balance = defer { s.set(1, 40); deposit(2); s.get(1); };"
+
+	agreeThroughTheStandardLibrary(t, source, "balance", []string{"0"}, 0)
 }
 
 // A run laid out of what a call answered, and a field read out of it. The two features meet


### PR DESCRIPTION
**Fecha a missão 3.** `SSTORE`/`SLOAD` no bytecode, e o harness provando.

```aurora
use std/evm/storage as s;

ident deposit = defer { s.set(1, s.get(1) + feed(0)); };
ident balance = defer { s.get(1); };
```

Isso agora sobrevive à transação **na chain**, e o harness compara com o evaluator. Um slot
nunca escrito responde zeros na chain e o tape neutro fora dela, e nenhum dos dois foi
mandado concordar com o outro.

## Um bug antigo que isto desenterrou

O harness nunca tinha coberto: **um valor que ninguém consome ficava preso na pilha.**

```aurora
ident f = defer { feed(0) + 1; feed(0) + 2; };
```

Isso responde 7 no evaluator e **revertia** na chain — o retorno esperava encontrar o
endereço de volta e encontrava o valor perdido, então pulava para lugar nenhum. Já estava
quebrado e ninguém tinha escrito, porque ninguém escreve uma linha de aritmética pelo efeito
dela.

`sstore 1 42;` numa linha sozinha **é** jeito normal de escrever programa. Foi assim que
apareceu.

O valor é descartado onde foi computado. E teve uma sutileza: **quais instruções deixam valor
é pergunta diferente de quais podem ser seguradas e movidas.** Uma chamada deixa valor e não
pode ser movida — é um salto, e onde ela está é onde ela acontece. Ler as duas como uma só é
o que deixava `deposit(2);` largar coisa na pilha; o `TestTheStandardLibraryKeepsOnChainToo`
foi exatamente quem pegou isso.

Quatro casos novos no harness só para esse bug, incluindo vários em sequência.

## O detalhe do `SSTORE`

Ele não deixa nada na pilha, e aqui uma escrita vale o que escreveu. Então o valor é copiado
antes de ser gasto:

```
value key          os dois operandos, como chegam
value value key    DUP1, a cópia que sobrevive
key value value    SWAP2, que traz a chave para cima
value              SSTORE, tendo levado a chave e um dos dois valores
```

Errar isso não daria crash: o contrato responderia o que estivesse embaixo, e um número
voltaria de qualquer jeito.

## O harness

Guardado e lido de volta, sobrescrito, chave sob a qual nada foi escrito, total acumulado —
e o conjunto todo **através da std**, que é uma chamada alcançando um módulo alcançando o
maquinário. Todas as peças da linguagem numa linha.

## E o `pending` está vazio de novo

Toda instrução que o emitter produz chega ao bytecode.

---

As três missões fechadas: inferência de shapes (#146, #147), teto de 32 bytes (#151),
storage como mapa (#153, #154, este).

🤖 Generated with [Claude Code](https://claude.com/claude-code)