### PR TITLE
A missing module says which kind it is

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -131,9 +131,22 @@ What it does not do yet:
   does. What would close it is embedding the same files in the binary and reading the directory
   over them when it is there — one source, two ways to reach it — and it waits until somebody
   wants the standard library in the playground.
-- **Nothing installs the standard library but `make install-std`.** A release ships a binary
-  and not the files beside it, so somebody who downloads one has the language and not its
-  library. What that needs is the release carrying both, and a first run that says so.
+- **Nothing installs the standard library but `make install-std`.** A release ships binaries
+  and not the files beside them, so somebody who downloads one has the language and not its
+  library, until they clone this repository and run that.
+
+  **Carrying it inside the binary was tried and refused.** It works, it costs 33 KB, and it
+  makes a second copy that can disagree with the first: install the library with one version,
+  upgrade the binary, forget to write it out again, and the toolchain is one version while its
+  library is another — silently, which is what one directory was chosen to prevent. Go does not
+  do it either; its library is files in `$GOROOT/src`, shipped in the same archive as the
+  binary, and upgrading replaces the whole tree.
+
+  So the shape of the answer is that one: the release archive carries `std/` beside the
+  binaries, and the toolchain finds it. What that costs is a place to look that is not one
+  place — a `.deb` puts the binary in `/usr/bin`, Homebrew reaches it through a symlink, and a
+  tarball lands wherever it was unpacked — and that is the search path this design set out to
+  avoid. It waits until somebody is stopped by it.
 
 Two things are decided against rather than missing. **An import is not passed on**: if `main`
 uses `a` and `a` uses `b`, `main` writes its own line for `b`, so a name used in a file has

--- a/hosting/cli/std_test.go
+++ b/hosting/cli/std_test.go
@@ -80,6 +80,11 @@ func TestAModuleOfTheLanguageThatIsNotInstalled(t *testing.T) {
 	if !strings.Contains(err.Error(), "std/evm/nothing") {
 		t.Errorf("error = %q, want it to name the module", err)
 	}
+	// A module of the language missing and a module of the program missing are two different
+	// things to have happened, and which one it was is most of what somebody needs.
+	if !strings.Contains(err.Error(), "comes with the language and is not installed") {
+		t.Errorf("error = %q, and reads like a name typed wrong", err)
+	}
 }
 
 // runWithStd runs a program that can reach what comes with the language.

--- a/resolver/resolver.go
+++ b/resolver/resolver.go
@@ -192,6 +192,14 @@ func (r *Resolver) resolveOne(state *resolution, declaration ast.UseDeclaration)
 
 	source, err := r.read(filename)
 	if err != nil {
+		// A module of the language missing and a module of the program missing are two
+		// different things to have happened, and telling them apart is most of what somebody
+		// needs: one is a name typed wrong, the other is a toolchain that was never finished
+		// being installed.
+		if module.IsStd(id) {
+			return token.NewError(declaration.Token, "module %s comes with the language and is not installed at line %d and column %d: no %s",
+				id, declaration.Token.GetLine(), declaration.Token.GetColumn(), filename)
+		}
 		return token.NewError(declaration.Token, "module %s is not there at line %d and column %d: no %s",
 			id, declaration.Token.GetLine(), declaration.Token.GetColumn(), filename)
 	}


### PR DESCRIPTION
Duas linhas de código e um registro.

## A mensagem

```
module std/evm/storage comes with the language and is not installed at line 1 and column 1
```

Em vez de soar como nome digitado errado. São duas coisas diferentes de ter acontecido — uma é
erro de digitação, a outra é toolchain que nunca terminou de ser instalado — e qual delas foi é
a maior parte do que a pessoa precisa saber.

## E por que o embed foi recusado, escrito no roadmap

Para ninguém (inclusive eu) repropor daqui a três meses. O argumento é seu e está lá com todas
as letras: embutir faz **uma segunda cópia que pode discordar da primeira**. Instala a std com
uma versão, atualiza o binário, esquece de escrever de novo — e o toolchain é uma versão com a
biblioteca de outra, em silêncio, que é justamente o que "um diretório" existia para impedir.

Junto vai o que eu conferi e que **não** era o argumento: 33 KB num binário de 12,8 MB, quase
tudo maquinaria do `embed`. E que **o Go não embute** — a std dele são arquivos em
`$GOROOT/src`, no mesmo tarball do binário, e atualizar substitui a árvore inteira.

E fica escrito qual é a forma certa quando doer: o release carregar `std/` ao lado dos
binários. Com o preço nomeado — três canais dão três lugares para procurar, que é a lista de
caminhos do C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)