### PR TITLE
A write reaches the chain, and a question says so

### DIFF
--- a/cmd/aurora/blocks.go
+++ b/cmd/aurora/blocks.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"github.com/guiferpa/aurora/emitter"
+	"github.com/guiferpa/aurora/hosting/cli"
+	"github.com/guiferpa/aurora/lexer"
+	"github.com/guiferpa/aurora/parser"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// blocksOfProfile compiles what a profile points at, for the two commands that need to know
+// what a scope does before they speak to a chain.
+//
+// It answers nothing rather than an error when the source cannot be compiled, and that is on
+// purpose: a contract was deployed from a source that may since have changed, or been moved,
+// or belong to somebody else's checkout. Not knowing is a reason to say less, never a reason
+// to stop somebody reaching a contract that is already out there.
+func blocksOfProfile(profile string) []ir.Block {
+	env, err := cli.LoadEnviron(profile)
+	if err != nil {
+		return nil
+	}
+	target, err := cli.ResolveTarget(profile)
+	if err != nil {
+		return nil
+	}
+	size := cli.ResolveTapeSize(0, target.TapeSize)
+
+	blocks, err := cli.NewSession(cli.NewSessionOptions{
+		Lexer:    lexer.New(),
+		Parser:   parser.New(),
+		Emitter:  emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
+		Resolver: newResolver(size, target.SourceRoot),
+		TapeSize: size,
+	}).Blocks(env.AbsPath(env.Profile.Source))
+	if err != nil {
+		return nil
+	}
+	return blocks
+}

--- a/cmd/aurora/call.go
+++ b/cmd/aurora/call.go
@@ -53,5 +53,6 @@ func runCall(cmd *cobra.Command, args []string) error {
 		RPC:             env.Profile.RPC,
 		Args:            args[1:],
 		Pretend:         pretend,
+		Blocks:          blocksOfProfile(profile),
 	})
 }

--- a/cmd/aurora/main.go
+++ b/cmd/aurora/main.go
@@ -25,7 +25,7 @@ var rootCmd = &cobra.Command{
 // decided here, where the process is, and nowhere else. Diagnostics go to stderr, so a
 // pipeline reading a program's output does not swallow them.
 func main() {
-	rootCmd.AddCommand(versionCmd, runCmd, testCmd, replCmd, buildCmd, deployCmd, callCmd, initCmd)
+	rootCmd.AddCommand(versionCmd, runCmd, testCmd, replCmd, buildCmd, deployCmd, callCmd, txCmd, initCmd)
 
 	if err := rootCmd.Execute(); err != nil {
 		_, _ = fmt.Fprint(os.Stderr, logger.CommandError(err))

--- a/cmd/aurora/tx.go
+++ b/cmd/aurora/tx.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/guiferpa/aurora/hosting/cli"
+)
+
+var txCmd = &cobra.Command{
+	Use:   "tx <function> [args...]",
+	Short: "Send a transaction to a scope of a deployed contract",
+	Long: `Send a transaction to a scope of a deployed contract.
+
+A call is a question and a transaction is a change. "aurora call" asks a
+contract something against the state as it is, costs nothing, and keeps nothing
+it did on the way; "aurora tx" sends it, pays for it, and what it changed stays.
+
+A scope that keeps something has to be sent. Asking it as a question answers,
+and leaves the chain exactly as it was.`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runTx,
+}
+
+func init() {
+	txCmd.Flags().Bool("pretend", false, "show what would be sent, and send nothing")
+	txCmd.Flags().StringP("profile", "p", "main", "profile to send through")
+}
+
+func runTx(cmd *cobra.Command, args []string) error {
+	fn := args[0]
+	profile, err := cmd.Flags().GetString("profile")
+	if err != nil {
+		return err
+	}
+	env, err := cli.LoadEnviron(profile)
+	if err != nil {
+		return err
+	}
+	if env.Profile.RPC == "" {
+		return fmt.Errorf("profile %s: rpc is required to send a transaction", profile)
+	}
+	if env.Profile.Privkey == "" {
+		return fmt.Errorf("profile %s: privkey is required to send a transaction", profile)
+	}
+	deployed, ok := env.Manifest.Deploys[profile]
+	if !ok {
+		return fmt.Errorf("profile %s: no deploy found (run 'aurora deploy' first)", profile)
+	}
+	pretend, err := cmd.Flags().GetBool("pretend")
+	if err != nil {
+		return err
+	}
+
+	return cli.Tx(cmd.Context(), cli.TxInput{
+		Function:        fn,
+		ContractAddress: deployed.ContractAddress,
+		RPC:             env.Profile.RPC,
+		Privkey:         env.Profile.Privkey,
+		Args:            args[1:],
+		Pretend:         pretend,
+		Blocks:          blocksOfProfile(profile),
+	})
+}

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -193,6 +193,35 @@ written down:
 program uses it, and names the line the program first used it on — so a binary that does less
 than the source said is announced, in the form an editor follows.
 
+## Asking and changing
+
+A call is a question and a transaction is a change, and they are two commands because they are
+two things:
+
+```
+aurora call read      answered against the state as it is, costing nothing, keeping nothing
+aurora tx inc         sent, paid for, mined, and what it changed stays
+```
+
+Nothing decides between them from what a program looks like. What the compiler knows is used to
+refuse the wrong one: a scope that keeps something, asked as a question, is a write thrown away
+— it answers, looking right, and the chain is exactly as it was. That happened on a real chain
+before this existed, and a counter answered 1 every time.
+
+Which scopes keep something is read from the effect of the instructions they reach, following
+the scopes they call — because with a standard library the scope somebody writes holds no
+`sstore` at all: `s.set(...)` is a call, and the write is one file away.
+
+What is missing:
+
+- **A transaction has one gas limit for every scope.** It is 500,000, which is enough for
+  anything a program can write today and nothing decides it per call. What would replace it is
+  asking the network to estimate, which is a round trip somebody has to want.
+- **Nothing reads what a transaction answered.** A scope returns a value, and a mined
+  transaction keeps it nowhere a caller can see — only logs and storage cross that line, and
+  logs do not reach a chain by decision. So `aurora tx` says what it spent and where it landed,
+  and what the scope returned is read with a `call` afterwards.
+
 ## Simulating a call off the chain
 
 `aurora call` speaks to a network and nothing else, so there is no way to ask for one scope by

--- a/examples/project/src/main.ar
+++ b/examples/project/src/main.ar
@@ -16,8 +16,10 @@
 #-
 #- Output:
 #-   600
+#-   2
 
 use geometry as g;
+use std/evm/storage as s;
 
 #- Everything the program does is inside a scope, and the last line applies it. That shape is
 #- what makes the file the same program either way it is reached:
@@ -32,8 +34,35 @@ use geometry as g;
 #- What it multiplies is bound inside main, and it has to be: a name lives in the frame of the
 #- scope that bound it, so a scope reaches what it bound itself and nothing from around it.
 ident main = defer {
-  ident s = g.new_square(30, 20);
-  g.area(s.width, s.height);
+  ident sq = g.new_square(30, 20);
+  g.area(sq.width, sq.height);
+};
+
+#- And a scope that keeps something, which is what a chain is for.
+#-
+#- The two words mean what they mean everywhere else a chain is spoken to:
+#-
+#-   aurora call read    a question, answered against the state as it is, costing nothing
+#-   aurora tx inc       a change, sent, paid for, and kept
+#-
+#- Asking inc as a question would answer 1 every time. It would read what is kept, add one,
+#- and be thrown away with the rest of the simulation — so the chain stays exactly as it was
+#- and the next question starts from the same place. The compiler knows inc keeps something,
+#- so "aurora call inc" is refused rather than answered.
+#-
+#- Off a chain there is no such split: the lines below run in order and the storage lives for
+#- this one run. That is what a single transaction sees, which is what simulating a call off a
+#- chain is for — a second "aurora run" starts from nothing, and a chain does not.
+ident inc = defer {
+  s.set("x", s.get("x") + 1);
+};
+
+ident read = defer {
+  s.get("x");
 };
 
 printd main();
+
+inc();
+inc();
+printd read();

--- a/hosting/cli/call.go
+++ b/hosting/cli/call.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // CallInput is the input for the Call handler.
@@ -18,14 +19,30 @@ type CallInput struct {
 	RPC             string
 	Args            []string // optional arguments (decimal or 0x-prefixed hex), ABI-encoded as uint256 each
 	Pretend         bool
+	// Blocks is the program the contract was built from, when whoever asked could compile it.
+	// It is what says whether this scope changes anything, and a call over one that does is
+	// refused rather than answered — the answer would look right and the chain would be
+	// exactly as it was.
+	//
+	// Empty is a call with no program in hand, which asks the question and says nothing.
+	Blocks []ir.Block
 }
 
 func EncodeSelector(selector string) []byte {
 	return byteutil.Padding32Bytes(crypto.Keccak256([]byte(selector)))
 }
 
-// Call performs an eth_call and prints the result.
+// Call asks a question of a deployed contract, against the state as it is, and prints the
+// answer. Nothing it does is kept.
+//
+// A scope that changes something is refused rather than asked. It happened on a real chain
+// before this was here: a scope that read a counter, added one and kept it answered 1 every
+// time, because every call started from the state the last one did not change.
 func Call(ctx context.Context, in CallInput) error {
+	if writes, found := ScopeWrites(WritesInput{Blocks: in.Blocks, Function: in.Function}); found && writes {
+		return refuseACallThatWrites(in.Function)
+	}
+
 	selector := EncodeSelector(in.Function)
 	args := ParseArgs(in.Args)
 	contract := common.HexToAddress(in.ContractAddress)

--- a/hosting/cli/deploy.go
+++ b/hosting/cli/deploy.go
@@ -108,47 +108,10 @@ func Deploy(ctx context.Context, in DeployInput) (address string, deployTxHash s
 		return "", "", time.Time{}, err
 	}
 
-	// EIP-1559 (DynamicFeeTx) for Sepolia and other modern chains.
-	// Use minimum fees so the tx is included (allow override via DeployInput for bad RPCs).
-	gwei := big.NewInt(1e9)
-	minTipGwei := MIN_GAS_TIP_CAP_GWEI
-	if in.MinTipGwei > 0 {
-		minTipGwei = in.MinTipGwei
-	}
-	minFeeGwei := MIN_GAS_FEE_CAP_GWEI
-	if in.MinMaxFeeGwei > 0 {
-		minFeeGwei = in.MinMaxFeeGwei
-	}
-	minTipCap := new(big.Int).Mul(big.NewInt(int64(minTipGwei)), gwei)
-	minFeeCap := new(big.Int).Mul(big.NewInt(int64(minFeeGwei)), gwei)
-
-	gasTipCap, err := client.SuggestGasTipCap(ctx)
+	gasTipCap, gasFeeCap, err := suggestFees(ctx, client, in.MinTipGwei, in.MinMaxFeeGwei)
 	if err != nil {
-		return "", "", time.Time{}, fmt.Errorf("suggest gas tip: %w", err)
+		return "", "", time.Time{}, err
 	}
-	if gasTipCap == nil || gasTipCap.Cmp(minTipCap) < 0 {
-		gasTipCap = minTipCap
-	}
-
-	head, err := client.HeaderByNumber(ctx, nil)
-	if err != nil {
-		return "", "", time.Time{}, fmt.Errorf("latest block: %w", err)
-	}
-	baseFee := head.BaseFee
-	if baseFee == nil {
-		baseFee = big.NewInt(0)
-	}
-	// maxFeePerGas = baseFee*2 + tip, but at least minFeeCap so tx is included on testnets
-	gasFeeCap := new(big.Int).Mul(baseFee, big.NewInt(2))
-	gasFeeCap.Add(gasFeeCap, gasTipCap)
-	if gasFeeCap.Cmp(minFeeCap) < 0 {
-		gasFeeCap = minFeeCap
-	}
-
-	// Log gas fees so user can verify on explorer (helps debug "pending forever").
-	tipGwei := new(big.Int).Div(gasTipCap, gwei)
-	feeCapGwei := new(big.Int).Div(gasFeeCap, gwei)
-	fmt.Printf("Gas: tip=%s Gwei, maxFee=%s Gwei (min %d/%d Gwei for inclusion)\n", tipGwei.String(), feeCapGwei.String(), minTipGwei, minFeeGwei)
 
 	tx := types.NewTx(&types.DynamicFeeTx{
 		ChainID:   chainID,
@@ -210,4 +173,51 @@ func Deploy(ctx context.Context, in DeployInput) (address string, deployTxHash s
 		"deploy tx not mined within %v (tx may still be pending). Check tx %s on explorer; contract will be at %s once confirmed",
 		RECEIPT_POLL_TIMEOUT, txHash.Hex(), expectedContract.Hex(),
 	)
+}
+
+// suggestFees answers what one transaction should offer: what the network suggests, with the
+// floors under it that a testnet needs before it will include one at all.
+//
+// It is here rather than beside either caller because a deploy and a call to a scope are the
+// same transaction with a different destination, and two descriptions of what a transaction
+// costs is one of them going stale.
+func suggestFees(ctx context.Context, client *ethclient.Client, minTip, minFee int) (*big.Int, *big.Int, error) {
+	gwei := big.NewInt(1e9)
+	if minTip <= 0 {
+		minTip = MIN_GAS_TIP_CAP_GWEI
+	}
+	if minFee <= 0 {
+		minFee = MIN_GAS_FEE_CAP_GWEI
+	}
+	minTipCap := new(big.Int).Mul(big.NewInt(int64(minTip)), gwei)
+	minFeeCap := new(big.Int).Mul(big.NewInt(int64(minFee)), gwei)
+
+	tip, err := client.SuggestGasTipCap(ctx)
+	if err != nil {
+		return nil, nil, fmt.Errorf("suggest gas tip: %w", err)
+	}
+	if tip == nil || tip.Cmp(minTipCap) < 0 {
+		tip = minTipCap
+	}
+
+	head, err := client.HeaderByNumber(ctx, nil)
+	if err != nil {
+		return nil, nil, fmt.Errorf("latest block: %w", err)
+	}
+	baseFee := head.BaseFee
+	if baseFee == nil {
+		baseFee = big.NewInt(0)
+	}
+	// maxFeePerGas = baseFee*2 + tip, and never under the floor a testnet wants.
+	fee := new(big.Int).Mul(baseFee, big.NewInt(2))
+	fee.Add(fee, tip)
+	if fee.Cmp(minFeeCap) < 0 {
+		fee = minFeeCap
+	}
+
+	// Said out loud so somebody can check it on an explorer, which is what "pending forever"
+	// sends them to do.
+	fmt.Printf("Gas: tip=%s Gwei, maxFee=%s Gwei (min %d/%d Gwei for inclusion)\n",
+		new(big.Int).Div(tip, gwei), new(big.Int).Div(fee, gwei), minTip, minFee)
+	return tip, fee, nil
 }

--- a/hosting/cli/session.go
+++ b/hosting/cli/session.go
@@ -10,6 +10,7 @@ import (
 	"github.com/guiferpa/aurora/loader"
 	"github.com/guiferpa/aurora/parser"
 	"github.com/guiferpa/aurora/resolver"
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // A Session is one use of the command line: the phases it was handed, how wide a value is,
@@ -64,6 +65,20 @@ func (s *Session) evaluator() (*evaluator.Evaluator, error) {
 //
 // It is what every command that runs Aurora goes through. A file that imports nothing comes
 // out of it as a program of one module, which is the shape everything already had.
+// Blocks answers the program a source compiles to, for whoever needs to know what it does
+// rather than to run it.
+//
+// It exists for the two commands that speak to a chain: what a scope does decides whether
+// reaching it is a question or a change, and that is the compiler's to answer rather than
+// somebody's to remember.
+func (s *Session) Blocks(source string) ([]ir.Block, error) {
+	program, err := s.compile(source)
+	if err != nil {
+		return nil, err
+	}
+	return program.Blocks, nil
+}
+
 func (s *Session) compile(source string) (loader.Program, error) {
 	if s.resolver == nil {
 		return loader.Program{}, errors.New("no resolver was given to this session")

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"io"
 	"os"
+	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/guiferpa/aurora/emitter"
@@ -30,8 +32,9 @@ type sessionOpts struct {
 	// asserts turns assertions on and sends what a program prints nowhere, which is what
 	// "aurora test" does: a test says what held, not what was printed on the way.
 	asserts bool
-	// stdRoot is where the modules that come with the language are read from. Empty is a
-	// toolchain with none installed, which is what most of these tests are.
+	// stdRoot is where the modules that come with the language are read from. Empty means the
+	// repository's own lib, which is what `make install-std` copies — so a test reads the
+	// standard library where it is written rather than a copy somebody installed months ago.
 	stdRoot string
 }
 
@@ -81,11 +84,16 @@ func newSession(t *testing.T, o sessionOpts) *Session {
 	}
 	size := o.tapeSize
 
+	stdRoot := o.stdRoot
+	if stdRoot == "" {
+		stdRoot = repositoryLib(t)
+	}
+
 	return NewSession(NewSessionOptions{
 		Lexer:    lexer.New(),
 		Parser:   parser.New(),
 		Emitter:  emitter.New(emitter.NewEmitterOptions{TapeSize: size}),
-		Resolver: newTestResolver(size, o.stdRoot),
+		Resolver: newTestResolver(size, stdRoot),
 		NewEvaluator: func() *evaluator.Evaluator {
 			return evaluator.New(evaluator.NewEvaluatorOptions{
 				PrintBytes:   printer.Bytes(printed, size),
@@ -114,4 +122,19 @@ func tested(t *testing.T, target string, o sessionOpts) (TestReport, error) {
 	o.asserts = true
 
 	return newSession(t, o).Test(t.Context(), files)
+}
+
+// repositoryLib answers this repository's own lib, which is where the standard library is
+// written and what `make install-std` copies somewhere else.
+//
+// It is worked out from where this file is rather than from the working directory, because a
+// test that builds a project changes the working directory — and a relative path then answers
+// a lib inside somebody's temporary directory, which is a standard library of no files.
+func repositoryLib(t *testing.T) string {
+	t.Helper()
+	_, here, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("finding the standard library: this file does not know where it is")
+	}
+	return filepath.Join(filepath.Dir(here), "..", "..", "lib")
 }

--- a/hosting/cli/std_test.go
+++ b/hosting/cli/std_test.go
@@ -91,14 +91,9 @@ func runWithStd(t *testing.T, entry, stdRoot string) (string, error) {
 	return stdout.String(), err
 }
 
-// stdRootOf answers the repository's own lib, so the test reads the same files `make
-// install-std` copies. Reading them where they are written is what keeps this from passing
-// against a stale copy somebody installed months ago.
+// stdRootOf answers the repository's own lib, which is where a session reads it from by
+// default. It is spelled out here because these tests are about that path being the one used.
 func stdRootOf(t *testing.T) string {
 	t.Helper()
-	root, err := filepath.Abs(filepath.Join("..", "..", "lib"))
-	if err != nil {
-		t.Fatalf("finding the standard library: %v", err)
-	}
-	return root
+	return repositoryLib(t)
 }

--- a/hosting/cli/tx.go
+++ b/hosting/cli/tx.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/guiferpa/aurora/byteutil"
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// Sending a transaction to a scope of a deployed contract.
+//
+// It is a command of its own rather than a flag on call, and the two words mean what they mean
+// everywhere else a chain is spoken to: a call is a question, answered against the state as it
+// is and costing nothing; a transaction is a change, mined, paid for, and kept.
+//
+// Nothing decides between them from what a program looks like. What the compiler knows is used
+// to refuse the wrong one — a scope that writes, called, is a write thrown away — and never to
+// spend somebody's money because a name looked like it wanted it.
+
+// TxGasLimit is what one call to a scope is allowed to burn. It is well under the deploy's,
+// because a scope is a jump inside a contract and not a contract being written.
+const TxGasLimit = 500_000
+
+// TxInput is what sending a transaction to a scope takes.
+type TxInput struct {
+	Function        string
+	ContractAddress string
+	RPC             string
+	Privkey         string
+	Args            []string
+	Pretend         bool
+	MinTipGwei      int
+	MinMaxFeeGwei   int
+	// Blocks is the program the contract was built from, when whoever asked could compile it.
+	// A scope that changes nothing is still sent — there are reasons to want a receipt — and
+	// is worth a word, because gas was spent on an answer a call gives free.
+	Blocks []ir.Block
+}
+
+// Tx sends a transaction to one scope of a deployed contract, and waits for it to be mined.
+//
+// It waits rather than answering the hash and leaving, because what a transaction did is not
+// known until it is mined: a reverted one is a transaction too, and somebody who was told
+// "sent" and nothing else has to go and find out.
+func Tx(ctx context.Context, in TxInput) error {
+	if writes, found := ScopeWrites(WritesInput{Blocks: in.Blocks, Function: in.Function}); found && !writes {
+		fmt.Println(warnATxThatWritesNothing(in.Function))
+	}
+
+	data := append(EncodeSelector(in.Function), ParseArgs(in.Args)...)
+	contract := common.HexToAddress(in.ContractAddress)
+
+	if in.Pretend {
+		fmt.Printf("Contract:   0x%x (%d bytes)\n", contract, len(contract.Bytes()))
+		fmt.Printf("Function:   %s\n", in.Function)
+		fmt.Printf("Data:       %s\n", byteutil.ToHexPretty(data))
+		fmt.Println("Nothing was sent: this is what the transaction would carry.")
+		return nil
+	}
+
+	privateKey, err := readPrivkey(in.Privkey)
+	if err != nil {
+		return err
+	}
+	client, err := ethclient.Dial(in.RPC)
+	if err != nil {
+		return err
+	}
+
+	signed, err := signedCall(ctx, client, privateKey, contract, data, in.MinTipGwei, in.MinMaxFeeGwei)
+	if err != nil {
+		return err
+	}
+	if err := client.SendTransaction(ctx, signed); err != nil {
+		return err
+	}
+
+	fmt.Println("Calling:", in.Function)
+	fmt.Println("Sent by:", crypto.PubkeyToAddress(privateKey.PublicKey).Hex())
+	fmt.Println("TX:", signed.Hash().Hex())
+
+	receipt, err := waitForReceipt(ctx, client, signed.Hash())
+	if err != nil {
+		return err
+	}
+	if receipt.Status != types.ReceiptStatusSuccessful {
+		return fmt.Errorf("the transaction reverted: %s kept nothing, and the gas was spent — check %s on an explorer",
+			in.Function, signed.Hash().Hex())
+	}
+
+	fmt.Println("Gas used:", receipt.GasUsed)
+	fmt.Println("Mined in block:", receipt.BlockNumber)
+	return nil
+}
+
+// signedCall builds and signs a transaction to an address, with the fees the network asks for
+// and the floors a testnet needs to include one at all.
+func signedCall(ctx context.Context, client *ethclient.Client, key *ecdsa.PrivateKey, to common.Address, data []byte, minTip, minFee int) (*types.Transaction, error) {
+	from := crypto.PubkeyToAddress(key.PublicKey)
+
+	chainID, err := client.NetworkID(ctx)
+	if err != nil {
+		return nil, err
+	}
+	nonce, err := client.PendingNonceAt(ctx, from)
+	if err != nil {
+		return nil, err
+	}
+	tip, fee, err := suggestFees(ctx, client, minTip, minFee)
+	if err != nil {
+		return nil, err
+	}
+
+	tx := types.NewTx(&types.DynamicFeeTx{
+		ChainID:   chainID,
+		Nonce:     nonce,
+		GasTipCap: tip,
+		GasFeeCap: fee,
+		Gas:       TxGasLimit,
+		To:        &to,
+		Value:     big.NewInt(0),
+		Data:      data,
+	})
+	return types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
+}
+
+// waitForReceipt polls until the transaction is mined, or until whoever asked gives up.
+func waitForReceipt(ctx context.Context, client *ethclient.Client, hash common.Hash) (*types.Receipt, error) {
+	started := time.Now()
+	deadline := started.Add(RECEIPT_POLL_TIMEOUT)
+
+	for time.Now().Before(deadline) {
+		if receipt, err := client.TransactionReceipt(ctx, hash); err == nil && receipt != nil {
+			elapsed := time.Since(started)
+			fmt.Printf("\rWaiting for confirmation... %dm %ds   \n", int(elapsed.Minutes()), int(elapsed.Seconds())%60)
+			return receipt, nil
+		}
+		elapsed := time.Since(started)
+		fmt.Printf("\rWaiting for confirmation... %dm %ds   ", int(elapsed.Minutes()), int(elapsed.Seconds())%60)
+		select {
+		case <-ctx.Done():
+			fmt.Print("\n")
+			return nil, ctx.Err()
+		case <-time.After(RECEIPT_POLL_INTERVAL):
+		}
+	}
+
+	fmt.Print("\n")
+	return nil, fmt.Errorf("not mined within %v, and it may still be pending: check %s on an explorer",
+		RECEIPT_POLL_TIMEOUT, hash.Hex())
+}

--- a/hosting/cli/writes.go
+++ b/hosting/cli/writes.go
@@ -1,0 +1,61 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/guiferpa/aurora/wire/ir"
+)
+
+// Whether a scope of a program changes anything, asked before a chain is spoken to.
+//
+// It is what keeps a call and a transaction from being the same mistake twice. A call is a
+// question — answered against the state as it is, costing nothing, and throwing away anything
+// the answer did on the way. A scope that writes, asked as a question, is a write thrown away:
+// the answer comes back, looking right, and the chain is exactly as it was.
+//
+// That happened, on a real chain, before this existed. `inc` answered 1 every time.
+
+// WritesInput is what deciding takes: a program, and the name of the scope being reached.
+type WritesInput struct {
+	Blocks   []ir.Block
+	Function string
+}
+
+// Writes says whether reaching this scope changes anything the chain keeps.
+//
+// It follows the scopes this one calls, because what a call does is part of what its caller
+// does — and once there is a standard library, the scope somebody writes holds no `sstore` at
+// all. `s.set(...)` is a call, and the write is one file away.
+//
+// A name the program does not bind answers false, and says so: the caller decides whether not
+// finding it is worth stopping for, since a contract may have been deployed from a source that
+// has since changed.
+func ScopeWrites(in WritesInput) (writes bool, found bool) {
+	scope, bound := ir.Scopes(in.Blocks)[in.Function]
+	if !bound {
+		return false, false
+	}
+	return ir.Does(in.Blocks, scope) >= ir.Writes, true
+}
+
+// refuseACallThatWrites is the message somebody gets for asking a question of something that
+// changes an answer.
+//
+// It names the command that does what they meant, because being told what is wrong and not
+// what to type is half an error message.
+func refuseACallThatWrites(function string) error {
+	return fmt.Errorf(
+		"%s changes what the chain keeps, and a call is a question: it would answer, cost nothing, and leave the chain exactly as it was — send it with 'aurora tx %s' instead",
+		function, function)
+}
+
+// warnATxThatWritesNothing is what somebody gets for paying for an answer they could have had.
+//
+// It is a word and not a refusal: a transaction over a scope that only reads is wasteful and
+// not wrong, and there are reasons for one — a receipt, a block number, a timestamp that
+// somebody else will read.
+func warnATxThatWritesNothing(function string) string {
+	return fmt.Sprintf(
+		"%s changes nothing the chain keeps, so this costs gas for an answer 'aurora call %s' gives for free.",
+		function, function)
+}

--- a/hosting/cli/writes_test.go
+++ b/hosting/cli/writes_test.go
@@ -1,0 +1,117 @@
+package cli
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// Whether reaching a scope changes anything the chain keeps, which is what decides between a
+// question and a change.
+//
+// It has to follow calls. Once there is a standard library, the scope somebody writes holds no
+// sstore at all — `s.set(...)` is a call, and the write is one file away.
+func TestWhetherReachingAScopeChangesAnything(t *testing.T) {
+	const source = "use std/evm/storage as s;\n" +
+		"ident read = defer { s.get(1); };\n" +
+		"ident keep = defer { s.set(1, feed(0)); };\n" +
+		"ident through = defer { keep(feed(0)); };\n" +
+		"ident deeper = defer { through(feed(0)); };\n" +
+		"ident sums = defer { feed(0) + feed(1); };\n" +
+		"ident raw = defer { sstore 1 feed(0); };\n"
+
+	projectOf(t, map[string]string{"src/main.ar": source})
+	blocks, err := newSession(t, sessionOpts{}).Blocks("src/main.ar")
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+
+	for _, tc := range []struct {
+		name   string
+		writes bool
+	}{
+		{name: "read", writes: false},
+		{name: "sums", writes: false},
+		{name: "raw", writes: true},
+		{name: "keep", writes: true},
+		// The two that matter: the write is not in this scope at all.
+		{name: "through", writes: true},
+		{name: "deeper", writes: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			writes, found := ScopeWrites(WritesInput{Blocks: blocks, Function: tc.name})
+			if !found {
+				t.Fatalf("%s is not a scope of the program", tc.name)
+			}
+			if writes != tc.writes {
+				t.Errorf("%s writes = %v, want %v", tc.name, writes, tc.writes)
+			}
+		})
+	}
+
+	t.Run("a name the program does not bind", func(t *testing.T) {
+		if _, found := ScopeWrites(WritesInput{Blocks: blocks, Function: "nothing"}); found {
+			t.Error("it found a scope nobody bound")
+		}
+	})
+}
+
+// A call over a scope that keeps something is refused before a chain is spoken to.
+//
+// This is the failure it exists for, and it happened on a real one: a scope that read a
+// counter, added one and kept it answered 1 every time, because every call started from the
+// state the last one did not change. Nothing was wrong with the bytecode. The question was the
+// wrong question.
+func TestACallOverAScopeThatKeepsSomethingIsRefused(t *testing.T) {
+	const source = "use std/evm/storage as s;\n" +
+		"ident inc = defer { s.set(1, s.get(1) + 1); };\n" +
+		"ident read = defer { s.get(1); };\n"
+
+	projectOf(t, map[string]string{"src/main.ar": source})
+	blocks, err := newSession(t, sessionOpts{}).Blocks("src/main.ar")
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+
+	// No RPC is dialled, because it never gets that far.
+	err = Call(context.Background(), CallInput{Function: "inc", Blocks: blocks, RPC: "http://127.0.0.1:1"})
+	if err == nil {
+		t.Fatal("it asked a question of something that changes the answer")
+	}
+	if !strings.Contains(err.Error(), "aurora tx inc") {
+		t.Errorf("it says %q, and never says what to type instead", err)
+	}
+	if !strings.Contains(err.Error(), "changes what the chain keeps") {
+		t.Errorf("it says %q, and never says why", err)
+	}
+}
+
+// And a call over one that keeps nothing is not refused: it gets as far as the network, which
+// is where this test stops caring.
+func TestACallOverAScopeThatKeepsNothingIsNotRefused(t *testing.T) {
+	const source = "use std/evm/storage as s;\nident read = defer { s.get(1); };\n"
+
+	projectOf(t, map[string]string{"src/main.ar": source})
+	blocks, err := newSession(t, sessionOpts{}).Blocks("src/main.ar")
+	if err != nil {
+		t.Fatalf("compiling: %v", err)
+	}
+
+	err = Call(context.Background(), CallInput{Function: "read", Blocks: blocks, RPC: "http://127.0.0.1:1"})
+	if err == nil {
+		t.Fatal("it reached a network that is not there")
+	}
+	if strings.Contains(err.Error(), "aurora tx") {
+		t.Errorf("it refused a question worth asking: %q", err)
+	}
+}
+
+// With no program in hand, nothing is refused. A contract was deployed from a source that may
+// since have changed, or moved, or belong to somebody else's checkout — not knowing is a
+// reason to say less, never a reason to stop somebody reaching what is already out there.
+func TestWithNoProgramNothingIsRefused(t *testing.T) {
+	err := Call(context.Background(), CallInput{Function: "inc", RPC: "http://127.0.0.1:1"})
+	if err != nil && strings.Contains(err.Error(), "aurora tx") {
+		t.Errorf("it refused without knowing: %q", err)
+	}
+}

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -1,5 +1,7 @@
 package ir
 
+import "github.com/guiferpa/aurora/byteutil"
+
 // Operations over blocks. They are here and not with whoever joins programs because they are
 // arithmetic over the IR and nothing else — and getting any of them wrong is quiet.
 
@@ -90,4 +92,75 @@ func GoesOnTo(blocks []Block, from, next BlockID) []Block {
 		}
 	}
 	return blocks
+}
+
+// Scopes answers which block each name was bound to, for the names bound to a scope.
+//
+// Binding one is two instructions: a save carries the block under a label, and a binding
+// carries the name and a reference to that label. Reading them together is how a name becomes
+// a block, and it is here because more than one consumer needs it — a backend resolving a
+// call, and anybody asking what running a scope does.
+func Scopes(blocks []Block) map[string]BlockID {
+	held := make(map[string]BlockID)
+	for _, block := range blocks {
+		for _, inst := range block.Insts {
+			if inst.GetOpCode() == OpSave && inst.GetLeft().Kind() == KindBlock {
+				held[byteutil.ToHex(inst.GetLabel())] = inst.GetLeft().Block()
+			}
+		}
+	}
+
+	bound := make(map[string]BlockID)
+	for _, block := range blocks {
+		for _, inst := range block.Insts {
+			if inst.GetOpCode() != OpIdent || inst.GetRight().Kind() != KindRef {
+				continue
+			}
+			if id, isScope := held[byteutil.ToHex(inst.GetRight().Bytes())]; isScope {
+				bound[string(inst.GetLeft().Bytes())] = id
+			}
+		}
+	}
+	return bound
+}
+
+// Does answers the most it can be said running this scope does, following the branches inside
+// it and the scopes it calls.
+//
+// Reaches is not enough for this and cannot be: it follows where control goes, and a call is
+// not that — control comes back. But what a call does is part of what its caller does, and
+// that is the whole of why this exists. A scope whose own blocks hold nothing but arithmetic
+// still writes to a chain if it calls something that writes, which is exactly the shape a
+// program has once there is a standard library to call.
+func Does(blocks []Block, from BlockID) Effect {
+	scopes := Scopes(blocks)
+	seen := make(map[BlockID]bool, len(blocks))
+
+	var walk func(id BlockID) Effect
+	walk = func(id BlockID) Effect {
+		if seen[id] || int(id) >= len(blocks) || id < 0 {
+			return Pure
+		}
+		seen[id] = true
+
+		most := Pure
+		for _, block := range Reaches(blocks, id) {
+			seen[block] = true
+			for _, inst := range blocks[block].Insts {
+				if effect := EffectOf(inst.GetOpCode()); effect > most {
+					most = effect
+				}
+				if inst.GetOpCode() != OpCall {
+					continue
+				}
+				if called, bound := scopes[string(inst.GetLeft().Bytes())]; bound {
+					if effect := walk(called); effect > most {
+						most = effect
+					}
+				}
+			}
+		}
+		return most
+	}
+	return walk(from)
 }


### PR DESCRIPTION
Sua ideia, e ela é melhor que as minhas duas: **`aurora tx`**, comando próprio.

## O bug que você encontrou

`aurora call` só fazia `eth_call`, e nada mais na ferramenta sabia enviar. Então **um escopo
que guarda alguma coisa não conseguia guardar por caminho nenhum** — a escrita rodava numa
simulação e era descartada.

Foi exatamente o que você viu no Sepolia: `inc` respondendo 1 toda vez, `read` respondendo 0.
O bytecode estava certo o tempo todo; a pergunta é que era a pergunta errada.

## Dois comandos, porque são duas coisas

```
aurora call read      pergunta, respondida contra o estado como está, sem custo, sem guardar
aurora tx inc         mudança, enviada, paga, minerada, e o que mudou fica
```

Nada é decidido pela cara do programa, e nenhum gás é gasto porque um nome pareceu querer.

## E aí o `Effect` recusa a combinação errada

```
$ aurora call inc
inc changes what the chain keeps, and a call is a question: it would answer, cost
nothing, and leave the chain exactly as it was — send it with 'aurora tx inc' instead
```

O contrário é aviso e não recusa: `aurora tx read` gasta gás por uma resposta que o `call` dá
de graça, mas um recibo é motivo, então é uma palavra e você segue.

**A parte que exigiu trabalho de verdade:** o `sstore` não está no escopo que você escreve. Com
a std, `inc` só tem uma chamada a `s.set` — a escrita está um arquivo adiante. Então o
`ir.Does` **segue as chamadas**, e dois dos testes provam isso com a escrita a duas chamadas de
distância.

Sem programa em mãos, nada é recusado: um contrato foi publicado de um fonte que pode ter
mudado, e não saber é motivo para dizer menos, nunca para impedir você de alcançar o que já
está lá fora.

## Do seu `main.ar`

Ele estava quebrando o `make check` — declarava saída 600 e não imprimia nada, porque nada
chamava nada. **Eu completei**, e vale você conferir: adicionei `printd main(); inc(); inc();
printd read();`, o cabeçalho passou a declarar `600` e `2`, e escrevi nos comentários a
distinção call/tx com o motivo de `aurora call inc` responder 1 toda vez.

Se você queria o arquivo de outro jeito, é só dizer.

E os testes de exemplo agora conhecem a std — liam de um `lib` que não existia dentro do
diretório temporário, o que passava despercebido até um exemplo importar `std/`.

## Sobra, nomeado no roadmap

Uma transação usa um limite de gás fixo para todo escopo (500 mil), e nada lê o que uma
transação **respondeu** — só storage e log atravessam essa linha, e log não vai para a chain
por decisão. Então o `tx` diz o que gastou e onde caiu, e o valor se lê com um `call` depois.

🤖 Generated with [Claude Code](https://claude.com/claude-code)