### PR TITLE
The IR can refuse a program that does not say what it means

### DIFF
--- a/builder/evm/builder.go
+++ b/builder/evm/builder.go
@@ -76,6 +76,9 @@ type RuntimeCode struct {
 type Builder struct {
 	tapeSize int
 	blocks   []ir.Block
+	// problems is what was wrong with the IR it was given, kept from when it arrived so the
+	// answer does not depend on what the lowering made of it.
+	problems []ir.Problem
 }
 
 // PickScopes answers the scopes a transaction can reach, and the block that is the top of the
@@ -212,6 +215,10 @@ func (b *Builder) WriteRuntimeBlock(bs io.Writer, rc *RuntimeCode) (int, error) 
 // back, and deciding where bytecode lands — a file, a deployment, a test — belongs to
 // whoever asked for it.
 func (b *Builder) Build() ([]byte, error) {
+	if len(b.problems) > 0 {
+		return nil, fmt.Errorf("this program does not say what it means, and no bytecode was written: %w", b.problems[0])
+	}
+
 	rc, err := b.PickRuntimeCode()
 	if err != nil {
 		return nil, err
@@ -243,6 +250,18 @@ type NewBuilderOptions struct {
 func NewBuilder(blocks []ir.Block, options NewBuilderOptions) *Builder {
 	tapeSize := byteutil.TapeSize(options.TapeSize)
 
+	// Checked as it arrives, before anything here touches it. The whole failure mode of this
+	// backend was a binary that came out, deployed, answered and was quietly wrong, and what
+	// kept that from happening was somebody keeping a list of opcodes in agreement with the
+	// emitter — which is not an assertion.
+	//
+	// It is the IR that is checked and not what the lowering makes of it. What comes out of
+	// the lowering is stack-scheduled and no longer a plain program: a binding that a scope
+	// ends with leaves nothing on the stack, so the lowering writes a push under that same
+	// name to stand in for it. Two values under one name is exactly what Verify refuses, and
+	// it is right to — of the IR. Of a schedule for one machine it is not a question.
+	problems := ir.Verify(blocks)
+
 	// Every block is put in the order the stack needs before any of it is written. It used to
 	// be done a scope at a time, as each was found, which was the same work spread out — and
 	// it had to be, because a scope was a stretch of a list and the list was walked once.
@@ -251,5 +270,5 @@ func NewBuilder(blocks []ir.Block, options NewBuilderOptions) *Builder {
 		lowered[at] = LowerBlock(block, tapeSize)
 	}
 
-	return &Builder{tapeSize: tapeSize, blocks: lowered}
+	return &Builder{tapeSize: tapeSize, blocks: lowered, problems: problems}
 }

--- a/docs/contributing/ir.md
+++ b/docs/contributing/ir.md
@@ -343,6 +343,43 @@ And one warning worth its own line: **anything you derive rather than read is a 
 description of the same program, and two descriptions drift.** Every silent bug this compiler
 has had came from one consumer counting something a different way from another.
 
+## A program can be refused
+
+```go
+ir.Verify(blocks) []ir.Problem   // everything wrong with it, and nothing when it is sound
+```
+
+Five things are asserted, before any consumer touches anything:
+
+- every `Ref` names a value left earlier in the same block, or one of its params;
+- every target names a block that exists;
+- every branch hands over exactly as many values as the target block takes;
+- every way of ending names as many blocks as that way of ending has — one, two, or none;
+- no value is left twice under one name.
+
+A call is not checked for how many values it hands over, and that is the language rather than
+an omission: a scope has no arity. Running one is applying a vector of values to it, and `feed`
+reads a position of that vector, so there is nothing to count.
+
+It answers all of them rather than the first, because a program that is wrong is usually wrong
+in several places and stopping at one turns fixing it into a loop.
+
+**`builder/evm` refuses rather than warns**, and the measurement is why: every program the
+compiler produces verifies clean, so refusing costs nothing today and catches the next mistake
+on the day it is made. It found one the day it was written — an empty block handed on a
+reference to a label nothing carried, and answered zeros anyway, because a consumer that looks
+a name up and finds nothing gets zeros. Working by accident is what a check is for.
+
+**It runs on the IR as it arrives, not on what the lowering makes of it.** That is not
+pedantry. What comes out of a lowering is a schedule for one machine: a binding a scope ends
+with leaves nothing on a stack, so `builder/evm` writes a push under that same name to stand in
+for it. Two values under one name is what the check refuses, and it is right to — of the IR. Of
+a schedule it is not a question.
+
+What is not asserted yet is the sixth: that every operand has the `Kind` its opcode expects.
+That one needs each opcode's operands written down as something a program can read rather than
+as the comment beside it in `wire/ir/opcodes.go`.
+
 ## Why it is not a list
 
 It was, until it was not. That is [why-blocks.md](why-blocks.md).

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -203,6 +203,20 @@ and answers from the evaluator, the same way the chain would.
 
 ---
 
+## What the IR does not assert yet
+
+`ir.Verify` asserts five of the six things the IR was reshaped to make assertable, and
+`builder/evm` refuses a program that fails any of them rather than writing bytes for it.
+
+The sixth is **that every operand has the `Kind` its opcode expects**. What it needs first is
+each opcode's operands written down as something a program can read — they are comments beside
+the opcodes today, which is a description kept in agreement by somebody remembering, and this
+file has a long list of what that costs.
+
+Nothing else about a program is asserted, and two things stay deliberately unasserted: what a
+call hands over, because a scope has no arity; and anything about a stack, a frame or an
+address, because those mean something on one target and nothing on another.
+
 ## Seeing what a phase produced
 
 `-l lexer,parser,emitter` used to print what each phase made, and it is gone. It went in two

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -145,6 +145,16 @@ func emitBlockExpression(tc *int, insts *[]ir.Instruction, n ast.BlockExpression
 		l = EmitInstruction(tc, &body, ins, tapeSize)
 	}
 
+	// An empty block is worth the neutral tape, and that has to be a value like any other.
+	// It used to be a reference to a label nothing carried, which read as a value nobody
+	// left — and it answered zeros anyway, because a consumer that looked the name up found
+	// nothing and nothing is zeros. Working by accident is what a check is for.
+	if l == nil {
+		l = GenerateLabel(tc)
+		body = append(body, ir.NewInstruction(l, ir.OpSave,
+			ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
+	}
+
 	lsc := GenerateLabel(tc)
 	*insts = append(*insts, ir.NewInstruction(lsc, opBeginScope, ir.Nothing(), ir.Nothing()))
 

--- a/hosting/cli/verify_test.go
+++ b/hosting/cli/verify_test.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/guiferpa/aurora/builder/evm"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// Every program this compiler produces says what it means.
+//
+// The check is in wire/ir and knows nothing about how a program got there; this runs it over
+// programs somebody would write, which is the only way to find out whether the emitter has
+// been producing something a consumer had to be forgiving about. Nobody could ask before,
+// because nothing in the IR was an assertion — the failure mode was a binary that deployed and
+// was quietly wrong.
+func TestEveryProgramTheCompilerProducesVerifies(t *testing.T) {
+	for _, tc := range []struct{ name, source string }{
+		{name: "arithmetic", source: `ident f = defer { feed(0) + feed(1) * 2; };`},
+		{name: "a name bound inside a scope", source: `ident f = defer { ident x = feed(0); x + x; };`},
+		{name: "a branch", source: `ident f = defer { if feed(0) bigger 2 { 1; } else { 2; }; };`},
+		{name: "a branch inside a branch", source: `ident f = defer { if feed(0) bigger 2 { if feed(0) bigger 4 { 1; } else { 2; }; } else { 3; }; };`},
+		{name: "a branch statement", source: `ident f = defer { branch { feed(0) equals 0: 1, feed(0) equals 1: 2, 3; }; };`},
+		{name: "a scope calling another", source: "ident g = defer { feed(0) * 2; };\nident f = defer { g(feed(0)) + 1; };"},
+		{name: "a scope nested in a scope", source: `ident f = defer { ident g = defer { 1; }; 2; };`},
+		{name: "a shape and a field", source: "shape P { a, b };\nident f = defer { ident p = P{feed(0), 2}; p.a + p.b; };"},
+		{name: "a wide shape", source: "shape W { a, b, c, d, e };\nident f = defer { ident w = W{1, 2, 3, 4, feed(0)}; w.e; };"},
+		{name: "the tape operations", source: `ident f = defer { ident x = feed(0); ident h = head x 1; ident t = tail x 1; h + t; };`},
+		{name: "storage", source: `ident f = defer { sstore 1 feed(0); sload 1; };`},
+		{name: "a value nothing takes", source: `ident f = defer { feed(0) + 1; feed(0) + 2; };`},
+		{name: "the prints", source: `ident f = defer { printd feed(0); };`},
+		{name: "an inline block", source: `ident f = defer { ident x = { feed(0) + 1; }; x + 1; };`},
+		{name: "text in a tape", source: `ident f = defer { "ab"; };`},
+		{name: "the top of a program", source: "printd 1 + 1;"},
+		// The one the check found the day it was written. An empty block is worth the neutral
+		// tape, and that used to be a reference to a label nothing carried — a value nobody
+		// left. It answered zeros anyway, because a consumer that looked the name up found
+		// nothing and nothing is zeros, which is working by accident.
+		{name: "an empty block", source: "ident empty = { };\nprintd empty;"},
+		{name: "an empty block inside a scope", source: "ident f = defer { ident e = { }; e + feed(0); };"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeAt(t, dir, "contract.ar", tc.source)
+			program, err := newSession(t, sessionOpts{}).compile(path)
+			if err != nil {
+				t.Fatalf("compiling: %v", err)
+			}
+
+			for _, problem := range ir.Verify(program.Blocks) {
+				t.Errorf("%v", problem)
+			}
+		})
+	}
+}
+
+// A program that does not say what it means gets no bytecode.
+//
+// It is checked as it arrives rather than after the lowering, and the difference is not
+// pedantry: what comes out of the lowering is a schedule for one machine, where a binding a
+// scope ends with leaves nothing on the stack and a push is written under that same name to
+// stand in for it. Two values under one name is exactly what the check refuses, and it is
+// right to — of the IR. Of a schedule it is not a question.
+func TestABuildRefusesAnIRThatDoesNotHold(t *testing.T) {
+	blocks := []ir.Block{{
+		ID:    0,
+		Insts: []ir.Instruction{ir.NewInstruction([]byte("01"), ir.OpAdd, ir.RefTo([]byte("ff")), ir.Nothing())},
+		Term:  ir.Ends(ir.RefTo([]byte("01"))),
+	}}
+
+	_, err := evm.NewBuilder(blocks, evm.NewBuilderOptions{TapeSize: 8}).Build()
+	if err == nil {
+		t.Fatal("it wrote bytecode for a program that reads a value nobody leaves")
+	}
+	if !strings.Contains(err.Error(), "does not say what it means") {
+		t.Errorf("it says %q", err)
+	}
+	if !strings.Contains(err.Error(), "block 0") {
+		t.Errorf("it says %q, and never says where", err)
+	}
+}
+
+// And a scope that ends with a binding still builds, which is the case that made the check
+// run where it does.
+func TestAScopeEndingWithABindingStillBuilds(t *testing.T) {
+	dir := t.TempDir()
+	path := writeAt(t, dir, "contract.ar", "ident f = defer { ident x = feed(0); ident y = x + 1; };\n")
+
+	if _, err := newSession(t, sessionOpts{}).Build(t.Context(), path, filepath.Join(dir, "out.bin")); err != nil {
+		t.Fatalf("building: %v", err)
+	}
+}

--- a/wire/ir/verify.go
+++ b/wire/ir/verify.go
@@ -1,0 +1,169 @@
+package ir
+
+import (
+	"fmt"
+
+	"github.com/guiferpa/aurora/byteutil"
+)
+
+// Whether a program says what it means, asked before any consumer touches it.
+//
+// This is what the rest of the IR was for. A consumer used to be handed a list and left to
+// work out what it meant — where a scope began, which operand named a value, how far a branch
+// jumped — and the failure was always the same shape: the binary came out, deployed, answered,
+// and was quietly wrong. What kept that from happening was a list of opcodes in the backend,
+// kept in agreement with the emitter by somebody remembering.
+//
+// A check is not a list. It is the difference between a compiler that refuses and one that
+// hands over bytes nobody asked for.
+
+// A Problem is one thing wrong with a program, and where it is.
+//
+// Where matters more than it looks. A block and a position are what an origin is worked out
+// from, and a problem nobody can find is a problem nobody fixes.
+type Problem struct {
+	Block BlockID
+	// At is which instruction, or WhereItEnds when the terminator is what is wrong.
+	At   int
+	Says string
+}
+
+// WhereItEnds is the position of the thing that ends a block, which is not one of its
+// instructions and so has no index among them.
+const WhereItEnds = -1
+
+func (p Problem) Error() string {
+	if p.At == WhereItEnds {
+		return fmt.Sprintf("block %d, where it ends: %s", p.Block, p.Says)
+	}
+	return fmt.Sprintf("block %d, instruction %d: %s", p.Block, p.At, p.Says)
+}
+
+// Verify answers everything wrong with a program, and nothing when it is sound.
+//
+// It answers all of them rather than the first, because a program that is wrong is usually
+// wrong in several places and stopping at one turns fixing it into a loop. A consumer that
+// wants one takes the first.
+func Verify(blocks []Block) []Problem {
+	found := make([]Problem, 0)
+	for _, block := range blocks {
+		found = append(found, verifyBlock(blocks, block)...)
+	}
+	return found
+}
+
+// verifyBlock asks of one block everything that can be asked of it alone.
+func verifyBlock(blocks []Block, block Block) []Problem {
+	found := make([]Problem, 0)
+
+	// A value is defined where the instruction that leaves it is written, and a label is
+	// unique in its block — so a label written twice is two values under one name, and every
+	// reader after it means whichever the reader happened to reach.
+	defined := make(map[string]bool, len(block.Params)+len(block.Insts))
+	for _, param := range block.Params {
+		defined[byteutil.ToHex(param)] = true
+	}
+
+	for at, inst := range block.Insts {
+		// Read before written: a Ref names a value that already exists, which is what makes
+		// the order of a block mean something.
+		for _, operand := range inst.GetOperands() {
+			if operand.Kind() != KindRef {
+				continue
+			}
+			if !defined[byteutil.ToHex(operand.Bytes())] {
+				found = append(found, Problem{Block: block.ID, At: at,
+					Says: fmt.Sprintf("it reads %s, and nothing before it leaves a value under that name", byteutil.ToHex(operand.Bytes()))})
+			}
+		}
+
+		label := byteutil.ToHex(inst.GetLabel())
+		if defined[label] {
+			found = append(found, Problem{Block: block.ID, At: at,
+				Says: fmt.Sprintf("it leaves a value under %s, and so does something before it", label)})
+		}
+		defined[label] = true
+	}
+
+	return append(found, verifyTerminator(blocks, block, defined)...)
+}
+
+// verifyTerminator asks of the way a block ends the three things that can be wrong with it.
+func verifyTerminator(blocks []Block, block Block, defined map[string]bool) []Problem {
+	found := make([]Problem, 0)
+	at := Problem{Block: block.ID, At: WhereItEnds}
+
+	if wanted, given := targetsWanted(block.Term.Kind), len(block.Term.Targets); wanted != given {
+		at.Says = fmt.Sprintf("it %s and names %d blocks, and that way of ending names %d",
+			describeKind(block.Term.Kind), given, wanted)
+		found = append(found, at)
+	}
+
+	for _, operand := range []Operand{block.Term.Cond, block.Term.Value} {
+		if operand.Kind() != KindRef || defined[byteutil.ToHex(operand.Bytes())] {
+			continue
+		}
+		found = append(found, Problem{Block: block.ID, At: WhereItEnds,
+			Says: fmt.Sprintf("it reads %s, and nothing in the block leaves a value under that name", byteutil.ToHex(operand.Bytes()))})
+	}
+
+	for _, target := range block.Term.Targets {
+		found = append(found, verifyTarget(blocks, block, target, defined)...)
+	}
+	return found
+}
+
+// verifyTarget asks of one place control goes whether it exists and whether it is handed what
+// it takes.
+//
+// A branch is checked for how many values it hands over and a call is not, and that is the
+// language rather than an omission: a scope has no arity — running one is applying a vector of
+// values to it, and feed reads a position of that vector — so there is nothing to count.
+func verifyTarget(blocks []Block, block Block, target Target, defined map[string]bool) []Problem {
+	at := Problem{Block: block.ID, At: WhereItEnds}
+
+	if target.Block < 0 || int(target.Block) >= len(blocks) {
+		at.Says = fmt.Sprintf("it goes to block %d, and the program has %d", target.Block, len(blocks))
+		return []Problem{at}
+	}
+
+	found := make([]Problem, 0)
+	if wanted := len(blocks[target.Block].Params); len(target.Args) != wanted {
+		at.Says = fmt.Sprintf("it hands %d values to block %d, which takes %d",
+			len(target.Args), target.Block, wanted)
+		found = append(found, at)
+	}
+	for _, arg := range target.Args {
+		if arg.Kind() != KindRef || defined[byteutil.ToHex(arg.Bytes())] {
+			continue
+		}
+		found = append(found, Problem{Block: block.ID, At: WhereItEnds,
+			Says: fmt.Sprintf("it hands over %s, and nothing in the block leaves a value under that name", byteutil.ToHex(arg.Bytes()))})
+	}
+	return found
+}
+
+// targetsWanted says how many blocks each way of ending names. There are three, and there is
+// no fourth.
+func targetsWanted(kind TermKind) int {
+	switch kind {
+	case Br:
+		return 1
+	case BrIf:
+		return 2
+	default:
+		return 0
+	}
+}
+
+// describeKind says how a block ends, in the words the language uses rather than a number.
+func describeKind(kind TermKind) string {
+	switch kind {
+	case Br:
+		return "goes somewhere"
+	case BrIf:
+		return "chooses between two somewheres"
+	default:
+		return "returns"
+	}
+}

--- a/wire/ir/verify_test.go
+++ b/wire/ir/verify_test.go
@@ -1,0 +1,135 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+)
+
+// Each of the things a program can be wrong about, and what it says about each.
+//
+// The point of the check is what it refuses, so this is the half that matters: a check that
+// passes everything passes a broken program too, and nobody finds out until a contract answers
+// something nobody asked for.
+func TestWhatVerifyRefuses(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		blocks []Block
+		says   string
+	}{
+		{
+			name: "a value read before anything leaves it",
+			blocks: []Block{{
+				ID:    0,
+				Insts: []Instruction{NewInstruction([]byte("01"), OpAdd, RefTo([]byte("ff")), Imm(1, 8))},
+				Term:  Ends(RefTo([]byte("01"))),
+			}},
+			says: "nothing before it leaves a value under that name",
+		},
+		{
+			name: "a value read by the terminator that nothing leaves",
+			blocks: []Block{{
+				ID:   0,
+				Term: Ends(RefTo([]byte("ff"))),
+			}},
+			says: "nothing in the block leaves a value under that name",
+		},
+		{
+			name: "two values under one name",
+			blocks: []Block{{
+				ID: 0,
+				Insts: []Instruction{
+					NewInstruction([]byte("01"), OpSave, Imm(1, 8), Nothing()),
+					NewInstruction([]byte("01"), OpSave, Imm(2, 8), Nothing()),
+				},
+				Term: Ends(RefTo([]byte("01"))),
+			}},
+			says: "and so does something before it",
+		},
+		{
+			name:   "a block that goes where there is no block",
+			blocks: []Block{{ID: 0, Term: Goes(7)}},
+			says:   "it goes to block 7, and the program has 1",
+		},
+		{
+			name: "a branch that hands over the wrong number of values",
+			blocks: []Block{
+				{ID: 0, Term: Goes(1)},
+				{ID: 1, Params: []Label{[]byte("aa")}, Term: Ends(RefTo([]byte("aa")))},
+			},
+			says: "it hands 0 values to block 1, which takes 1",
+		},
+		{
+			name: "a way of ending that names the wrong number of blocks",
+			blocks: []Block{
+				{ID: 0, Term: Terminator{Kind: BrIf, Cond: Imm(1, 8), Targets: []Target{{Block: 1}}}},
+				{ID: 1, Term: Ends(Imm(1, 8))},
+			},
+			says: "chooses between two somewheres and names 1 blocks, and that way of ending names 2",
+		},
+		{
+			name: "a value handed over that nothing leaves",
+			blocks: []Block{
+				{ID: 0, Term: Goes(1, RefTo([]byte("ff")))},
+				{ID: 1, Params: []Label{[]byte("aa")}, Term: Ends(RefTo([]byte("aa")))},
+			},
+			// The label is named as every other reader of the IR names one, which is the hex of
+			// its bytes: "ff" written here is 6666 there, and a message that spelled it
+			// differently would be a name nobody could search for.
+			says: "it hands over 6666, and nothing in the block leaves a value under that name",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := Verify(tc.blocks)
+			if len(problems) == 0 {
+				t.Fatal("it verified a program that is wrong")
+			}
+			if !strings.Contains(problems[0].Error(), tc.says) {
+				t.Errorf("it says %q, want it to say %q", problems[0], tc.says)
+			}
+			// Where, or nobody finds it.
+			if !strings.HasPrefix(problems[0].Error(), "block ") {
+				t.Errorf("it says %q, and never says where", problems[0])
+			}
+		})
+	}
+}
+
+// A sound program has nothing said about it, which is the other half.
+func TestVerifySaysNothingAboutASoundProgram(t *testing.T) {
+	blocks := []Block{
+		{
+			ID: 0,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, Imm(1, 8), Nothing()),
+				NewInstruction([]byte("02"), OpAdd, RefTo([]byte("01")), Imm(2, 8)),
+			},
+			Term: Terminator{Kind: BrIf, Cond: RefTo([]byte("02")),
+				Targets: []Target{{Block: 1, Args: []Operand{RefTo([]byte("02"))}}, {Block: 2, Args: []Operand{RefTo([]byte("01"))}}}},
+		},
+		{ID: 1, Params: []Label{[]byte("aa")}, Term: Ends(RefTo([]byte("aa")))},
+		{ID: 2, Params: []Label{[]byte("bb")}, Term: Ends(RefTo([]byte("bb")))},
+	}
+
+	if problems := Verify(blocks); len(problems) != 0 {
+		t.Errorf("it refused a sound program: %v", problems)
+	}
+}
+
+// Everything wrong at once, and not the first of them.
+//
+// A program that is wrong is usually wrong in several places, and a check that stops at one
+// turns fixing it into a loop of compile, read, fix, compile.
+func TestVerifyAnswersEverythingWrongAtOnce(t *testing.T) {
+	blocks := []Block{{
+		ID: 0,
+		Insts: []Instruction{
+			NewInstruction([]byte("01"), OpAdd, RefTo([]byte("ff")), Nothing()),
+			NewInstruction([]byte("01"), OpAdd, RefTo([]byte("ee")), Nothing()),
+		},
+		Term: Goes(9),
+	}}
+
+	if problems := Verify(blocks); len(problems) != 4 {
+		t.Errorf("it found %d things wrong, want the four that are: %v", len(problems), problems)
+	}
+}


### PR DESCRIPTION
Isto é o **custo 5 da `rfcs/ir.md`** — "não poder recusar nada" — que era a última coisa em
aberto da demanda original, e a que eu tinha apontado como a maior que faltava.

```go
ir.Verify(blocks) []ir.Problem
```

Cinco afirmações, antes de qualquer consumidor tocar em nada: toda `Ref` nomeia um valor
deixado antes dela no mesmo bloco (ou um parâmetro dele); todo alvo nomeia bloco que existe;
todo desvio entrega tantos valores quantos o destino declara; toda forma de terminar nomeia
tantos blocos quantos ela tem; nenhum valor é deixado duas vezes sob um nome.

Uma **chamada** não é conferida por quantidade de valores, e isso é a linguagem e não
omissão: um escopo não tem aridade.

## Medi antes de recusar, e a medição achou coisa

Todo programa que o compilador produz passa limpo — 18 formas, de aritmética a storage. Então
recusar não custa nada hoje e pega o próximo erro no dia em que ele for cometido. O
`builder/evm` **recusa** em vez de avisar.

E achou um no dia em que foi escrito:

```aurora
ident empty = { };
```

Um bloco vazio entregava uma referência a um label que ninguém carregava — um valor que
ninguém deixou. **E respondia zeros mesmo assim**, porque um consumidor que procura o nome e
não acha, acha nada, e nada é zeros. Funcionar por acidente é exatamente o que um verificador
existe para pegar. Agora um bloco vazio deixa o tape neutro de verdade.

## Um erro meu que a medição também pegou

Eu tinha posto o `Verify` **depois** da lowering. Ele reclamou de todo escopo que termina com
um `ident`, e estava certo: a lowering escreve um push sob o mesmo nome do binding, porque um
binding não deixa nada na pilha.

Mas o que sai da lowering **não é mais um programa** — é um escalonamento para uma máquina.
Dois valores sob um nome é o que o check recusa, e ele tem razão **do IR**; de um
escalonamento não é pergunta. Movi para onde a RFC dizia desde o começo: sobre o IR como ele
chega.

## O que fica aberto, nomeado

A sexta afirmação — que todo operando tem o `Kind` que o opcode espera. Ela precisa dos
operandos de cada opcode escritos como coisa que um programa lê, e não como o comentário ao
lado deles em `wire/ir/opcodes.go`. Está no roadmap, com o motivo.

---

Com isto, dos seis custos que a `rfcs/ir.md` nomeou, **cinco estão fechados**. Sobra o 3
(resolução de nome refeita pelo builder), que é o `Scope.Names` — o `IdentManager` já saiu,
mas nome→lugar ainda é trabalho que cada consumidor refaz.

🤖 Generated with [Claude Code](https://claude.com/claude-code)