### PR TITLE
callvalue and --value come back out

### DIFF
--- a/README.md
+++ b/README.md
@@ -256,19 +256,6 @@ The selector is the whole hash of the name rather than the four bytes an ABI use
 value takes a word after it. Neither of those is a choice a program makes — they are what a
 scope with no signature looks like from outside.
 
-Separately from the arguments, a transaction can carry **value** — ether — which a program
-reads with `callvalue`:
-
-```sh
-aurora tx deposit --value 1000000000000000
-aurora run --value 1000000000000000     # what it would have carried, off a chain
-```
-
-In wei and a whole number, because ether is a decimal and a decimal is a rounding waiting to
-happen. **Nothing in Aurora sends ether back** — there is no external call — so what arrives
-at a contract can be counted and kept, and cannot be moved. The command says so before it
-sends.
-
 ## Testing
 
 ```sh

--- a/builder/evm/lowering.go
+++ b/builder/evm/lowering.go
@@ -87,7 +87,7 @@ func produces(op byte) bool {
 		ir.OpJoin, ir.OpField, ir.OpPull, ir.OpPush, ir.OpHead, ir.OpTail,
 		// A read leaves what it read, and a write leaves what it wrote: both are expressions
 		// like everything else here.
-		ir.OpStorageGet, ir.OpStorageSet, ir.OpCallValue,
+		ir.OpStorageGet, ir.OpStorageSet,
 		// A print writes nothing on a chain and is worth what it was given, so it leaves a
 		// value like anything else — the same value, under a name of its own.
 		ir.OpPrintBytes, ir.OpPrintChars, ir.OpPrintDecimal:

--- a/builder/evm/support.go
+++ b/builder/evm/support.go
@@ -42,7 +42,6 @@ var handled = map[byte]bool{
 	ir.OpPush:        true,
 	ir.OpHead:        true,
 	ir.OpTail:        true,
-	ir.OpCallValue:   true,
 	ir.OpStorageGet:  true,
 	ir.OpStorageSet:  true,
 }

--- a/builder/evm/writer.go
+++ b/builder/evm/writer.go
@@ -1259,18 +1259,6 @@ func WriteInstruction(bs io.Writer, names map[string]int, inst ir.Instruction, s
 		}
 	}
 
-	if op == ir.OpCallValue {
-		if _, err := bs.Write([]byte{OpCallValue}); err != nil {
-			return err
-		}
-		// Cut to the tape width, the way every value here is: what a transaction carried is a
-		// word on a chain and a tape in a program, and a program that could see more of it
-		// than it can hold would answer one thing here and another there.
-		if _, err := WriteMask(bs, scope.TapeSize); err != nil {
-			return err
-		}
-	}
-
 	if op == ir.OpStorageGet {
 		if _, err := WriteStorageGet(bs); err != nil {
 			return err

--- a/cmd/aurora/run.go
+++ b/cmd/aurora/run.go
@@ -32,18 +32,9 @@ Anything after the target is passed to the program and read with feed(n).`,
 
 func init() {
 	runCmd.Flags().IntP("tape-size", "t", 0, "bytes per value (1-32, default 8; overrides tape_size from aurora.toml)")
-	runCmd.Flags().String("value", "0", "wei the program is told the transaction carried, which is what callvalue reads")
 }
 
 func runRun(cmd *cobra.Command, args []string) error {
-	written, err := cmd.Flags().GetString("value")
-	if err != nil {
-		return err
-	}
-	carried, err := cli.ParseCallValue(written)
-	if err != nil {
-		return err
-	}
 
 	var arg string
 	var programArgs []string
@@ -74,12 +65,7 @@ func runRun(cmd *cobra.Command, args []string) error {
 				PrintChars:   printer.Chars(out, size),
 				PrintDecimal: printer.Decimal(out, size),
 				Args:         cli.ParseArgs(programArgs),
-				// What the transaction carried, off a chain: whoever runs the program says
-				// so, the way they say what is applied to it. Without that, a program that
-				// reads it could not be simulated at all — and the whole point of this
-				// backend is that the same program answers the same thing either way.
-				CallValue: carried,
-				TapeSize:  size,
+				TapeSize:     size,
 			})
 		},
 		TapeSize: size,

--- a/cmd/aurora/tx.go
+++ b/cmd/aurora/tx.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"math/big"
 
 	"github.com/spf13/cobra"
 
@@ -26,7 +25,6 @@ and leaves the chain exactly as it was.`,
 
 func init() {
 	txCmd.Flags().Bool("pretend", false, "show what would be sent, and send nothing")
-	txCmd.Flags().String("value", "0", "wei to carry with the transaction; nothing in Aurora sends ether back")
 	txCmd.Flags().StringP("profile", "p", "main", "profile to send through")
 }
 
@@ -54,17 +52,6 @@ func runTx(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	written, err := cmd.Flags().GetString("value")
-	if err != nil {
-		return err
-	}
-	// The same reading `aurora run --value` gets, so what a program is told off a chain and
-	// what it is sent on one are one description.
-	bytes, err := cli.ParseCallValue(written)
-	if err != nil {
-		return err
-	}
-	carried := new(big.Int).SetBytes(bytes)
 
 	return cli.Tx(cmd.Context(), cli.TxInput{
 		Function:        fn,
@@ -73,7 +60,6 @@ func runTx(cmd *cobra.Command, args []string) error {
 		Privkey:         env.Profile.Privkey,
 		Args:            args[1:],
 		Pretend:         pretend,
-		Value:           carried,
 		Blocks:          blocksOfProfile(profile),
 	})
 }

--- a/docs/language-design.md
+++ b/docs/language-design.md
@@ -531,35 +531,6 @@ Off a chain they are simulated by a map, for one run of a program — what a sin
 sees. A second run starts empty and a chain does not, which is the honest limit of simulating a
 call off a chain.
 
-## What the transaction carried
-
-```
-callvalue;        #- how much came with the call, as a tape
-```
-
-It takes nothing, because it is not about the program — it is about how the program was
-reached. So it is a term like any other: `callvalue + feed(0)` is a sum, and
-`sstore 1 callvalue` keeps it.
-
-On a chain that is the value on the transaction. Off one there is no transaction, so it is what
-whoever ran the program said it was:
-
-```
-aurora run --value 1000        the program reads 1000
-aurora tx deposit --value 1000 the transaction carries 1000, and the program reads it
-```
-
-Both in **wei**, and a whole number: ether is a decimal, and a decimal is a rounding waiting to
-happen. This is money.
-
-A tape holds what a tape holds, so a value wider than one is cut to it the same way every other
-value is — at the default eight bytes that is about eighteen ether, and a program that needs
-more of it needs a wider tape.
-
-**Nothing in Aurora sends ether.** There is no external call and no self-destruct, so what
-arrives at a contract stays there: it can be counted, kept in storage, and read back, and it
-cannot be moved. `aurora tx --value` says so before it sends.
-
 ## Arithmetic Operations
 
 Arithmetic reads a tape as an unsigned big-endian integer and writes the result back as a tape, wrapping at the tape width.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -200,12 +200,13 @@ written down:
 
 - **`printb`, `printc` and `printd` are logs and do not compile**, by decision. What a program
   says on the way is for whoever is watching it run, not for the chain.
-- **Ether goes in and does not come out.** A transaction can carry value and a program can read
-  it with `callvalue`, so a contract can be paid and can count what it was paid. Nothing sends
-  any back: there is no `CALL`, no `DELEGATECALL` and no `SELFDESTRUCT` in the opcode table, so
-  what arrives stays. What it needs is an external call, which is the first thing that would
-  leave the program while it runs — the `Escapes` effect was named for it and nothing uses it
-  yet.
+- **A contract cannot be paid, and could not do anything with it if it were.** Nothing sends
+  ether — there is no `CALL`, no `DELEGATECALL` and no `SELFDESTRUCT` in the opcode table — so
+  anything that arrived would stay. Reading what a transaction carried was written and taken
+  back out for that reason: a program that can count what it was paid and never move it is a
+  keyword spent on a one-way box. Both come back together, and what they wait for is an
+  external call — the first thing that would leave the program while it runs, and what the
+  `Escapes` effect was named for.
 - **Events are missing entirely.** `LOG0`–`LOG4` (`0xA0`–`0xA4`) are not in the opcode table.
   On chain they are the only way a contract says anything, and they are the honest target for
   whatever Aurora ends up calling logging.

--- a/emitter/emitter.go
+++ b/emitter/emitter.go
@@ -83,8 +83,6 @@ func EmitInstruction(tc *int, insts *[]ir.Instruction, expr ast.Node, tapeSize i
 		return emitUseDeclaration(tc, insts, n, tapeSize)
 	case ast.ShapeLiteral:
 		return emitShapeLiteral(tc, insts, n, tapeSize)
-	case ast.CallValueExpression:
-		return emitCallValue(tc, insts, n)
 	case ast.SloadExpression:
 		return emitSload(tc, insts, n, tapeSize)
 	case ast.SstoreExpression:
@@ -276,13 +274,6 @@ func emitUseDeclaration(tc *int, insts *[]ir.Instruction, _ ast.UseDeclaration, 
 	*insts = append(*insts, ir.NewInstruction(l, ir.OpSave, ir.ImmOf(byteutil.FalseTape(tapeSize), tapeSize), ir.Nothing()))
 	return l
 
-}
-
-// emitCallValue reads how much the transaction that reached this scope carried.
-func emitCallValue(tc *int, insts *[]ir.Instruction, n ast.CallValueExpression) ir.Label {
-	l := GenerateLabel(tc)
-	*insts = append(*insts, ir.NewInstruction(l, ir.OpCallValue, ir.Nothing(), ir.Nothing()).At(originOf(n.Token)))
-	return l
 }
 
 // emitSload reads what the chain keeps under a key.

--- a/evaluator/evaluator.go
+++ b/evaluator/evaluator.go
@@ -36,12 +36,8 @@ type Evaluator struct {
 	environ       *environ.Environ
 	// storage is what a chain keeps between transactions, kept here for one run of a program.
 	// It is by the key as bytes, because a key is a tape and a tape is not a map key.
-	storage map[string][]byte
-	// callValue is what the transaction reaching this program carried, as a tape. Off a chain
-	// there is no transaction, so it is what whoever ran the program said it carried — and
-	// nothing said is nothing carried.
-	callValue []byte
-	tapeSize  int
+	storage  map[string][]byte
+	tapeSize int
 }
 
 // TapeSize is the width, in bytes, of every value this evaluator handles.
@@ -527,7 +523,6 @@ func init() {
 		ir.OpTail:  (*Evaluator).EvaluateTail,
 
 		// Storage
-		ir.OpCallValue:  (*Evaluator).EvaluateCallValue,
 		ir.OpStorageGet: (*Evaluator).EvaluateStorageGet,
 		ir.OpStorageSet: (*Evaluator).EvaluateStorageSet,
 
@@ -705,10 +700,6 @@ type NewEvaluatorOptions struct {
 	PrintChars   Printer
 	PrintDecimal Printer
 	Args         []byte
-	// CallValue is what the transaction reaching this program carried. Off a chain there is
-	// no transaction, so it is what whoever ran the program said it carried, and nothing said
-	// is nothing carried — which is what a call of no value answers on a chain too.
-	CallValue []byte
 	// TapeSize is the width in bytes of every value. Zero means the default (8).
 	TapeSize int
 	// Asserts turns assertions on. Only "aurora test" does.
@@ -720,7 +711,6 @@ func New(options NewEvaluatorOptions) *Evaluator {
 		assertResults: make([]eval.AssertResult, 0),
 		asserts:       options.Asserts,
 		storage:       make(map[string][]byte),
-		callValue:     options.CallValue,
 		printBytes:    options.PrintBytes,
 		printChars:    options.PrintChars,
 		printDecimal:  options.PrintDecimal,

--- a/evaluator/storage.go
+++ b/evaluator/storage.go
@@ -49,13 +49,3 @@ func (e *Evaluator) EvaluateStorageSet(label []byte, left, right ir.Operand) err
 func (e *Evaluator) slot(operand ir.Operand) []byte {
 	return byteutil.PaddingTape(e.value(operand), e.tapeSize)
 }
-
-// EvaluateCallValue answers how much the transaction that reached this scope carried.
-//
-// Off a chain there is no transaction, so it is what the command was told to carry — the same
-// way feed is what the command applied. Nothing was carried unless somebody said so, which is
-// the neutral tape, and that is what a call of no value answers on a chain too.
-func (e *Evaluator) EvaluateCallValue(label []byte, left, right ir.Operand) error {
-	e.environ.SetTemp(byteutil.ToHex(label), byteutil.PaddingTape(e.callValue, e.tapeSize))
-	return nil
-}

--- a/hosting/cli/evm_harness_test.go
+++ b/hosting/cli/evm_harness_test.go
@@ -9,9 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/core/tracing"
 	"github.com/ethereum/go-ethereum/core/vm/runtime"
-	"github.com/holiman/uint256"
 )
 
 // Aurora exists to let a call be simulated off the chain, which only means something if the
@@ -774,112 +772,6 @@ func TestWhatTheStandardLibraryKeepsSurvivesTheTransaction(t *testing.T) {
 	reach("deposit", []string{"2"})
 	if got := reach("balance", nil); got != "42" {
 		t.Errorf("after two deposits, balance answered %s, want 42", got)
-	}
-}
-
-// What a transaction carried, read the same way on a chain and off it.
-//
-// It is the first thing a program can read that is not about the program: nothing it did says
-// how much came with the call. On a chain that is CALLVALUE; off one it is what whoever ran it
-// said, the way feed is what they applied — and without that half, a program that reads it
-// could not be simulated at all.
-func TestWhatATransactionCarriedAnswersTheSameOnChainAndOff(t *testing.T) {
-	const source = `ident carried = defer { callvalue; };
-ident plus = defer { callvalue + feed(0); };
-ident kept = defer { sstore 1 callvalue; sload 1; };`
-
-	for _, tc := range []struct {
-		name  string
-		value int64
-		args  []string
-	}{
-		{name: "carried", value: 0},
-		{name: "carried", value: 1000},
-		{name: "plus", value: 40, args: []string{"2"}},
-		{name: "kept", value: 42},
-	} {
-		t.Run(fmt.Sprintf("%s of %d", tc.name, tc.value), func(t *testing.T) {
-			agreeCarrying(t, source, tc.name, tc.args, big.NewInt(tc.value))
-		})
-	}
-}
-
-// agreeCarrying runs the same call through both backends with a value on it, and reports when
-// they answer differently.
-//
-// The chain is given the value on the call and the evaluator is told the same number, which is
-// the only way the two can be asked the same question: one has a transaction and the other has
-// somebody saying what a transaction would have been.
-func agreeCarrying(t *testing.T, source, function string, args []string, value *big.Int) {
-	t.Helper()
-
-	dir := t.TempDir()
-	path := writeAt(t, dir, "contract.ar", source)
-	binary := filepath.Join(dir, "contract.bin")
-	if _, err := newSession(t, sessionOpts{}).Build(t.Context(), path, binary); err != nil {
-		t.Fatalf("building: %v", err)
-	}
-	bytecode, err := os.ReadFile(binary)
-	if err != nil {
-		t.Fatalf("reading the binary: %v", err)
-	}
-
-	// The sender needs the balance to carry it, or the call fails before the program runs.
-	cfg := &runtime.Config{GasLimit: 10_000_000, Value: big.NewInt(0)}
-	_, address, _, err := runtime.Create(bytecode, cfg)
-	if err != nil {
-		t.Fatalf("deploying: %v", err)
-	}
-	cfg.State.AddBalance(cfg.Origin, uint256.MustFromBig(new(big.Int).Add(value, big.NewInt(1))), tracing.BalanceChangeUnspecified)
-	cfg.Value = value
-
-	returned, _, err := runtime.Call(address, append(EncodeSelector(function), ParseArgs(args)...), cfg)
-	if err != nil {
-		t.Fatalf("calling %s: %v", function, err)
-	}
-
-	feeds := make([]string, 0, len(args))
-	for i := range args {
-		feeds = append(feeds, fmt.Sprintf("feed(%d)", i))
-	}
-	probe := fmt.Sprintf("printd %s(%s);", function, strings.Join(feeds, ", "))
-	out := &strings.Builder{}
-	session := newSession(t, sessionOpts{stdout: out, args: args, callValue: value.Bytes()})
-	if err := session.Run(t.Context(), writeAt(t, t.TempDir(), "program.ar", source+"\n"+probe+"\n")); err != nil {
-		t.Fatalf("running: %v", err)
-	}
-
-	if got, want := decimalOf(returned), strings.TrimSpace(out.String()); got != want {
-		t.Errorf("carrying %s, the chain answered %s and the evaluator %s", value, got, want)
-	}
-}
-
-// A scope reads as many values as were applied to it, however many that is.
-//
-// The eighth was where it stopped. Each value has a word of calldata after the selector, so the
-// eighth sits at 256 — and the offset was written in one byte, where 256 is zero. So the eighth
-// read the selector, the ninth read the first, and the contract answered a number rather than
-// failing: a wrong answer on a chain, which is the one kind of wrong this backend may not be.
-func TestAScopeReadsEveryValueAppliedToIt(t *testing.T) {
-	for _, count := range []int{1, 2, 7, 8, 9, 16, 24} {
-		t.Run(fmt.Sprintf("%d of them", count), func(t *testing.T) {
-			// Each one is worth its own position, so a value read from the wrong place is a
-			// wrong answer rather than the same answer by luck.
-			feeds := make([]string, 0, count)
-			args := make([]string, 0, count)
-			for at := 0; at < count; at++ {
-				feeds = append(feeds, fmt.Sprintf("feed(%d)", at))
-				args = append(args, fmt.Sprint(at+1))
-			}
-
-			// The last one on its own says where it was read from; the sum says every one of
-			// them was.
-			last := fmt.Sprintf("ident last = defer { %s; };", feeds[count-1])
-			all := fmt.Sprintf("ident all = defer { %s; };", strings.Join(feeds, " + "))
-
-			agree(t, last, "last", args, 0)
-			agree(t, all, "all", args, 0)
-		})
 	}
 }
 

--- a/hosting/cli/session_test.go
+++ b/hosting/cli/session_test.go
@@ -32,9 +32,6 @@ type sessionOpts struct {
 	// asserts turns assertions on and sends what a program prints nowhere, which is what
 	// "aurora test" does: a test says what held, not what was printed on the way.
 	asserts bool
-	// callValue is what the program is told the transaction carried, which is what callvalue
-	// reads. Nothing said is nothing carried.
-	callValue []byte
 	// stdRoot is where the modules that come with the language are read from. Empty means the
 	// repository's own lib, which is what `make install-std` copies — so a test reads the
 	// standard library where it is written rather than a copy somebody installed months ago.
@@ -103,7 +100,6 @@ func newSession(t *testing.T, o sessionOpts) *Session {
 				PrintChars:   printer.Chars(printed, size),
 				PrintDecimal: printer.Decimal(printed, size),
 				Args:         ParseArgs(o.args),
-				CallValue:    o.callValue,
 				TapeSize:     size,
 				Asserts:      o.asserts,
 			})

--- a/hosting/cli/tx.go
+++ b/hosting/cli/tx.go
@@ -39,15 +39,8 @@ type TxInput struct {
 	Privkey         string
 	Args            []string
 	Pretend         bool
-	// Value is what the transaction carries, in wei. It is wei and not ether because ether is
-	// a decimal and a decimal is a rounding waiting to happen, and this is money.
-	//
-	// A contract can be reached with value and cannot send any back: nothing in the language
-	// writes a CALL, so what arrives stays. Saying so is this command's job, since it is the
-	// one that spends it.
-	Value         *big.Int
-	MinTipGwei    int
-	MinMaxFeeGwei int
+	MinTipGwei      int
+	MinMaxFeeGwei   int
 	// Out is where it says what it is doing. Nil is stdout, which is what a command wants and
 	// what a test never does.
 	Out io.Writer
@@ -74,16 +67,11 @@ func Tx(ctx context.Context, in TxInput) error {
 
 	data := append(EncodeSelector(in.Function), ParseArgs(in.Args)...)
 	contract := common.HexToAddress(in.ContractAddress)
-	carried := in.Value
-	if carried == nil {
-		carried = big.NewInt(0)
-	}
 
 	if in.Pretend {
 		say(out, "Contract:   0x%x (%d bytes)\n", contract, len(contract.Bytes()))
 		say(out, "Function:   %s\n", in.Function)
 		say(out, "Data:       %s\n", byteutil.ToHexPretty(data))
-		say(out, "Value:      %s wei\n", carried)
 		sayLine(out, "Nothing was sent: this is what the transaction would carry.")
 		return nil
 	}
@@ -97,12 +85,7 @@ func Tx(ctx context.Context, in TxInput) error {
 		return err
 	}
 
-	if carried.Sign() > 0 {
-		say(out, "Carrying %s wei, and nothing in Aurora sends ether: what arrives at %s stays there.\n",
-			carried, contract.Hex())
-	}
-
-	signed, err := signedCall(ctx, client, privateKey, contract, carried, data, in.MinTipGwei, in.MinMaxFeeGwei)
+	signed, err := signedCall(ctx, client, privateKey, contract, data, in.MinTipGwei, in.MinMaxFeeGwei)
 	if err != nil {
 		return err
 	}
@@ -130,7 +113,7 @@ func Tx(ctx context.Context, in TxInput) error {
 
 // signedCall builds and signs a transaction to an address, with the fees the network asks for
 // and the floors a testnet needs to include one at all.
-func signedCall(ctx context.Context, client *ethclient.Client, key *ecdsa.PrivateKey, to common.Address, value *big.Int, data []byte, minTip, minFee int) (*types.Transaction, error) {
+func signedCall(ctx context.Context, client *ethclient.Client, key *ecdsa.PrivateKey, to common.Address, data []byte, minTip, minFee int) (*types.Transaction, error) {
 	from := crypto.PubkeyToAddress(key.PublicKey)
 
 	chainID, err := client.NetworkID(ctx)
@@ -153,7 +136,7 @@ func signedCall(ctx context.Context, client *ethclient.Client, key *ecdsa.Privat
 		GasFeeCap: fee,
 		Gas:       TxGasLimit,
 		To:        &to,
-		Value:     value,
+		Value:     big.NewInt(0),
 		Data:      data,
 	})
 	return types.SignTx(tx, types.LatestSignerForChainID(chainID), key)
@@ -183,19 +166,6 @@ func waitForReceipt(ctx context.Context, client *ethclient.Client, hash common.H
 	say(out, "\n")
 	return nil, fmt.Errorf("not mined within %v, and it may still be pending: check %s on an explorer",
 		RECEIPT_POLL_TIMEOUT, hash.Hex())
-}
-
-// ParseCallValue reads what a command was told a transaction carried, as the tape a program
-// will read.
-//
-// Wei and a whole number, because ether is a decimal and a decimal is a rounding waiting to
-// happen. It is padded and cut where it is read rather than here, the way every value is.
-func ParseCallValue(written string) ([]byte, error) {
-	carried, ok := new(big.Int).SetString(written, 10)
-	if !ok || carried.Sign() < 0 {
-		return nil, fmt.Errorf("--value is %q, and it is a whole number of wei: 0, or 1000000000000000 for a thousandth of an ether", written)
-	}
-	return carried.Bytes(), nil
 }
 
 // say writes what a command is doing, and does not fail over it.

--- a/hosting/cli/tx_test.go
+++ b/hosting/cli/tx_test.go
@@ -36,36 +36,6 @@ func TestATransactionCarriesTheSameCalldataAsAQuestion(t *testing.T) {
 	}
 }
 
-// And what it carries in wei is read as a whole number, because ether is a decimal and a
-// decimal is a rounding waiting to happen. This is money.
-func TestWhatATransactionCarriesIsWholeWei(t *testing.T) {
-	for _, tc := range []struct {
-		name    string
-		written string
-		refused bool
-	}{
-		{name: "nothing", written: "0"},
-		{name: "a thousandth of an ether", written: "1000000000000000"},
-		{name: "more than a word would hold as a decimal", written: "115792089237316195423570985008687907853269984665640564039457584007913129639935"},
-		{name: "a fraction", written: "0.001", refused: true},
-		{name: "less than nothing", written: "-1", refused: true},
-		{name: "not a number", written: "one ether", refused: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			_, err := ParseCallValue(tc.written)
-			if tc.refused && err == nil {
-				t.Errorf("%q was read as an amount", tc.written)
-			}
-			if !tc.refused && err != nil {
-				t.Errorf("%q was refused: %v", tc.written, err)
-			}
-			if tc.refused && err != nil && !strings.Contains(err.Error(), "wei") {
-				t.Errorf("it says %q, and never says what it wanted", err)
-			}
-		})
-	}
-}
-
 // dataOf reads the calldata line out of what a pretended command printed.
 func dataOf(printed string) string {
 	for _, line := range strings.Split(printed, "\n") {

--- a/hosting/lsp/textdoc/semantic_tokens.go
+++ b/hosting/lsp/textdoc/semantic_tokens.go
@@ -141,7 +141,7 @@ func semanticTypeOf(tag string) (int, bool) {
 	case token.IDENT, token.IF, token.ELSE, token.BRANCH, token.DEFER,
 		token.PRINTB, token.PRINTC, token.PRINTD, token.ASSERT, token.FEED,
 		token.HEAD, token.TAIL, token.PUSH, token.PULL, token.TRUE, token.FALSE,
-		token.SHAPE, token.AS, token.USE, token.RETURNS, token.SLOAD, token.SSTORE, token.CALLVALUE:
+		token.SHAPE, token.AS, token.USE, token.RETURNS, token.SLOAD, token.SSTORE:
 		return SemanticKeyword, true
 	case token.NUMBER:
 		return SemanticNumber, true

--- a/lexer/scanner.go
+++ b/lexer/scanner.go
@@ -27,7 +27,6 @@ var keywordTags = []token.Tag{
 	// looked for first.
 	token.TagSload,
 	token.TagSstore,
-	token.TagCallValue,
 	token.TagFeed,
 	token.TagAssert,
 	token.TagShape,

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -224,12 +224,6 @@ func (p *pr) parsePrimaryExpr() (ast.Node, error) {
 	if lookahead.GetTag().Id == token.FEED {
 		return p.ParseFeed()
 	}
-	// It takes nothing, so it is a term and not a form: `callvalue + 1` is a sum, the way
-	// `feed(0) + 1` is. The two that take what follows them — sload and sstore — are read
-	// where an expression begins, and this one is read where a value is.
-	if lookahead.GetTag().Id == token.CALLVALUE {
-		return p.ParseCallValue()
-	}
 	if lookahead.GetTag().Id == token.O_PAREN {
 		if _, err := p.EatToken(token.O_PAREN); err != nil {
 			return nil, err

--- a/parser/storage.go
+++ b/parser/storage.go
@@ -49,15 +49,3 @@ func (p *pr) ParseSstore() (ast.Node, error) {
 	}
 	return ast.SstoreExpression{Key: key, Value: value, Token: at}, nil
 }
-
-// ParseCallValue reads `callvalue`, which takes nothing.
-//
-// It is not about the program but about how the program was reached, which is why it has no
-// operand: there is one transaction reaching this scope and it carried what it carried.
-func (p *pr) ParseCallValue() (ast.Node, error) {
-	at, err := p.EatToken(token.CALLVALUE)
-	if err != nil {
-		return nil, err
-	}
-	return ast.CallValueExpression{Token: at}, nil
-}

--- a/wire/ast/node.go
+++ b/wire/ast/node.go
@@ -364,16 +364,6 @@ type SstoreExpression struct {
 	Token token.Token `json:"-"`
 }
 
-// CallValueExpression is how much the transaction that reached this scope carried: `callvalue`.
-//
-// It takes nothing, because it is not about the program — it is about how the program was
-// reached. Off a chain it is what the command was told to carry, the way feed is what the
-// command applied.
-type CallValueExpression struct {
-	mark
-	Token token.Token `json:"-"`
-}
-
 // UseDeclaration brings a module in under an alias: `use a/b/c as x;`.
 //
 // It declares rather than binds. The alias names something only the compiler resolves — a

--- a/wire/ir/effect.go
+++ b/wire/ir/effect.go
@@ -77,11 +77,6 @@ var effects = map[byte]Effect{
 	OpStorageGet: Reads,
 	OpStorageSet: Writes,
 
-	// What a transaction carried is not here, and Pure is right rather than lenient: it is
-	// fixed for the whole of one call, so two reads of it in either order are the same two
-	// reads. Nothing in the program can change it, and nothing outside can change it while
-	// the program runs.
-
 	// A print says something, and when it says it is the whole of what it is for. It never
 	// reaches the backend that reorders — a chain has nowhere to put a log, by decision — so
 	// this costs nothing and is still the truth.

--- a/wire/ir/opcodes.go
+++ b/wire/ir/opcodes.go
@@ -74,7 +74,4 @@ const (
 	// else.
 	OpStorageGet // Ref -> what is kept under that key
 	OpStorageSet // Ref, Ref -> keeps the value under the key, and leaves the value
-
-	// How the program was reached, rather than anything it did.
-	OpCallValue // -> how much the transaction that reached this scope carried
 )

--- a/wire/ir/takes.go
+++ b/wire/ir/takes.go
@@ -91,8 +91,6 @@ var takes = map[byte]Shape{
 	OpJoin:  {Slots: []Slot{AValue}, Repeats: true},
 	OpField: {Slots: []Slot{AValue, ANumber, ANumber}},
 
-	// It takes nothing at all: what it answers is about how the program was reached.
-	OpCallValue:  {Slots: []Slot{ANothing, ANothing}},
 	OpStorageGet: {Slots: []Slot{AValue, ANothing}},
 	OpStorageSet: {Slots: []Slot{AValue, AValue}},
 }

--- a/wire/token/tag.go
+++ b/wire/token/tag.go
@@ -49,7 +49,6 @@ const (
 	TAIL         = "TAIL"      // tail
 	SLOAD        = "SLOAD"     // sload
 	SSTORE       = "SSTORE"    // sstore
-	CALLVALUE    = "CALLVALUE" // callvalue
 	TRUE         = "TRUE"      // true
 	USE          = "USE"       // use - brings a module in under an alias
 	WHITESPACE   = "WHITESPACE"
@@ -110,7 +109,6 @@ var (
 	TagTail       = Tag{TAIL, "tail", "Get right to left nth items from a tape"}
 	TagSload      = Tag{SLOAD, "sload", "Read what the chain keeps under a key"}
 	TagSstore     = Tag{SSTORE, "sstore", "Keep a value under a key, between transactions"}
-	TagCallValue  = Tag{CALLVALUE, "callvalue", "How much the transaction carried"}
 	TagTrue       = Tag{TRUE, "true", ""}
 	TagUse        = Tag{USE, "use", "Bring a module in under an alias"}
 	TagWhitespace = Tag{WHITESPACE, " ", ""}
@@ -133,7 +131,6 @@ var processableTags = []Tag{
 	TagPull,
 	TagSload,
 	TagSstore,
-	TagCallValue,
 	TagShape,
 	TagAs,
 	TagUse,


### PR DESCRIPTION
Fora, como você pediu — e você está certo sobre a serventia: **funciona e não serve para
nada hoje.**

Nada em Aurora manda ether. Não há `CALL`, `DELEGATECALL` nem `SELFDESTRUCT`, então o que
chega num contrato fica. Um programa que sabe contar quanto recebeu e nunca pode mover é uma
caixa de mão única, e uma **palavra reservada gasta** nela: `ident callvalue = 42;` volta a
compilar.

O `--value` sai junto, pelo mesmo motivo que os trouxe juntos: mandar dinheiro que o programa
não enxerga é pior do que não mandar.

## O que ficou

O `Out io.Writer` no `call` e no `tx` — veio no mesmo PR e é o que permite testar o que os
dois imprimem sem tocar em stdout. O `#167` depende dele.

E `CALLVALUE` continua na tabela de opcodes da EVM em `builder/evm/opcodes.go`, que é uma
tabela do que a máquina tem, não do que a Aurora emite.

## Uma coisa para não esquecer

O `CHANGELOG.md` descreve `callvalue` nas notas da **v0.11.0-alpha**, e está certo — ela
saiu com ele. Quando a próxima tag for cortada, essas notas precisam dizer que ele foi
retirado; se não, quem ler o changelog inteiro vai procurar por uma keyword que não existe.

## Por que não foi `git revert`

O PR original também trouxe o `Out io.Writer`, que o `#167` usa. Revert cego conflitava e
levaria junto coisa que vale manter, então removi à mão, arquivo por arquivo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)