### PR TITLE
An opcode says what it takes, and the IR checks it

### DIFF
--- a/docs/contributing/ir.md
+++ b/docs/contributing/ir.md
@@ -376,9 +376,29 @@ with leaves nothing on a stack, so `builder/evm` writes a push under that same n
 for it. Two values under one name is what the check refuses, and it is right to — of the IR. Of
 a schedule it is not a question.
 
-What is not asserted yet is the sixth: that every operand has the `Kind` its opcode expects.
-That one needs each opcode's operands written down as something a program can read rather than
-as the comment beside it in `wire/ir/opcodes.go`.
+And a sixth: **every operand is what its opcode takes**. What each one accepts is written in
+`wire/ir/takes.go`, as something a program reads rather than as the comment beside it —
+
+```go
+OpIdent: {Slots: []Slot{AName, AValue}}
+OpField: {Slots: []Slot{AValue, ANumber, ANumber}}
+OpCall:  {Slots: []Slot{AName, AValue}, Repeats: true}
+```
+
+— because a comment cannot be checked, and this is the disease that cost twice. A slot is a
+class of kinds rather than one: a value is a value whether the program computed it or wrote it
+down, and a consumer that cared about the difference would be one for whom folding a literal
+changed the program.
+
+`Repeats` says the last slot stands for any number of operands. A call is why: a scope has no
+arity, so a name comes first and as many values as were applied follow.
+
+Writing it down found one immediately. The comment beside `OpSave` said it takes an `Imm`, and
+it takes the number of a block too — that is how a name reaches the scope it was bound to, and
+it had been true for as long as the comment had been wrong.
+
+An opcode nobody has described is said nothing about, which is the honest answer and the reason
+this file is worth keeping in agreement.
 
 ## Why it is not a list
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -245,19 +245,18 @@ and answers from the evaluator, the same way the chain would.
 
 ---
 
-## What the IR does not assert yet
+## What the IR asserts
 
-`ir.Verify` asserts five of the six things the IR was reshaped to make assertable, and
-`builder/evm` refuses a program that fails any of them rather than writing bytes for it.
+`ir.Verify` asserts all six things the IR was reshaped to make assertable, and `builder/evm`
+refuses a program that fails any of them rather than writing bytes for it.
 
-The sixth is **that every operand has the `Kind` its opcode expects**. What it needs first is
-each opcode's operands written down as something a program can read — they are comments beside
-the opcodes today, which is a description kept in agreement by somebody remembering, and this
-file has a long list of what that costs.
-
-Nothing else about a program is asserted, and two things stay deliberately unasserted: what a
-call hands over, because a scope has no arity; and anything about a stack, a frame or an
+Two things stay deliberately unasserted: what a call hands over, because a scope has no arity —
+running one is applying a vector of values to it; and anything about a stack, a frame or an
 address, because those mean something on one target and nothing on another.
+
+What is left is not about the IR: **`Scope.Names` is name resolution done again.** The emitter
+knows where every name lives and does not say, so `builder/evm` works it out a second time —
+the third of the six costs `rfcs/ir.md` named, and the only one still open.
 
 ## Seeing what a phase produced
 

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -22,8 +22,9 @@ const (
 
 	// Names and values.
 	OpIdent // Name, Ref -> binds the name to the value, and leaves the neutral tape
-	OpSave  // Imm -> the bytes themselves, which is how a literal reaches the program
-	OpLoad  // Name -> what the name is bound to, looked up where the program is running
+	OpSave  // Imm or Block -> the bytes themselves, which is how a literal reaches the program,
+	//            and how a name reaches the scope it was bound to
+	OpLoad // Name -> what the name is bound to, looked up where the program is running
 
 	// Comparison. What it returns is a tape like any other: false is all zeros.
 	OpDiff    // Ref, Ref -> whether the two differ

--- a/wire/ir/takes.go
+++ b/wire/ir/takes.go
@@ -1,0 +1,185 @@
+package ir
+
+import "fmt"
+
+// What each opcode takes, written where the opcode is written.
+//
+// This is the second half of the disease the IR was reshaped to cure. The first made a
+// consumer guess structure; this one made it guess meaning — the same bytes are a number under
+// one kind and a name under another, and which one an opcode wants was a comment beside it and
+// a decision in every consumer's head.
+//
+// It has cost twice, both times the same way: somebody found out afterwards and patched the
+// side that happened to be right. A comment cannot be checked. This can.
+
+// A Slot says what one operand may be.
+//
+// It is a class of kinds rather than one, because more than one kind carries the same idea. A
+// value is a value whether the program computed it — a Ref — or wrote it down, an Imm; a
+// consumer that cared about the difference would be a consumer for whom folding a literal
+// changed the program.
+type Slot byte
+
+const (
+	// AValue is something of the program: computed by another instruction, or written down.
+	AValue Slot = iota
+	// AName is something that outlives the instruction: a name a scope bound, or a scope to
+	// call.
+	AName
+	// ANumber is a number the operation takes about itself — a width, an index, a position.
+	// It is Const where the emitter says so, and Imm where the number came from the source.
+	ANumber
+	// AText is bytes written for a person, and never a value.
+	AText
+	// AnythingWritten is an operand whose kind the opcode does not constrain: a save carries
+	// what it was given, and what it was given is a value or the number of a block.
+	AnythingWritten
+	// ANothing is an operand that is not there.
+	ANothing
+)
+
+// A Shape is what an instruction takes: one Slot per operand.
+//
+// Repeats says the last Slot may stand for any number of operands, including none. A
+// construction is what it is for — a shape has as many fields as it has — and a call, which
+// applies a vector of values to a scope.
+type Shape struct {
+	Slots   []Slot
+	Repeats bool
+}
+
+// takes is what each opcode accepts. An opcode not here is unconstrained, and Verify says
+// nothing about it — which is the honest answer for one nobody has written down yet.
+var takes = map[byte]Shape{
+	OpMultiply:    {Slots: []Slot{AValue, AValue}},
+	OpAdd:         {Slots: []Slot{AValue, AValue}},
+	OpSubtract:    {Slots: []Slot{AValue, AValue}},
+	OpDivide:      {Slots: []Slot{AValue, AValue}},
+	OpExponential: {Slots: []Slot{AValue, AValue}},
+
+	OpDiff:    {Slots: []Slot{AValue, AValue}},
+	OpEquals:  {Slots: []Slot{AValue, AValue}},
+	OpBigger:  {Slots: []Slot{AValue, AValue}},
+	OpSmaller: {Slots: []Slot{AValue, AValue}},
+	OpAnd:     {Slots: []Slot{AValue, AValue}},
+	OpOr:      {Slots: []Slot{AValue, AValue}},
+
+	OpIdent: {Slots: []Slot{AName, AValue}},
+	// A save carries what it was handed, and that is a value of the program or the number of
+	// a block — a scope bound to a name is the second. The comment beside the opcode said Imm
+	// for a long time and was wrong for as long.
+	OpSave: {Slots: []Slot{AnythingWritten, ANothing}},
+	OpLoad: {Slots: []Slot{AName, ANothing}},
+
+	OpGetFeed: {Slots: []Slot{ANumber, ANothing}},
+	// A scope has no arity: running one is applying a vector of values to it, so the name
+	// comes first and as many values as were applied follow.
+	OpCall: {Slots: []Slot{AName, AValue}, Repeats: true},
+
+	OpPrintBytes:   {Slots: []Slot{AValue, ANothing}},
+	OpPrintChars:   {Slots: []Slot{AValue, ANothing}},
+	OpPrintDecimal: {Slots: []Slot{AValue, ANothing}},
+
+	OpPull: {Slots: []Slot{AValue}, Repeats: true},
+	OpPush: {Slots: []Slot{AValue, AValue}},
+	OpHead: {Slots: []Slot{AValue, ANumber}},
+	OpTail: {Slots: []Slot{AValue, ANumber}},
+
+	OpAssert: {Slots: []Slot{AValue, AText}},
+
+	// A run is its tapes and nothing else, so a construction takes as many as it has.
+	OpJoin:  {Slots: []Slot{AValue}, Repeats: true},
+	OpField: {Slots: []Slot{AValue, ANumber, ANumber}},
+
+	OpStorageGet: {Slots: []Slot{AValue, ANothing}},
+	OpStorageSet: {Slots: []Slot{AValue, AValue}},
+}
+
+// holds says whether a kind is one of the things a slot accepts.
+func (slot Slot) holds(kind Kind) bool {
+	switch slot {
+	case AValue:
+		return kind == KindRef || kind == KindImm || kind == KindConst
+	case AName:
+		return kind == KindName
+	case ANumber:
+		return kind == KindConst || kind == KindImm
+	case AText:
+		return kind == KindText
+	case AnythingWritten:
+		return kind != KindEmpty && kind != KindTarget
+	case ANothing:
+		return kind == KindEmpty
+	}
+	return true
+}
+
+// describe says what a slot wants, in words rather than a number.
+func (slot Slot) describe() string {
+	switch slot {
+	case AValue:
+		return "a value"
+	case AName:
+		return "a name"
+	case ANumber:
+		return "a number of its own"
+	case AText:
+		return "text"
+	case AnythingWritten:
+		return "something written down"
+	case ANothing:
+		return "nothing"
+	}
+	return "anything"
+}
+
+// verifyTakes answers what is wrong with the operands of one instruction, and nothing when
+// they are what its opcode takes.
+func verifyTakes(block BlockID, at int, inst Instruction) []Problem {
+	shape, written := takes[inst.GetOpCode()]
+	if !written {
+		return nil
+	}
+
+	operands := inst.GetOperands()
+	found := make([]Problem, 0)
+
+	if !shape.Repeats && len(operands) > len(shape.Slots) {
+		return []Problem{{Block: block, At: at, Says: fmt.Sprintf(
+			"opcode %d takes %d operands and was given %d", inst.GetOpCode(), len(shape.Slots), len(operands))}}
+	}
+
+	for position, operand := range operands {
+		slot := shape.Slots[min(position, len(shape.Slots)-1)]
+		if slot.holds(operand.Kind()) {
+			continue
+		}
+		found = append(found, Problem{Block: block, At: at, Says: fmt.Sprintf(
+			"operand %d of opcode %d is %s, and that operand takes %s",
+			position, inst.GetOpCode(), describeKindOf(operand.Kind()), slot.describe())})
+	}
+	return found
+}
+
+// describeKindOf says what an operand is, in the words the kinds are documented in.
+func describeKindOf(kind Kind) string {
+	switch kind {
+	case KindRef:
+		return "a value another instruction left"
+	case KindImm:
+		return "a value written down"
+	case KindConst:
+		return "a number the operation takes about itself"
+	case KindName:
+		return "a name"
+	case KindText:
+		return "text"
+	case KindBlock:
+		return "the number of a block"
+	case KindTarget:
+		return "where control goes"
+	case KindEmpty:
+		return "not there"
+	}
+	return "something"
+}

--- a/wire/ir/verify.go
+++ b/wire/ir/verify.go
@@ -77,6 +77,11 @@ func verifyBlock(blocks []Block, block Block) []Problem {
 			}
 		}
 
+		// And that each operand is the kind its opcode takes, which is the other half of a
+		// consumer never guessing: one half is which operand names a value, and this is what
+		// the bytes under it mean.
+		found = append(found, verifyTakes(block.ID, at, inst)...)
+
 		label := byteutil.ToHex(inst.GetLabel())
 		if defined[label] {
 			found = append(found, Problem{Block: block.ID, At: at,

--- a/wire/ir/verify_test.go
+++ b/wire/ir/verify_test.go
@@ -129,7 +129,112 @@ func TestVerifyAnswersEverythingWrongAtOnce(t *testing.T) {
 		Term: Goes(9),
 	}}
 
-	if problems := Verify(blocks); len(problems) != 4 {
-		t.Errorf("it found %d things wrong, want the four that are: %v", len(problems), problems)
+	// Six: each of the two adds reads a value nobody leaves and is missing its second
+	// operand, the second leaves a value under a name the first already used, and the block
+	// goes where there is no block.
+	if problems := Verify(blocks); len(problems) != 6 {
+		t.Errorf("it found %d things wrong, want the six that are: %v", len(problems), problems)
+	}
+}
+
+// What an operand may be, which is the half of the check about meaning rather than shape.
+//
+// The same bytes are a number under one kind and a name under another, and which one an opcode
+// wants used to be a comment beside it — a description kept in agreement by whoever remembered.
+// It cost twice, and both times somebody found out afterwards.
+func TestWhatAnOpcodeTakes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		inst Instruction
+		says string
+	}{
+		{
+			name: "a name where a value goes",
+			inst: NewInstruction([]byte("01"), OpAdd, NameOf("x"), Imm(1, 8)),
+			says: "operand 0 of opcode 2 is a name, and that operand takes a value",
+		},
+		{
+			name: "a value where a name goes",
+			inst: NewInstruction([]byte("01"), OpLoad, Imm(1, 8), Nothing()),
+			says: "takes a name",
+		},
+		{
+			name: "text where a value goes",
+			inst: NewInstruction([]byte("01"), OpPrintDecimal, TextOf("hello"), Nothing()),
+			says: "is text, and that operand takes a value",
+		},
+		{
+			name: "something where nothing goes",
+			inst: NewInstruction([]byte("01"), OpLoad, NameOf("x"), Imm(1, 8)),
+			says: "takes nothing",
+		},
+		{
+			name: "a name in the second half of a binding",
+			inst: NewInstruction([]byte("01"), OpIdent, NameOf("x"), NameOf("y")),
+			says: "operand 1 of opcode 6 is a name, and that operand takes a value",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			problems := Verify([]Block{{ID: 0, Insts: []Instruction{tc.inst}, Term: Ends(Nothing())}})
+			if len(problems) == 0 {
+				t.Fatal("it verified an instruction given something its opcode does not take")
+			}
+			said := false
+			for _, problem := range problems {
+				said = said || strings.Contains(problem.Error(), tc.says)
+			}
+			if !said {
+				t.Errorf("it says %v, want one of them to say %q", problems, tc.says)
+			}
+		})
+	}
+}
+
+// And the ones that are right are said nothing about — including the two an opcode's comment
+// used to get wrong.
+func TestWhatAnOpcodeTakesAndIsGiven(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		inst Instruction
+	}{
+		{name: "a value written down where a value goes", inst: NewInstruction([]byte("01"), OpAdd, Imm(1, 8), Imm(2, 8))},
+		{name: "a binding", inst: NewInstruction([]byte("01"), OpIdent, NameOf("x"), Imm(1, 8))},
+		// A save carries a literal, and it carries the number of a block: a scope bound to a
+		// name is the second, and the comment beside the opcode said Imm for a long time.
+		{name: "a save of a literal", inst: NewInstruction([]byte("01"), OpSave, Imm(1, 8), Nothing())},
+		{name: "a save of a scope", inst: NewInstruction([]byte("01"), OpSave, BlockOf(3), Nothing())},
+		// A call takes a name and as many values as were applied, because a scope has no
+		// arity — none of them is as right as any other.
+		{name: "a call of no values", inst: NewInstructionOver([]byte("01"), OpCall, NameOf("f"))},
+		{name: "a call of three", inst: NewInstructionOver([]byte("01"), OpCall, NameOf("f"), Imm(1, 8), Imm(2, 8), Imm(3, 8))},
+		{name: "a run of five", inst: NewInstructionOver([]byte("01"), OpJoin, Imm(1, 8), Imm(2, 8), Imm(3, 8), Imm(4, 8), Imm(5, 8))},
+		{name: "a field", inst: NewInstructionOver([]byte("01"), OpField, RefTo([]byte("00")), Const(1, 8), Const(3, 8))},
+		{name: "an assertion", inst: NewInstruction([]byte("01"), OpAssert, RefTo([]byte("00")), TextOf("it holds"))},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blocks := []Block{{
+				ID:     0,
+				Params: []Label{[]byte("00")},
+				Insts:  []Instruction{tc.inst},
+				Term:   Ends(Nothing()),
+			}}
+			for _, problem := range Verify(blocks) {
+				t.Errorf("%v", problem)
+			}
+		})
+	}
+}
+
+// An opcode nobody wrote down is said nothing about, which is the honest answer for one that
+// has not been described yet — and the reason this file is worth keeping in agreement.
+func TestAnOpcodeNobodyWroteDownIsNotRefused(t *testing.T) {
+	blocks := []Block{{
+		ID:    0,
+		Insts: []Instruction{NewInstruction([]byte("01"), 0xFE, NameOf("anything"), TextOf("at all"))},
+		Term:  Ends(RefTo([]byte("01"))),
+	}}
+
+	if problems := Verify(blocks); len(problems) != 0 {
+		t.Errorf("it refused an opcode nobody has described: %v", problems)
 	}
 }


### PR DESCRIPTION
A sexta afirmação do `Verify`, que era a última em aberto — e ela é a **segunda metade da
doença** que a `rfcs/ir.md` chamou de mais séria: a primeira fazia o consumidor adivinhar
*estrutura*, esta fazia ele adivinhar *significado*.

O que cada opcode aceita agora é dado, não comentário:

```go
OpIdent: {Slots: []Slot{AName, AValue}}
OpField: {Slots: []Slot{AValue, ANumber, ANumber}}
OpCall:  {Slots: []Slot{AName, AValue}, Repeats: true}
```

## Escrever achou um na hora, que é o argumento para escrever

O comentário do `OpSave` dizia que ele recebe um `Imm`. **Recebe o número de um bloco também** —
é assim que um nome alcança o escopo a que foi ligado (`emitter/blocks.go:125`), e isso era
verdade há tanto tempo quanto o comentário estava errado.

Um comentário não pode ser conferido. Isto pode.

## Duas decisões de forma

**Um slot é uma classe de kinds, não um.** Um valor é um valor tendo o programa calculado
(`Ref`) ou escrito (`Imm`) — um consumidor que se importasse com a diferença seria um para quem
dobrar um literal muda o programa.

**`Repeats` cobre as duas coisas sem contagem fixa:** uma construção tem tantos tapes quantos
tem, e uma chamada aplica um vetor de valores a um escopo que **não tem aridade**. Nenhuma das
duas é "aridade errada", e a checagem não finge que é.

Um opcode que ninguém descreveu não recebe nada dito sobre ele — resposta honesta para um que
ainda não foi escrito, e o motivo pelo qual vale manter o arquivo em dia.

## Todo programa passa

Rodei sobre o corpus inteiro antes de ligar. O único teste que quebrou foi um meu, que contava
4 problemas num programa quebrado à mão e agora acha 6 — porque a checagem nova pega também os
dois `OpAdd` sem segundo operando.

---

Com isto o roadmap deixa de listar **o que o IR não afirma** e passa a listar **o que ele
afirma**. Dos seis custos da `rfcs/ir.md`, sobra um — e ele não é sobre o IR: o emitter sabe
onde cada nome mora e não diz, então o backend descobre de novo (`Scope.Names`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)