### PR TITLE
A scope reads every value applied to it, not the first seven

### DIFF
--- a/builder/evm/getter.go
+++ b/builder/evm/getter.go
@@ -16,8 +16,13 @@ func GetRuntimeCodeLength(rc *RuntimeCode) int {
 	return l
 }
 
-// GetCalldataArgsOffset returns the calldata byte offset for the Nth argument (0-based).
-// ABI layout: selector at 0, then each arg in a 32-byte slot: arg0 at 0x20, arg1 at 0x40, arg2 at 0x60, ...
-func GetCalldataArgsOffset(index uint64) byte {
-	return byte(CALLDATA_SLOT_READABLE * (index + 1))
+// GetCalldataArgsOffset answers where the Nth value applied to a scope sits in the calldata,
+// counting from zero.
+//
+// The selector is first and each value has a word after it, so the eighth sits at 256 — which
+// is why this answers a number and not a byte. It used to answer a byte, and 256 in a byte is
+// zero: the eighth value read the selector, the ninth read the first, and the contract answered
+// something rather than failing.
+func GetCalldataArgsOffset(index uint64) int {
+	return CALLDATA_SLOT_READABLE * int(index+1)
 }

--- a/builder/evm/getter_test.go
+++ b/builder/evm/getter_test.go
@@ -2,35 +2,29 @@ package evm
 
 import "testing"
 
-func TestGetCalldataArgsOffset(t *testing.T) {
-	cases := []struct {
-		Name     string
-		NthArg   uint64
-		Expected byte
+// Where each value applied to a scope sits in the calldata: the selector first, then a word
+// each.
+//
+// It answers a number and not a byte, and that is the whole of what was wrong with it. The
+// eighth sits at 256, and 256 in a byte is zero — so the eighth value read the selector and the
+// ninth read the first, and the contract answered something rather than failing.
+func TestWhereEachValueAppliedSits(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		nth   uint64
+		where int
 	}{
-		{
-			"sample_get_calldata_args_index_from_bytes_1",
-			0,
-			0x20, // 32 bytes
-		},
-		{
-			"sample_get_calldata_args_index_from_bytes_2",
-			1,
-			0x40, // 64 bytes
-		},
-		{
-			"sample_get_calldata_args_index_from_bytes_3",
-			2,
-			0x60, // 96 bytes (third slot)
-		},
-	}
-
-	for _, c := range cases {
-		got := GetCalldataArgsOffset(c.NthArg)
-		t.Run(c.Name, func(t *testing.T) {
-			expected := c.Expected
-			if got != expected {
-				t.Errorf("EVM get calldata args index from bytes: name: %v, got: %v, expected: %v", c.Name, got, expected)
+		{name: "the first, past the selector", nth: 0, where: 0x20},
+		{name: "the second", nth: 1, where: 0x40},
+		{name: "the third", nth: 2, where: 0x60},
+		// The one that used to come out as zero.
+		{name: "the eighth, past what a byte holds", nth: 7, where: 256},
+		{name: "the ninth", nth: 8, where: 288},
+		{name: "the thirty-second", nth: 31, where: 1024},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := GetCalldataArgsOffset(tc.nth); got != tc.where {
+				t.Errorf("value %d sits at %d, want %d", tc.nth, got, tc.where)
 			}
 		})
 	}

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -218,7 +218,9 @@ func WriteFrameAddress(w io.Writer, offset int) error {
 // the same body serve a transaction and a scope.
 func WriteScopePrologue(w io.Writer, reads int, tapeSize int, epilogue, internal int) error {
 	for at := 0; at < reads; at++ {
-		if _, err := w.Write([]byte{OpPush1, GetCalldataArgsOffset(uint64(at))}); err != nil {
+		// In two bytes, because the eighth value sits at 256 and one byte holds 255. The
+		// prologue is measured rather than added up, so it costs nothing to say that here.
+		if _, err := WritePush2(w, GetCalldataArgsOffset(uint64(at))); err != nil {
 			return err
 		}
 		if _, err := w.Write([]byte{OpCallDataLoad}); err != nil {

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -854,6 +854,35 @@ func agreeCarrying(t *testing.T, source, function string, args []string, value *
 	}
 }
 
+// A scope reads as many values as were applied to it, however many that is.
+//
+// The eighth was where it stopped. Each value has a word of calldata after the selector, so the
+// eighth sits at 256 — and the offset was written in one byte, where 256 is zero. So the eighth
+// read the selector, the ninth read the first, and the contract answered a number rather than
+// failing: a wrong answer on a chain, which is the one kind of wrong this backend may not be.
+func TestAScopeReadsEveryValueAppliedToIt(t *testing.T) {
+	for _, count := range []int{1, 2, 7, 8, 9, 16, 24} {
+		t.Run(fmt.Sprintf("%d of them", count), func(t *testing.T) {
+			// Each one is worth its own position, so a value read from the wrong place is a
+			// wrong answer rather than the same answer by luck.
+			feeds := make([]string, 0, count)
+			args := make([]string, 0, count)
+			for at := 0; at < count; at++ {
+				feeds = append(feeds, fmt.Sprintf("feed(%d)", at))
+				args = append(args, fmt.Sprint(at+1))
+			}
+
+			// The last one on its own says where it was read from; the sum says every one of
+			// them was.
+			last := fmt.Sprintf("ident last = defer { %s; };", feeds[count-1])
+			all := fmt.Sprintf("ident all = defer { %s; };", strings.Join(feeds, " + "))
+
+			agree(t, last, "last", args, 0)
+			agree(t, all, "all", args, 0)
+		})
+	}
+}
+
 // A write is worth what it wrote, on a chain as much as off one.
 //
 // SSTORE leaves nothing on the stack, so the value is copied before it is spent. Getting that


### PR DESCRIPTION
Você pediu suporte para mais de um parâmetro, e mais de um **já funcionava** — até o sétimo.
Do oitavo em diante o contrato respondia errado, **em silêncio**.

```go
func GetCalldataArgsOffset(index uint64) byte {
	return byte(CALLDATA_SLOT_READABLE * (index + 1))   // 32 * 8 = 256 → byte(256) = 0
}
```

O seletor vem primeiro e cada valor ocupa uma palavra depois dele, então o oitavo mora em 256 —
e 256 num byte é zero. O oitavo lia o **seletor**, o nono lia o primeiro, e assim por diante.

Medido antes de consertar:

| argumentos | chain | evaluator |
|---|---|---|
| 2, 4, 7 | ✓ | ✓ |
| **8** | 581774555382273317 (um pedaço do seletor) | 42 |
| **12** | 1 (o valor do quarto, dando a volta) | 42 |

Resposta errada numa chain, que é o único tipo de errado que este backend não pode ser.

## O conserto

Dois bytes, como os outros tetos de `PUSH1` que já derrubamos. E não custou nada em outro
lugar: o prólogo é **medido escrevendo**, não somado por tabela, então ele se ajustou sozinho —
que é aquela decisão de desenho pagando de novo.

## Os testes

Sete tamanhos no harness, de 1 a 24, e cada caso faz **duas** perguntas: o último valor sozinho
(que diz de onde ele foi lido) e a soma de todos (que diz que cada um foi lido do lugar dele).
Cada argumento vale a própria posição, então valor lido do lugar errado é resposta errada e não
a mesma resposta por sorte.

Mais o teste de unidade, agora com o oitavo — o que dava zero — e o trigésimo segundo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)