### PR TITLE
What a chain keeps is narrower than what an instruction writes

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -223,9 +223,16 @@ refuse the wrong one: a scope that keeps something, asked as a question, is a wr
 — it answers, looking right, and the chain is exactly as it was. That happened on a real chain
 before this existed, and a counter answered 1 every time.
 
-Which scopes keep something is read from the effect of the instructions they reach, following
-the scopes they call — because with a standard library the scope somebody writes holds no
-`sstore` at all: `s.set(...)` is a call, and the write is one file away.
+Which scopes keep something is read from the instructions they reach, following the scopes they
+call — because with a standard library the scope somebody writes holds no `sstore` at all:
+`s.set(...)` is a call, and the write is one file away.
+
+**What a chain keeps is narrower than what an instruction writes**, and the two were read as
+one for a while. A binding writes the frame, because a frame is memory and a load after a store
+must stay after it — and a frame is gone when the scope is, and nobody outside the program ever
+saw it. A print is sharper: its effect is a write, and it reaches no bytecode at all. So a scope
+that only computed was refused for changing the chain. What counts is storage, and events and
+an external call when they are written.
 
 What is missing:
 

--- a/hosting/cli/writes.go
+++ b/hosting/cli/writes.go
@@ -21,7 +21,12 @@ type WritesInput struct {
 	Function string
 }
 
-// Writes says whether reaching this scope changes anything the chain keeps.
+// ScopeWrites says whether reaching this scope changes anything the chain keeps.
+//
+// What a chain keeps is a narrower thing than what an instruction writes, and reading the two
+// as one was a mistake: a scope that binds a name writes the frame, and a frame is gone when
+// the scope is. A scope that only computes was refused for changing the chain, which is how it
+// was found.
 //
 // It follows the scopes this one calls, because what a call does is part of what its caller
 // does — and once there is a standard library, the scope somebody writes holds no `sstore` at
@@ -35,7 +40,7 @@ func ScopeWrites(in WritesInput) (writes bool, found bool) {
 	if !bound {
 		return false, false
 	}
-	return ir.Does(in.Blocks, scope) >= ir.Writes, true
+	return ir.KeepsAnything(in.Blocks, scope), true
 }
 
 // refuseACallThatWrites is the message somebody gets for asking a question of something that

--- a/hosting/cli/writes_test.go
+++ b/hosting/cli/writes_test.go
@@ -20,7 +20,13 @@ func TestWhetherReachingAScopeChangesAnything(t *testing.T) {
 		"ident through = defer { keep(feed(0)); };\n" +
 		"ident deeper = defer { through(feed(0)); };\n" +
 		"ident sums = defer { feed(0) + feed(1); };\n" +
-		"ident raw = defer { sstore 1 feed(0); };\n"
+		"ident raw = defer { sstore 1 feed(0); };\n" +
+		// The two that were wrong. A binding writes the frame and a print writes a log, and
+		// neither is anything a chain keeps: a frame is gone when the scope is, and a print
+		// reaches no bytecode at all.
+		"ident binds = defer { ident x = feed(0); x * 2; };\n" +
+		"ident prints = defer { printd feed(0); };\n" +
+		"ident both = defer { ident x = feed(0); printd x; };\n"
 
 	projectOf(t, map[string]string{"src/main.ar": source})
 	blocks, err := newSession(t, sessionOpts{}).Blocks("src/main.ar")
@@ -34,6 +40,9 @@ func TestWhetherReachingAScopeChangesAnything(t *testing.T) {
 	}{
 		{name: "read", writes: false},
 		{name: "sums", writes: false},
+		{name: "binds", writes: false},
+		{name: "prints", writes: false},
+		{name: "both", writes: false},
 		{name: "raw", writes: true},
 		{name: "keep", writes: true},
 		// The two that matter: the write is not in this scope at all.

--- a/wire/ir/blocks.go
+++ b/wire/ir/blocks.go
@@ -134,34 +134,63 @@ func Scopes(blocks []Block) map[string]BlockID {
 // still writes to a chain if it calls something that writes, which is exactly the shape a
 // program has once there is a standard library to call.
 func Does(blocks []Block, from BlockID) Effect {
+	most := Pure
+	reaching(blocks, from, func(inst Instruction) {
+		if effect := EffectOf(inst.GetOpCode()); effect > most {
+			most = effect
+		}
+	})
+	return most
+}
+
+// KeepsAnything answers whether running this scope changes something that outlives the program.
+//
+// It is the question a chain asks and the effect is not: a binding writes the frame and a frame
+// is gone when the scope is, and a print reaches no bytecode at all. What is left is storage,
+// and events and an external call when they are written.
+//
+// Like Does, it follows the scopes this one calls — with a standard library the scope somebody
+// writes holds no sstore at all, and the write is one file away.
+func KeepsAnything(blocks []Block, from BlockID) bool {
+	kept := false
+	reaching(blocks, from, func(inst Instruction) {
+		kept = kept || Keeps(inst.GetOpCode())
+	})
+	return kept
+}
+
+// reaching walks every instruction running this scope can run, following the branches inside it
+// and the scopes it calls, and hands each one to whoever asked.
+//
+// Reaches is not enough on its own and cannot be: it follows where control goes, and a call is
+// not that — control comes back. But what a call does is part of what its caller does, which is
+// the whole of why this exists.
+func reaching(blocks []Block, from BlockID, each func(Instruction)) {
 	scopes := Scopes(blocks)
 	seen := make(map[BlockID]bool, len(blocks))
 
-	var walk func(id BlockID) Effect
-	walk = func(id BlockID) Effect {
-		if seen[id] || int(id) >= len(blocks) || id < 0 {
-			return Pure
+	var walk func(id BlockID)
+	walk = func(id BlockID) {
+		if id < 0 || int(id) >= len(blocks) || seen[id] {
+			return
 		}
 		seen[id] = true
 
-		most := Pure
 		for _, block := range Reaches(blocks, id) {
+			if block != id && seen[block] {
+				continue
+			}
 			seen[block] = true
 			for _, inst := range blocks[block].Insts {
-				if effect := EffectOf(inst.GetOpCode()); effect > most {
-					most = effect
-				}
+				each(inst)
 				if inst.GetOpCode() != OpCall {
 					continue
 				}
 				if called, bound := scopes[string(inst.GetLeft().Bytes())]; bound {
-					if effect := walk(called); effect > most {
-						most = effect
-					}
+					walk(called)
 				}
 			}
 		}
-		return most
 	}
-	return walk(from)
+	walk(from)
 }

--- a/wire/ir/effect.go
+++ b/wire/ir/effect.go
@@ -85,6 +85,31 @@ var effects = map[byte]Effect{
 	OpPrintDecimal: Writes,
 }
 
+// keeps names the instructions whose work outlives the program that did it.
+//
+// It is a different question from the effect, and reading them as one is a mistake worth
+// naming here so nobody makes it twice. An effect answers whether two instructions may swap,
+// and by that measure a binding writes: the frame is memory, and a load after a store must
+// stay after it. But a frame is gone when the scope is, and nothing outside the program ever
+// saw it — so a scope that binds a name changes nothing anybody can come back and read.
+//
+// A print is the sharper case: its effect is Writes, because when it says something matters,
+// and it reaches no bytecode at all. On a chain it is the identity.
+//
+// So this is the short list, and it is short because there is one thing a program can do today
+// that survives it. Events and an external call join it when they are written.
+var keeps = map[byte]bool{
+	OpStorageSet: true,
+}
+
+// Keeps says whether what an instruction does outlives the program that did it.
+//
+// It is what tells a question from a change: a scope that only computes can be asked, against
+// the state as it is, for nothing; a scope that keeps something has to be sent.
+func Keeps(op byte) bool {
+	return keeps[op]
+}
+
 // EffectOf answers what an opcode does beside leaving a value.
 //
 // It is a function of the opcode rather than a field on the instruction, which is where the

--- a/wire/ir/effect_test.go
+++ b/wire/ir/effect_test.go
@@ -62,3 +62,80 @@ func TestWhatAnOpcodeDoesBesideLeavingAValue(t *testing.T) {
 		})
 	}
 }
+
+// What outlives the program that did it, which is a different question from the effect.
+//
+// Reading them as one is a mistake worth a test: by the effect, a binding writes, because the
+// frame is memory and a load after a store must stay after it. But a frame is gone when the
+// scope is, and nobody outside the program ever saw it. A print is sharper still — its effect
+// is Writes and it reaches no bytecode at all.
+//
+// It is what tells a question from a change, so getting it wrong sends somebody to pay for an
+// answer, or lets them ask for something they meant to keep.
+func TestWhatOutlivesTheProgram(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		op    byte
+		keeps bool
+	}{
+		{name: "keeping something under a key", op: OpStorageSet, keeps: true},
+		{name: "reading what is kept", op: OpStorageGet, keeps: false},
+		// Both of these are Writes, and neither is anything a chain keeps.
+		{name: "binding a name", op: OpIdent, keeps: false},
+		{name: "a log", op: OpPrintDecimal, keeps: false},
+		{name: "arithmetic", op: OpAdd, keeps: false},
+		{name: "an opcode nobody wrote down", op: 0xFF, keeps: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := Keeps(tc.op); got != tc.keeps {
+				t.Errorf("keeps = %v, want %v", got, tc.keeps)
+			}
+		})
+	}
+}
+
+// And a scope keeps something when what it calls does, however far away.
+func TestWhatAScopeKeepsFollowsWhatItCalls(t *testing.T) {
+	blocks := []Block{
+		{
+			ID: 0,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, BlockOf(2), Nothing()),
+				NewInstruction([]byte("02"), OpIdent, NameOf("writer"), RefTo([]byte("01"))),
+				NewInstruction([]byte("03"), OpSave, BlockOf(3), Nothing()),
+				NewInstruction([]byte("04"), OpIdent, NameOf("binder"), RefTo([]byte("03"))),
+			},
+			Term: Ends(Nothing()),
+		},
+		{
+			ID:    1,
+			Insts: []Instruction{NewInstructionOver([]byte("01"), OpCall, NameOf("writer"))},
+			Term:  Ends(RefTo([]byte("01"))),
+		},
+		{
+			ID:    2,
+			Insts: []Instruction{NewInstruction([]byte("01"), OpStorageSet, Imm(1, 8), Imm(2, 8))},
+			Term:  Ends(RefTo([]byte("01"))),
+		},
+		{
+			// Binds a name and prints, and keeps nothing.
+			ID: 3,
+			Insts: []Instruction{
+				NewInstruction([]byte("01"), OpSave, Imm(7, 8), Nothing()),
+				NewInstruction([]byte("02"), OpIdent, NameOf("x"), RefTo([]byte("01"))),
+				NewInstruction([]byte("03"), OpPrintDecimal, RefTo([]byte("01")), Nothing()),
+			},
+			Term: Ends(RefTo([]byte("03"))),
+		},
+	}
+
+	if !KeepsAnything(blocks, 1) {
+		t.Error("a scope calling one that keeps something was said to keep nothing")
+	}
+	if !KeepsAnything(blocks, 2) {
+		t.Error("a scope that keeps something was said to keep nothing")
+	}
+	if KeepsAnything(blocks, 3) {
+		t.Error("a scope that binds a name and prints was said to keep something")
+	}
+}


### PR DESCRIPTION
Você nomeou exatamente: *"tx deveria ser para mudar o estado do contrato e call apenas para
consultar"*. Era isso, e eu tinha feito a pergunta errada.

## O que estava errado

O `call` perguntava *"alguma instrução que este escopo alcança é `Writes`?"*. Só que:

- **`ident sq = ...` escreve** — o frame é memória, e um load depois de um store tem que ficar
  depois. Mas um frame **acaba junto com o escopo**, e ninguém fora do programa nunca o viu.
- **`printd` escreve** — quando ele diz importa. E ele **não gera byte nenhum**.

Então `main`, que só multiplica dois números, era recusado por mudar a chain. E qualquer escopo
com um `printd` dentro também.

Um efeito responde *"essas duas podem trocar de lugar?"*. A sua pergunta é outra. Eu juntei as
duas.

## Agora

O que a chain guarda tem lista própria, e ela é curta porque **hoje existe uma coisa só** que um
programa faz e que sobrevive a ele. Eventos e chamada externa entram quando forem escritos.

No seu arquivo de verdade, com a `geometry` junto:

```
main  writes=false     consulta
inc   writes=true      muda estado
read  writes=false     consulta
```

## E a travessia virou uma só

O que um escopo *faz* e o que ele *guarda* são o mesmo passeio com duas perguntas, em vez de
dois passeios — que é a mesma armadilha em que eu caí no #164 e não quero cair de novo no mesmo
arquivo.

---

Depois do merge: **`make build` na raiz** — o `target/bin/aurora` é de 16:48 e não tem nem o
#164 nem este. Você rodou `aurora build`, que *usa* o binário; quem o reconstrói é o `make`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)