### PR TITLE
v0.11.1-alpha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,31 @@ All notable changes and release notes for Aurora are documented here.
 
 ---
 
+## v0.11.1-alpha — 2026-08-27
+
+### A scope reads every value applied to it, not the first seven
+
+```
+aurora call sum 1 2 3 4 5 6 7 8
+```
+
+The eighth was read from the wrong place, and so was everything after it. The selector comes
+first in the calldata and each value takes a word after it, so the eighth sits at 256 — and
+where that offset was written, 256 in a byte is zero. The eighth value read the selector, the
+ninth read the first, and the contract answered a number rather than failing.
+
+At eight arguments the chain answered a piece of the selector where the evaluator answered 42;
+at twelve it answered the fourth argument's value. A wrong answer on a chain, which is the one
+kind of wrong this backend may not be.
+
+Two bytes now, like the other ceilings of its kind before it. Seven sizes in the differential
+harness, from one argument to twenty-four, each asked twice: the last value alone, which says
+where it was read from, and the sum of all of them, which says every one was.
+
+Nothing else changed.
+
+---
+
 ## v0.11.0-alpha — 2026-08-26
 
 ### Asking and changing are two commands


### PR DESCRIPTION
Correção pura: um escopo lê todo valor aplicado a ele, e não os sete primeiros. Nada mais mudou.

O oitavo argumento e os seguintes eram lidos do lugar errado — o offset ia em um byte e o oitavo mora em 256. Numa chain isso era resposta errada em silêncio, que é o único tipo de errado que este backend não pode ser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)