### PR TITLE
make build builds

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -59,7 +59,7 @@ jobs:
 
       # Through the Makefile, so CI and a laptop run the same thing.
       - name: Compile every package
-        run: make build
+        run: make compile
 
       # The playground is the only target that does not come out of `go build ./...`, and
       # the only one that breaks without anything noticing.

--- a/Makefile
+++ b/Makefile
@@ -25,15 +25,23 @@ all: test lint build-force
 #
 # The wasm build is in here because the playground is the one target that does not come out
 # of `go build ./...`, and it is the one that breaks silently — nothing else compiles for it.
-check: build wasm test lint
+check: compile wasm test lint
 
-# Compile every package, without producing binaries.
-build:
+# Compile every package, and write nothing. It is the check that everything still builds, and
+# it is not what somebody means by building.
+compile:
 	@go build ./...
 
 # Compile for the browser, which is what the playground runs on.
 wasm:
 	@GOOS=js GOARCH=wasm go build ./...
+
+# The binaries, into target/bin. This is what "build" means to whoever types it.
+#
+# It used to be the target above, which compiles every package and produces nothing — so
+# `make build` looked like it had rebuilt the binary and had not, and the old one kept
+# answering. That is a way to debug something that was fixed an hour ago.
+build: aurora aurorals
 
 build-force: clean aurora aurorals
 
@@ -126,4 +134,4 @@ $(GODEPGRAPH_BIN):
 	@echo "==> Installing godepgraph..."
 	@go install github.com/kisielk/godepgraph@latest
 
-.PHONY: all check build wasm build-force install-std aurora aurorals test bench lint complexity act cover-html clean depgraph
+.PHONY: all check compile build wasm build-force install-std aurora aurorals test bench lint complexity act cover-html clean depgraph

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ list: **[docs/contributing/why-blocks.md](docs/contributing/why-blocks.md)**.
 
 ```sh
 go run ./cmd/aurora repl   # fast loop, no build needed
-make aurora                # the binary, into target/bin
+make build                 # the binaries, into target/bin
 make check                 # build, wasm, test, lint — what CI runs
 make install-std           # the standard library, into $AURORA_ROOT/lib
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,10 +33,15 @@ go run ./cmd/aurora repl
 
 ```sh
 go build -o /tmp/aurora ./cmd/aurora   # plain, fast
-make aurora                            # ./target/bin/aurora, rebuilt whenever sources change
-make aurorals                          # ./target/bin/aurorals, the language server
+make build                             # both, into ./target/bin, whenever sources change
+make aurora                            # only the CLI
+make aurorals                          # only the language server
 make build-force                       # clean + rebuild both from scratch
 ```
+
+`make build` used to be `go build ./...`, which compiles every package and writes nothing — so
+it looked like it had rebuilt the binary and had not, and the old one kept answering. That
+check is `make compile` now, which is what `make check` and CI run.
 
 The project ships **two binaries**: `aurora` (CLI) and `aurorals` (language server, see [lsp.md](lsp.md)). Both are declared in `.goreleaser.yaml`, so a missing one breaks the release build.
 


### PR DESCRIPTION
`make build` era `go build ./...` — compila todo pacote e **não escreve binário nenhum**. Então
alguém digita `make build`, vê sucesso, e o `target/bin/aurora` continua sendo o de antes,
respondendo o comportamento antigo.

Isso me pegou nesta sessão: eu te mandei rodar `make build` duas vezes para pegar um conserto,
e as duas vezes não reconstruiu nada.

Cada alvo passa a dizer o que faz:

| alvo | o que faz |
|---|---|
| `make compile` | compila todo pacote e escreve nada — a checagem, que o `check` e a CI rodam |
| `make build` | os binários, em `target/bin` |
| `make aurora` / `make aurorals` | um de cada vez |
| `make build-force` | limpa e reconstrói os dois |

O step da CI que rodava `make build` se chamava **"Compile every package"** — o próprio nome
dizia que o alvo estava mal batizado. Agora ele roda `make compile`.

Verificado dos dois lados: apaguei os binários e `make build` os produziu; `make compile` não
produz nada; `make check` continua verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)