### PR TITLE
A label is unique in its block, and which name is which block is read that way

### DIFF
--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -551,8 +551,9 @@ func emitIdentifierLiteral(tc *int, insts *[]ir.Instruction, n ast.IdentifierLit
 // most scopes rather than the few that declared. This is that fact reaching the blocks, where
 // a backend can read it.
 //
-// The way from a name to a block is two steps, because that is how a scope is bound: a save
-// carries the block under a label, and a binding carries the name and a ref to that label.
+// Which name is which block is ir.Scopes, which is the one description of it: the emitter kept
+// a copy of that walk for a while, and the copy and the original did not agree about whether a
+// label is unique in its block or in the program.
 func widened(blocks []ir.Block, returns []ast.Returns) []ir.Block {
 	tapes := make(map[string]int, len(returns))
 	for _, each := range returns {
@@ -562,36 +563,12 @@ func widened(blocks []ir.Block, returns []ast.Returns) []ir.Block {
 		return blocks
 	}
 
-	for _, block := range blocks {
-		for name, id := range scopesBoundIn(block) {
-			if wide, said := tapes[name]; said && int(id) < len(blocks) {
-				blocks[id].Tapes = wide
-			}
+	for name, id := range ir.Scopes(blocks) {
+		if wide, said := tapes[name]; said && int(id) < len(blocks) {
+			blocks[id].Tapes = wide
 		}
 	}
 	return blocks
-}
-
-// scopesBoundIn answers which block each name in this block was bound to, for the names bound
-// to a scope. A name bound to anything else is not here, and neither is a block nobody named.
-func scopesBoundIn(block ir.Block) map[string]ir.BlockID {
-	held := make(map[string]ir.BlockID)
-	for _, inst := range block.Insts {
-		if inst.GetOpCode() == ir.OpSave && inst.GetLeft().Kind() == ir.KindBlock {
-			held[byteutil.ToHex(inst.GetLabel())] = inst.GetLeft().Block()
-		}
-	}
-
-	bound := make(map[string]ir.BlockID)
-	for _, inst := range block.Insts {
-		if inst.GetOpCode() != ir.OpIdent || inst.GetRight().Kind() != ir.KindRef {
-			continue
-		}
-		if id, isScope := held[byteutil.ToHex(inst.GetRight().Bytes())]; isScope {
-			bound[string(inst.GetLeft().Bytes())] = id
-		}
-	}
-	return bound
 }
 
 func (e *emt) Emit(tree ast.AST) ([]ir.Block, error) {

--- a/hosting/cli/writes_test.go
+++ b/hosting/cli/writes_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"strings"
 	"testing"
+
+	"github.com/guiferpa/aurora/wire/ir"
 )
 
 // Whether reaching a scope changes anything the chain keeps, which is what decides between a
@@ -48,6 +50,20 @@ func TestWhetherReachingAScopeChangesAnything(t *testing.T) {
 			}
 		})
 	}
+
+	// The one that shipped broken. Which name is which block is worked out one block at a
+	// time, because a label is unique in its block and not in the program — read together, a
+	// scope of the standard library and a scope of the program came out sharing one block, and
+	// `aurora call read` was refused for writing.
+	t.Run("a scope of the program and one of the library keep their own blocks", func(t *testing.T) {
+		bound := ir.Scopes(blocks)
+		if bound["read"] == bound["std/evm/storage.set"] {
+			t.Errorf("read is block %d, and so is the library's set", bound["read"])
+		}
+		if bound["keep"] == bound["std/evm/storage.get"] {
+			t.Errorf("keep is block %d, and so is the library's get", bound["keep"])
+		}
+	})
 
 	t.Run("a name the program does not bind", func(t *testing.T) {
 		if _, found := ScopeWrites(WritesInput{Blocks: blocks, Function: "nothing"}); found {

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -101,17 +101,18 @@ func GoesOnTo(blocks []Block, from, next BlockID) []Block {
 // a block, and it is here because more than one consumer needs it — a backend resolving a
 // call, and anybody asking what running a scope does.
 func Scopes(blocks []Block) map[string]BlockID {
-	held := make(map[string]BlockID)
+	bound := make(map[string]BlockID)
 	for _, block := range blocks {
+		// One block at a time, because a label is unique in its block and not in the program.
+		// Read together, the label of one block's save answers for another block's binding —
+		// so a name resolves to whichever block was walked last, and a caller asking what a
+		// scope does is told what a different scope does.
+		held := make(map[string]BlockID)
 		for _, inst := range block.Insts {
 			if inst.GetOpCode() == OpSave && inst.GetLeft().Kind() == KindBlock {
 				held[byteutil.ToHex(inst.GetLabel())] = inst.GetLeft().Block()
 			}
 		}
-	}
-
-	bound := make(map[string]BlockID)
-	for _, block := range blocks {
 		for _, inst := range block.Insts {
 			if inst.GetOpCode() != OpIdent || inst.GetRight().Kind() != KindRef {
 				continue

--- a/wire/ir/blocks_test.go
+++ b/wire/ir/blocks_test.go
@@ -167,3 +167,76 @@ func TestOriginIsKnownOnlyWhenItPointsSomewhere(t *testing.T) {
 		t.Error("an origin at the first line says it points nowhere")
 	}
 }
+
+// A label is unique in its block and not in the program, so which name is which block is
+// worked out one block at a time.
+//
+// Read together, the save of one block answers for the binding of another: two names come out
+// pointing at one block, and a caller asking what a scope does is told what a different scope
+// does. That shipped — `aurora call read` was refused for writing, because read had been given
+// the block of something that writes.
+func TestTwoBlocksMayUseOneLabelForTwoThings(t *testing.T) {
+	// Both blocks leave a value under "01" and bind a name to it, and the two are different
+	// scopes. Nothing about that is unusual: labels are numbered from the start in each block.
+	blocks := []Block{
+		{
+			ID: 0,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, BlockOf(7), Nothing()),
+				NewInstruction([]byte("02"), OpIdent, NameOf("here"), RefTo([]byte("01"))),
+			},
+			Term: Ends(Nothing()),
+		},
+		{
+			ID: 1,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, BlockOf(9), Nothing()),
+				NewInstruction([]byte("02"), OpIdent, NameOf("there"), RefTo([]byte("01"))),
+			},
+			Term: Ends(Nothing()),
+		},
+	}
+
+	bound := Scopes(blocks)
+	if got := bound["here"]; got != 7 {
+		t.Errorf("here is block %d, want 7", got)
+	}
+	if got := bound["there"]; got != 9 {
+		t.Errorf("there is block %d, want 9", got)
+	}
+}
+
+// And what a scope does follows the scopes it calls, which is what the resolution above is for.
+func TestWhatAScopeDoesFollowsWhatItCalls(t *testing.T) {
+	// Block 0 binds "writer" to block 2 and "caller" to block 1; block 1 calls writer; block 2
+	// writes. So caller writes, one call away.
+	blocks := []Block{
+		{
+			ID: 0,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, BlockOf(2), Nothing()),
+				NewInstruction([]byte("02"), OpIdent, NameOf("writer"), RefTo([]byte("01"))),
+				NewInstruction([]byte("03"), OpSave, BlockOf(1), Nothing()),
+				NewInstruction([]byte("04"), OpIdent, NameOf("caller"), RefTo([]byte("03"))),
+			},
+			Term: Ends(Nothing()),
+		},
+		{
+			ID:    1,
+			Insts: []Instruction{NewInstructionOver([]byte("01"), OpCall, NameOf("writer"))},
+			Term:  Ends(RefTo([]byte("01"))),
+		},
+		{
+			ID:    2,
+			Insts: []Instruction{NewInstruction([]byte("01"), OpStorageSet, Imm(1, 8), Imm(2, 8))},
+			Term:  Ends(RefTo([]byte("01"))),
+		},
+	}
+
+	if got := Does(blocks, 1); got != Writes {
+		t.Errorf("the caller does %d, want it to write like what it calls", got)
+	}
+	if got := Does(blocks, 2); got != Writes {
+		t.Errorf("the writer does %d, want Writes", got)
+	}
+}


### PR DESCRIPTION
**Bug meu, do #158, e você achou.** `aurora call read` e `aurora call main` sendo recusados
por escrita, quando nenhum dos dois escreve.

## O que era

Reproduzi com o seu arquivo e o mapa nome→bloco saiu assim:

```
map[inc:5  main:4  read:6  std/evm/storage.get:5  std/evm/storage.set:1]
```

`inc` e `std/evm/storage.get` **no mesmo bloco 5**. Um label é único **dentro do bloco**, não
no programa — e eu resolvia nome→bloco varrendo todos os blocos de uma vez, então o `save` de
um bloco respondia pelo `ident` de outro. Aí perguntar "o que `read` faz" respondia o que outro
escopo faz.

Depois do conserto:

```
main   writes=false
inc    writes=true
read   writes=false
```

## E o pior detalhe

**O emitter já tinha a travessia certa**, um bloco por vez. O que eu escrevi no #158 foi uma
*cópia* dela com o laço achatado — duas descrições da mesma coisa, feitas por mim, fazendo
exatamente o que este compilador passa o tempo removendo. E as duas discordavam sobre se um
label é único no bloco ou no programa.

Agora há uma só, em `ir.Scopes`, e o emitter usa ela.

## Testes

Dois no `wire/ir`: que dois blocos podem chamar coisas diferentes de `"01"` e ambos resolverem
certo, e que o que um escopo faz continua seguindo o que ele chama depois disso. Mais um caso
no `hosting/cli` provando que um escopo do programa e um da std não compartilham bloco.

---

Sobre o `aurora call inc` continuar recusado: esse está **certo**, `inc` escreve mesmo. Para
esse é `aurora tx inc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)