### PR TITLE
A question answers the bytes that came back

### DIFF
--- a/cmd/aurora/call.go
+++ b/cmd/aurora/call.go
@@ -17,6 +17,7 @@ var callCmd = &cobra.Command{
 
 func init() {
 	callCmd.Flags().Bool("pretend", false, "pretend/simulate the call (dry run)")
+	callCmd.Flags().Bool("hex", false, "write the answer as 0x-prefixed hex instead of the bytes themselves")
 	callCmd.Flags().StringP("profile", "p", "main", "profile to call")
 }
 
@@ -47,12 +48,17 @@ func runCall(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	asHex, err := cmd.Flags().GetBool("hex")
+	if err != nil {
+		return err
+	}
 	return cli.Call(cmd.Context(), cli.CallInput{
 		Function:        fn,
 		ContractAddress: d.ContractAddress,
 		RPC:             env.Profile.RPC,
 		Args:            args[1:],
 		Pretend:         pretend,
+		Hex:             asHex,
 		Blocks:          blocksOfProfile(profile),
 	})
 }

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -224,6 +224,12 @@ aurora call read      answered against the state as it is, costing nothing, keep
 aurora tx inc         sent, paid for, mined, and what it changed stays
 ```
 
+**A question answers the bytes that came back, and nothing else.** They go to stdout on their
+own, so `aurora call read | xxd` is a pipe and not something to undo first — it used to be a
+line saying "Result:" with the value as decimals inside brackets, which is readable and is not
+the answer. `--hex` writes `0x…` and a newline instead, for a person and for pasting into an
+explorer.
+
 Nothing decides between them from what a program looks like. What the compiler knows is used to
 refuse the wrong one: a scope that keeps something, asked as a question, is a write thrown away
 — it answers, looking right, and the chain is exactly as it was. That happened on a real chain

--- a/hosting/cli/call.go
+++ b/hosting/cli/call.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 
@@ -27,7 +28,11 @@ type CallInput struct {
 	//
 	// Empty is a call with no program in hand, which asks the question and says nothing.
 	Blocks []ir.Block
-	// Out is where it says what it is doing. Nil is stdout.
+	// Hex writes the answer as 0x-prefixed hex and a newline, rather than as the bytes
+	// themselves. It is for a person and for pasting into an explorer; the bytes are for
+	// everything else.
+	Hex bool
+	// Out is where the answer goes. Nil is stdout.
 	Out io.Writer
 }
 
@@ -79,6 +84,24 @@ func Call(ctx context.Context, in CallInput) error {
 		return err
 	}
 
-	say(out, "Result: %v\n", result)
-	return nil
+	return writeAnswer(out, result, in.Hex)
+}
+
+// writeAnswer hands back what the contract answered, and nothing else.
+//
+// The bytes themselves, because that is what came back: a question asked of a chain is worth
+// piping somewhere, and a line that says "Result:" in front of them is a line whoever reads
+// this has to undo. It used to say that, and the value came out as a list of decimals inside
+// brackets — readable, and not the answer.
+//
+// So stdout carries the answer alone. Hex is for a person, and it is a flag rather than the
+// default for the same reason: it is a reading of the bytes, and the bytes are the thing.
+func writeAnswer(out io.Writer, answer []byte, asHex bool) error {
+	if asHex {
+		_, err := fmt.Fprintf(out, "0x%x\n", answer)
+		return err
+	}
+	// No newline: the bytes are the bytes, and a byte nobody sent is not part of the answer.
+	_, err := out.Write(answer)
+	return err
 }

--- a/hosting/cli/tx_test.go
+++ b/hosting/cli/tx_test.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -73,4 +74,54 @@ func dataOf(printed string) string {
 		}
 	}
 	return ""
+}
+
+// What a question answers is the bytes that came back, and nothing else.
+//
+// It used to be a line saying "Result:" with the value as decimals inside brackets — readable,
+// and not the answer. Anybody piping it somewhere had to undo it first.
+func TestWhatAQuestionAnswers(t *testing.T) {
+	answer := []byte{0, 0, 0, 0, 0, 0, 0, 42}
+
+	t.Run("the bytes themselves", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := writeAnswer(&out, answer, false); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		if !bytes.Equal(out.Bytes(), answer) {
+			t.Errorf("it wrote %v, want the eight bytes that came back", out.Bytes())
+		}
+	})
+
+	t.Run("and nothing around them", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := writeAnswer(&out, answer, false); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		// Not even a newline: a byte nobody sent is not part of the answer, and one more at
+		// the end is one more to strip.
+		if out.Len() != len(answer) {
+			t.Errorf("it wrote %d bytes for an answer of %d", out.Len(), len(answer))
+		}
+	})
+
+	t.Run("as hex, for a person", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := writeAnswer(&out, answer, true); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		if got := out.String(); got != "0x000000000000002a\n" {
+			t.Errorf("it wrote %q, want the hex and a newline", got)
+		}
+	})
+
+	t.Run("an answer of nothing", func(t *testing.T) {
+		var out bytes.Buffer
+		if err := writeAnswer(&out, nil, false); err != nil {
+			t.Fatalf("writing: %v", err)
+		}
+		if out.Len() != 0 {
+			t.Errorf("it wrote %q for a contract that answered nothing", out.String())
+		}
+	})
 }


### PR DESCRIPTION
```
$ aurora call read -p sepolia | xxd
00000000: 0000 0000 0000 002a                      .......*

$ aurora call read -p sepolia --hex
0x000000000000002a
```

Antes era `Result: [0 0 0 0 0 0 0 42]` — legível, e **não é a resposta**. Quem quisesse usar
aquilo tinha que desfazer a formatação primeiro.

Agora o stdout carrega **só o que voltou**. Nem newline: um byte que ninguém mandou não faz
parte da resposta, e um a mais no fim é um a mais para tirar.

`--hex` dá a forma que todo tooling de Ethereum imprime, para pessoa e para colar num explorer.
É flag e não padrão pelo mesmo motivo: hex é uma *leitura* dos bytes, e os bytes são a coisa.

Quatro casos: os bytes, nada em volta deles, o hex com newline, e um contrato que respondeu
nada respondendo nada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)